### PR TITLE
remove . from sentence as it triggers matcher for includes

### DIFF
--- a/pkg/codegen/templates/doc.go
+++ b/pkg/codegen/templates/doc.go
@@ -1,3 +1,3 @@
 package templates
 
-//go:generate sh -c "templates -s . > templates.gen.go"
+//go:generate templates -s . -o templates.gen.go

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -308,8 +308,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
 {{end}}
 
 {{if .RequiresParamObject}}
-    // Parameter object where we will unmarshal all parameters from the
-    // context.
+    // Parameter object where we will unmarshal all parameters from the context
     var params {{.OperationId}}Params
 {{range $paramIdx, $param := .QueryParams}}// ------------- {{if .Required}}Required{{else}}Optional{{end}} query parameter "{{.ParamName}}" -------------
     if paramValue := ctx.QueryParam("{{.ParamName}}"); paramValue != "" {
@@ -425,4 +424,3 @@ func Parse(t *template.Template) (*template.Template, error) {
 	}
 	return t, nil
 }
-

--- a/pkg/codegen/templates/wrappers.tmpl
+++ b/pkg/codegen/templates/wrappers.tmpl
@@ -26,8 +26,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
 {{end}}
 
 {{if .RequiresParamObject}}
-    // Parameter object where we will unmarshal all parameters from the
-    // context.
+    // Parameter object where we will unmarshal all parameters from the context
     var params {{.OperationId}}Params
 {{range $paramIdx, $param := .QueryParams}}// ------------- {{if .Required}}Required{{else}}Optional{{end}} query parameter "{{.ParamName}}" -------------
     if paramValue := ctx.QueryParam("{{.ParamName}}"); paramValue != "" {


### PR DESCRIPTION
if you generate only server code `context.` will match for adding context include which isn't required
additionally i used the -o parameter to generate the templates