### PR TITLE
Handle empty optional style params

### DIFF
--- a/pkg/runtime/styleparam.go
+++ b/pkg/runtime/styleparam.go
@@ -153,6 +153,9 @@ func styleStruct(style string, explode bool, paramName string, value interface{}
 		if err != nil {
 			return "", fmt.Errorf("error formatting '%s': %s", paramName, err)
 		}
+		if str != "" {
+			fieldDict[fieldName] = str
+		}
 		fieldDict[fieldName] = str
 	}
 
@@ -250,6 +253,9 @@ func primitiveToString(value interface{}) (string, error) {
 
 	// Values may come in by pointer for optionals, so make sure to dereferene.
 	v := reflect.Indirect(reflect.ValueOf(value))
+	if !v.IsValid() {
+		return output, nil
+	}
 	t := v.Type()
 	kind := t.Kind()
 

--- a/pkg/runtime/styleparam.go
+++ b/pkg/runtime/styleparam.go
@@ -156,7 +156,6 @@ func styleStruct(style string, explode bool, paramName string, value interface{}
 		if str != "" {
 			fieldDict[fieldName] = str
 		}
-		fieldDict[fieldName] = str
 	}
 
 	var parts []string

--- a/pkg/runtime/styleparam_test.go
+++ b/pkg/runtime/styleparam_test.go
@@ -218,6 +218,7 @@ func TestStyleParam(t *testing.T) {
 	// Test that we handle optional fields
 	type TestObject2 struct {
 		FirstName *string `json:"firstName"`
+		LastName  *string `json:"firstName,omitempty"`
 		Role      *string `json:"role"`
 	}
 	name := "Alex"

--- a/pkg/runtime/styleparam_test.go
+++ b/pkg/runtime/styleparam_test.go
@@ -218,7 +218,7 @@ func TestStyleParam(t *testing.T) {
 	// Test that we handle optional fields
 	type TestObject2 struct {
 		FirstName *string `json:"firstName"`
-		LastName  *string `json:"firstName,omitempty"`
+		LastName  *string `json:"lastName,omitempty"`
 		Role      *string `json:"role"`
 	}
 	name := "Alex"


### PR DESCRIPTION
Prevents panic when passing a struct with nil pointers to StyleParam.

Issue: #17 