### PR TITLE
DeepObject support

### DIFF
--- a/pkg/runtime/bindparam.go
+++ b/pkg/runtime/bindparam.go
@@ -388,7 +388,34 @@ func BindQueryParameter(style string, explode bool, required bool, paramName str
 			dv.Set(reflect.ValueOf(output))
 		}
 		return nil
-	case "spaceDelimited", "pipeDelimited", "deepObject":
+	case "deepObject":
+		// Loop through all queryParams and fill the objectMap with all key/value pairs having paramName as key
+		objectMap := map[string]string{}
+		for k, v := range queryParams {
+			split := strings.Split(k, "[")
+			if len(split) != 2 {
+				return echo.NewHTTPError(http.StatusBadRequest,
+					fmt.Sprintf("parameter '%s=%s' does not match deepObject style", k, v))
+			}
+
+			if split[0] != paramName {
+				continue
+			}
+
+			k = strings.TrimSuffix(split[1], "]")
+			objectMap[k] = v[0]
+		}
+
+		// Marshal and unmarshal the objectMap into dest
+		data, err := json.Marshal(objectMap)
+		if err != nil {
+			return err
+		}
+		if err = json.Unmarshal(data, dest); err != nil {
+			return err
+		}
+		return nil
+	case "spaceDelimited", "pipeDelimited":
 		return echo.NewHTTPError(http.StatusNotImplemented,
 			fmt.Sprintf("query arguments of style '%s' aren't yet supported", style))
 	default:

--- a/pkg/runtime/bindparam.go
+++ b/pkg/runtime/bindparam.go
@@ -392,14 +392,13 @@ func BindQueryParameter(style string, explode bool, required bool, paramName str
 		// Loop through all queryParams and fill the objectMap with all key/value pairs having paramName as key
 		objectMap := map[string]string{}
 		for k, v := range queryParams {
+			if !strings.HasPrefix(k, paramName + "[") {
+				continue
+			}
 			split := strings.Split(k, "[")
 			if len(split) != 2 {
 				return echo.NewHTTPError(http.StatusBadRequest,
 					fmt.Sprintf("parameter '%s=%s' does not match deepObject style", k, v))
-			}
-
-			if split[0] != paramName {
-				continue
 			}
 
 			k = strings.TrimSuffix(split[1], "]")

--- a/pkg/runtime/bindparam_test.go
+++ b/pkg/runtime/bindparam_test.go
@@ -243,6 +243,7 @@ func TestBindQueryParameter(t *testing.T) {
 	queryParams := url.Values{
 		"id[firstName]": {"Alex"},
 		"id[role]": {"admin"},
+		"foo": {"bar"},
 	}
 
 	err := BindQueryParameter("deepObject", true, false, paramName, queryParams, &actual)

--- a/pkg/runtime/bindparam_test.go
+++ b/pkg/runtime/bindparam_test.go
@@ -14,6 +14,7 @@
 package runtime
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -225,4 +226,26 @@ func TestSplitParameter(t *testing.T) {
 		"role=admin&firstName=Alex")
 	assert.NoError(t, err)
 	assert.EqualValues(t, expectedExplodedObject, result)
+}
+
+func TestBindQueryParameter(t *testing.T) {
+	type ID struct{
+		FirstName *string	`json:"firstName"`
+		LastName  *string 	`json:"lastName"`
+		Role      string	`json:"role"`
+	}
+
+	expectedName := "Alex"
+	expectedDeepObject := &ID{FirstName: &expectedName, Role: "admin"}
+
+	actual := new(ID)
+	paramName := "id"
+	queryParams := url.Values{
+		"id[firstName]": {"Alex"},
+		"id[role]": {"admin"},
+	}
+
+	err := BindQueryParameter("deepObject", true, false, paramName, queryParams, &actual)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedDeepObject, actual)
 }


### PR DESCRIPTION
Adds support for deepObject parameters.
https://swagger.io/docs/specification/serialization/
