### PR TITLE
Ignoring oneOf and anyOf schemas

### DIFF
--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -133,7 +133,7 @@ paths:
   /test/{name}:
     get:
       tags:
-      - pet
+      - test
       summary: Get test
       operationId: getTestByName
       parameters:
@@ -161,9 +161,38 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
+  /cat:
+    get:
+      tags:
+      - cat
+      summary: Get cat status
+      operationId: getCatStatus
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                oneOf:
+                - $ref: '#/components/schemas/CatAlive'
+                - $ref: '#/components/schemas/CatDead'
+            application/xml:
+              schema:
+                anyOf:
+                - $ref: '#/components/schemas/CatAlive'
+                - $ref: '#/components/schemas/CatDead'
+            application/yaml:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/CatAlive'
+                - $ref: '#/components/schemas/CatDead'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 components:
   schemas:
@@ -183,7 +212,7 @@ components:
           type: string
         command:
           type: string
-  
+
     Error:
       properties:
         code:
@@ -191,4 +220,23 @@ components:
           format: int32
         message:
           type: string
+
+    CatAlive:
+      properties:
+        name:
+          type: string
+        alive_since:
+          type: string
+          format: date-time
+
+    CatDead:
+      properties:
+        name:
+          type: string
+        dead_since:
+          type: string
+          format: date-time
+        cause:
+          type: string
+          enum: [car, dog, oldage]
 `

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -131,6 +131,12 @@ func genResponseType(operationID string, responses openapi3.Responses) string {
 						continue
 					}
 
+					// We get "interface{}" when using "anyOf" or "oneOf" (which doesn't work with Go types):
+					if goType == "interface{}" {
+						// Unable to unmarshal this, so we leave it out:
+						continue
+					}
+
 					// Generate different attribute names for different content-types:
 					switch {
 
@@ -228,6 +234,12 @@ func genResponseUnmarshal(operationID string, responses openapi3.Responses) stri
 			goType, err := schemaToGoType(contentType.Schema, true)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Unable to determine Go type for %s.%s: %v\n", operationID, contentTypeName, err)
+				continue
+			}
+
+			// We get "interface{}" when using "anyOf" or "oneOf" (which doesn't work with Go types):
+			if goType == "interface{}" {
+				// Unable to unmarshal this, so we leave it out:
 				continue
 			}
 


### PR DESCRIPTION
I realised that I hadn't tested this case (and it does cause issues). Sorry for missing this.

Once I added oneOf and anyOf to the test schema the lint test in `codegen_test.go` picked up the broken code, so I've made the helper functions omit unmarshaling and payloads for these schemas.