### PR TITLE
Response payload names and comments

### DIFF
--- a/examples/petstore-expanded/api/petstore-client.gen.go
+++ b/examples/petstore-expanded/api/petstore-client.gen.go
@@ -124,8 +124,8 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 	}
 }
 
-// OAPIFindPetsResponse is returned by Client.FindPets()
-type OAPIFindPetsResponse struct {
+// findPetsResponse is returned by Client.FindPets()
+type findPetsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]struct {
@@ -138,7 +138,7 @@ type OAPIFindPetsResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIFindPetsResponse) Status() string {
+func (r *findPetsResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -146,22 +146,22 @@ func (r *OAPIFindPetsResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIFindPetsResponse) StatusCode() int {
+func (r *findPetsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIFindPetsResponse parses an HTTP response from a FindPetsWithResponse call
-func ParseOAPIFindPetsResponse(rsp *http.Response) (*OAPIFindPetsResponse, error) {
+// ParsefindPetsResponse parses an HTTP response from a FindPetsWithResponse call
+func ParsefindPetsResponse(rsp *http.Response) (*findPetsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIFindPetsResponse{
+	response := &findPetsResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -188,16 +188,16 @@ func ParseOAPIFindPetsResponse(rsp *http.Response) (*OAPIFindPetsResponse, error
 }
 
 // FindPets request returning *FindPetsResponse
-func (c *ClientWithResponses) FindPetsWithResponse(ctx context.Context, params *FindPetsParams) (*OAPIFindPetsResponse, error) {
+func (c *ClientWithResponses) FindPetsWithResponse(ctx context.Context, params *FindPetsParams) (*findPetsResponse, error) {
 	rsp, err := c.FindPets(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIFindPetsResponse(rsp)
+	return ParsefindPetsResponse(rsp)
 }
 
-// OAPIAddPetResponse is returned by Client.AddPet()
-type OAPIAddPetResponse struct {
+// addPetResponse is returned by Client.AddPet()
+type addPetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
@@ -210,7 +210,7 @@ type OAPIAddPetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIAddPetResponse) Status() string {
+func (r *addPetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -218,22 +218,22 @@ func (r *OAPIAddPetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIAddPetResponse) StatusCode() int {
+func (r *addPetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIAddPetResponse parses an HTTP response from a AddPetWithResponse call
-func ParseOAPIAddPetResponse(rsp *http.Response) (*OAPIAddPetResponse, error) {
+// ParseaddPetResponse parses an HTTP response from a AddPetWithResponse call
+func ParseaddPetResponse(rsp *http.Response) (*addPetResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIAddPetResponse{
+	response := &addPetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -260,23 +260,23 @@ func ParseOAPIAddPetResponse(rsp *http.Response) (*OAPIAddPetResponse, error) {
 }
 
 // AddPet request with JSON body returning *AddPetResponse
-func (c *ClientWithResponses) AddPetWithResponse(ctx context.Context, body NewPet) (*OAPIAddPetResponse, error) {
+func (c *ClientWithResponses) AddPetWithResponse(ctx context.Context, body NewPet) (*addPetResponse, error) {
 	rsp, err := c.AddPet(ctx, body)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIAddPetResponse(rsp)
+	return ParseaddPetResponse(rsp)
 }
 
-// OAPIDeletePetResponse is returned by Client.DeletePet()
-type OAPIDeletePetResponse struct {
+// deletePetResponse is returned by Client.DeletePet()
+type deletePetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSONDefault  *Error
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIDeletePetResponse) Status() string {
+func (r *deletePetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -284,22 +284,22 @@ func (r *OAPIDeletePetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIDeletePetResponse) StatusCode() int {
+func (r *deletePetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIDeletePetResponse parses an HTTP response from a DeletePetWithResponse call
-func ParseOAPIDeletePetResponse(rsp *http.Response) (*OAPIDeletePetResponse, error) {
+// ParsedeletePetResponse parses an HTTP response from a DeletePetWithResponse call
+func ParsedeletePetResponse(rsp *http.Response) (*deletePetResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIDeletePetResponse{
+	response := &deletePetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -318,16 +318,16 @@ func ParseOAPIDeletePetResponse(rsp *http.Response) (*OAPIDeletePetResponse, err
 }
 
 // DeletePet request returning *DeletePetResponse
-func (c *ClientWithResponses) DeletePetWithResponse(ctx context.Context, id int64) (*OAPIDeletePetResponse, error) {
+func (c *ClientWithResponses) DeletePetWithResponse(ctx context.Context, id int64) (*deletePetResponse, error) {
 	rsp, err := c.DeletePet(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIDeletePetResponse(rsp)
+	return ParsedeletePetResponse(rsp)
 }
 
-// OAPIFindPetByIdResponse is returned by Client.FindPetById()
-type OAPIFindPetByIdResponse struct {
+// findPetByIdResponse is returned by Client.FindPetById()
+type findPetByIdResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
@@ -340,7 +340,7 @@ type OAPIFindPetByIdResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIFindPetByIdResponse) Status() string {
+func (r *findPetByIdResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -348,22 +348,22 @@ func (r *OAPIFindPetByIdResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIFindPetByIdResponse) StatusCode() int {
+func (r *findPetByIdResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIFindPetByIdResponse parses an HTTP response from a FindPetByIdWithResponse call
-func ParseOAPIFindPetByIdResponse(rsp *http.Response) (*OAPIFindPetByIdResponse, error) {
+// ParsefindPetByIdResponse parses an HTTP response from a FindPetByIdWithResponse call
+func ParsefindPetByIdResponse(rsp *http.Response) (*findPetByIdResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIFindPetByIdResponse{
+	response := &findPetByIdResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -390,12 +390,12 @@ func ParseOAPIFindPetByIdResponse(rsp *http.Response) (*OAPIFindPetByIdResponse,
 }
 
 // FindPetById request returning *FindPetByIdResponse
-func (c *ClientWithResponses) FindPetByIdWithResponse(ctx context.Context, id int64) (*OAPIFindPetByIdResponse, error) {
+func (c *ClientWithResponses) FindPetByIdWithResponse(ctx context.Context, id int64) (*findPetByIdResponse, error) {
 	rsp, err := c.FindPetById(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIFindPetByIdResponse(rsp)
+	return ParsefindPetByIdResponse(rsp)
 }
 
 // NewFindPetsRequest generates requests for FindPets

--- a/examples/petstore-expanded/api/petstore-client.gen.go
+++ b/examples/petstore-expanded/api/petstore-client.gen.go
@@ -133,8 +133,8 @@ type FindPetsResponse struct {
 		NewPet
 		// Embedded fields due to inline allOf schema
 		Id int64 `json:"id"`
-	} // 'pet response' ()
-	JSONDefault *Error // 'unexpected error' (#/components/schemas/Error)
+	}
+	JSONDefault *Error
 }
 
 // Status returns HTTPResponse.Status
@@ -205,8 +205,8 @@ type AddPetResponse struct {
 		NewPet
 		// Embedded fields due to inline allOf schema
 		Id int64 `json:"id"`
-	} // 'pet response' (#/components/schemas/Pet)
-	JSONDefault *Error // 'unexpected error' (#/components/schemas/Error)
+	}
+	JSONDefault *Error
 }
 
 // Status returns HTTPResponse.Status
@@ -272,7 +272,7 @@ func (c *ClientWithResponses) AddPetWithResponse(ctx context.Context, body NewPe
 type DeletePetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSONDefault  *Error // 'unexpected error' (#/components/schemas/Error)
+	JSONDefault  *Error
 }
 
 // Status returns HTTPResponse.Status
@@ -335,8 +335,8 @@ type FindPetByIdResponse struct {
 		NewPet
 		// Embedded fields due to inline allOf schema
 		Id int64 `json:"id"`
-	} // 'pet response' (#/components/schemas/Pet)
-	JSONDefault *Error // 'unexpected error' (#/components/schemas/Error)
+	}
+	JSONDefault *Error
 }
 
 // Status returns HTTPResponse.Status

--- a/examples/petstore-expanded/api/petstore-client.gen.go
+++ b/examples/petstore-expanded/api/petstore-client.gen.go
@@ -124,8 +124,8 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 	}
 }
 
-// FindPetsResponse is returned by Client.FindPets()
-type FindPetsResponse struct {
+// OAPIFindPetsResponse is returned by Client.FindPets()
+type OAPIFindPetsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]struct {
@@ -138,7 +138,7 @@ type FindPetsResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r *FindPetsResponse) Status() string {
+func (r *OAPIFindPetsResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -146,22 +146,22 @@ func (r *FindPetsResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *FindPetsResponse) StatusCode() int {
+func (r *OAPIFindPetsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseFindPetsResponse parses an HTTP response from a FindPetsWithResponse call
-func ParseFindPetsResponse(rsp *http.Response) (*FindPetsResponse, error) {
+// ParseOAPIFindPetsResponse parses an HTTP response from a FindPetsWithResponse call
+func ParseOAPIFindPetsResponse(rsp *http.Response) (*OAPIFindPetsResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &FindPetsResponse{
+	response := &OAPIFindPetsResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -188,16 +188,16 @@ func ParseFindPetsResponse(rsp *http.Response) (*FindPetsResponse, error) {
 }
 
 // FindPets request returning *FindPetsResponse
-func (c *ClientWithResponses) FindPetsWithResponse(ctx context.Context, params *FindPetsParams) (*FindPetsResponse, error) {
+func (c *ClientWithResponses) FindPetsWithResponse(ctx context.Context, params *FindPetsParams) (*OAPIFindPetsResponse, error) {
 	rsp, err := c.FindPets(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	return ParseFindPetsResponse(rsp)
+	return ParseOAPIFindPetsResponse(rsp)
 }
 
-// AddPetResponse is returned by Client.AddPet()
-type AddPetResponse struct {
+// OAPIAddPetResponse is returned by Client.AddPet()
+type OAPIAddPetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
@@ -210,7 +210,7 @@ type AddPetResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r *AddPetResponse) Status() string {
+func (r *OAPIAddPetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -218,22 +218,22 @@ func (r *AddPetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *AddPetResponse) StatusCode() int {
+func (r *OAPIAddPetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseAddPetResponse parses an HTTP response from a AddPetWithResponse call
-func ParseAddPetResponse(rsp *http.Response) (*AddPetResponse, error) {
+// ParseOAPIAddPetResponse parses an HTTP response from a AddPetWithResponse call
+func ParseOAPIAddPetResponse(rsp *http.Response) (*OAPIAddPetResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &AddPetResponse{
+	response := &OAPIAddPetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -260,23 +260,23 @@ func ParseAddPetResponse(rsp *http.Response) (*AddPetResponse, error) {
 }
 
 // AddPet request with JSON body returning *AddPetResponse
-func (c *ClientWithResponses) AddPetWithResponse(ctx context.Context, body NewPet) (*AddPetResponse, error) {
+func (c *ClientWithResponses) AddPetWithResponse(ctx context.Context, body NewPet) (*OAPIAddPetResponse, error) {
 	rsp, err := c.AddPet(ctx, body)
 	if err != nil {
 		return nil, err
 	}
-	return ParseAddPetResponse(rsp)
+	return ParseOAPIAddPetResponse(rsp)
 }
 
-// DeletePetResponse is returned by Client.DeletePet()
-type DeletePetResponse struct {
+// OAPIDeletePetResponse is returned by Client.DeletePet()
+type OAPIDeletePetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSONDefault  *Error
 }
 
 // Status returns HTTPResponse.Status
-func (r *DeletePetResponse) Status() string {
+func (r *OAPIDeletePetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -284,22 +284,22 @@ func (r *DeletePetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *DeletePetResponse) StatusCode() int {
+func (r *OAPIDeletePetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseDeletePetResponse parses an HTTP response from a DeletePetWithResponse call
-func ParseDeletePetResponse(rsp *http.Response) (*DeletePetResponse, error) {
+// ParseOAPIDeletePetResponse parses an HTTP response from a DeletePetWithResponse call
+func ParseOAPIDeletePetResponse(rsp *http.Response) (*OAPIDeletePetResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &DeletePetResponse{
+	response := &OAPIDeletePetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -318,16 +318,16 @@ func ParseDeletePetResponse(rsp *http.Response) (*DeletePetResponse, error) {
 }
 
 // DeletePet request returning *DeletePetResponse
-func (c *ClientWithResponses) DeletePetWithResponse(ctx context.Context, id int64) (*DeletePetResponse, error) {
+func (c *ClientWithResponses) DeletePetWithResponse(ctx context.Context, id int64) (*OAPIDeletePetResponse, error) {
 	rsp, err := c.DeletePet(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return ParseDeletePetResponse(rsp)
+	return ParseOAPIDeletePetResponse(rsp)
 }
 
-// FindPetByIdResponse is returned by Client.FindPetById()
-type FindPetByIdResponse struct {
+// OAPIFindPetByIdResponse is returned by Client.FindPetById()
+type OAPIFindPetByIdResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
@@ -340,7 +340,7 @@ type FindPetByIdResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r *FindPetByIdResponse) Status() string {
+func (r *OAPIFindPetByIdResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -348,22 +348,22 @@ func (r *FindPetByIdResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *FindPetByIdResponse) StatusCode() int {
+func (r *OAPIFindPetByIdResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseFindPetByIdResponse parses an HTTP response from a FindPetByIdWithResponse call
-func ParseFindPetByIdResponse(rsp *http.Response) (*FindPetByIdResponse, error) {
+// ParseOAPIFindPetByIdResponse parses an HTTP response from a FindPetByIdWithResponse call
+func ParseOAPIFindPetByIdResponse(rsp *http.Response) (*OAPIFindPetByIdResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &FindPetByIdResponse{
+	response := &OAPIFindPetByIdResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -390,12 +390,12 @@ func ParseFindPetByIdResponse(rsp *http.Response) (*FindPetByIdResponse, error) 
 }
 
 // FindPetById request returning *FindPetByIdResponse
-func (c *ClientWithResponses) FindPetByIdWithResponse(ctx context.Context, id int64) (*FindPetByIdResponse, error) {
+func (c *ClientWithResponses) FindPetByIdWithResponse(ctx context.Context, id int64) (*OAPIFindPetByIdResponse, error) {
 	rsp, err := c.FindPetById(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return ParseFindPetByIdResponse(rsp)
+	return ParseOAPIFindPetByIdResponse(rsp)
 }
 
 // NewFindPetsRequest generates requests for FindPets

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -439,14 +439,14 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 	}
 }
 
-// GetContentObjectResponse is returned by Client.GetContentObject()
-type GetContentObjectResponse struct {
+// OAPIGetContentObjectResponse is returned by Client.GetContentObject()
+type OAPIGetContentObjectResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetContentObjectResponse) Status() string {
+func (r *OAPIGetContentObjectResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -454,22 +454,22 @@ func (r *GetContentObjectResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetContentObjectResponse) StatusCode() int {
+func (r *OAPIGetContentObjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetContentObjectResponse parses an HTTP response from a GetContentObjectWithResponse call
-func ParseGetContentObjectResponse(rsp *http.Response) (*GetContentObjectResponse, error) {
+// ParseOAPIGetContentObjectResponse parses an HTTP response from a GetContentObjectWithResponse call
+func ParseOAPIGetContentObjectResponse(rsp *http.Response) (*OAPIGetContentObjectResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetContentObjectResponse{
+	response := &OAPIGetContentObjectResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -483,22 +483,22 @@ func ParseGetContentObjectResponse(rsp *http.Response) (*GetContentObjectRespons
 }
 
 // GetContentObject request returning *GetContentObjectResponse
-func (c *ClientWithResponses) GetContentObjectWithResponse(ctx context.Context, param ComplexObject) (*GetContentObjectResponse, error) {
+func (c *ClientWithResponses) GetContentObjectWithResponse(ctx context.Context, param ComplexObject) (*OAPIGetContentObjectResponse, error) {
 	rsp, err := c.GetContentObject(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetContentObjectResponse(rsp)
+	return ParseOAPIGetContentObjectResponse(rsp)
 }
 
-// GetCookieResponse is returned by Client.GetCookie()
-type GetCookieResponse struct {
+// OAPIGetCookieResponse is returned by Client.GetCookie()
+type OAPIGetCookieResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetCookieResponse) Status() string {
+func (r *OAPIGetCookieResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -506,22 +506,22 @@ func (r *GetCookieResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetCookieResponse) StatusCode() int {
+func (r *OAPIGetCookieResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetCookieResponse parses an HTTP response from a GetCookieWithResponse call
-func ParseGetCookieResponse(rsp *http.Response) (*GetCookieResponse, error) {
+// ParseOAPIGetCookieResponse parses an HTTP response from a GetCookieWithResponse call
+func ParseOAPIGetCookieResponse(rsp *http.Response) (*OAPIGetCookieResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetCookieResponse{
+	response := &OAPIGetCookieResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -533,22 +533,22 @@ func ParseGetCookieResponse(rsp *http.Response) (*GetCookieResponse, error) {
 }
 
 // GetCookie request returning *GetCookieResponse
-func (c *ClientWithResponses) GetCookieWithResponse(ctx context.Context, params *GetCookieParams) (*GetCookieResponse, error) {
+func (c *ClientWithResponses) GetCookieWithResponse(ctx context.Context, params *GetCookieParams) (*OAPIGetCookieResponse, error) {
 	rsp, err := c.GetCookie(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetCookieResponse(rsp)
+	return ParseOAPIGetCookieResponse(rsp)
 }
 
-// GetHeaderResponse is returned by Client.GetHeader()
-type GetHeaderResponse struct {
+// OAPIGetHeaderResponse is returned by Client.GetHeader()
+type OAPIGetHeaderResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetHeaderResponse) Status() string {
+func (r *OAPIGetHeaderResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -556,22 +556,22 @@ func (r *GetHeaderResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetHeaderResponse) StatusCode() int {
+func (r *OAPIGetHeaderResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetHeaderResponse parses an HTTP response from a GetHeaderWithResponse call
-func ParseGetHeaderResponse(rsp *http.Response) (*GetHeaderResponse, error) {
+// ParseOAPIGetHeaderResponse parses an HTTP response from a GetHeaderWithResponse call
+func ParseOAPIGetHeaderResponse(rsp *http.Response) (*OAPIGetHeaderResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetHeaderResponse{
+	response := &OAPIGetHeaderResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -583,22 +583,22 @@ func ParseGetHeaderResponse(rsp *http.Response) (*GetHeaderResponse, error) {
 }
 
 // GetHeader request returning *GetHeaderResponse
-func (c *ClientWithResponses) GetHeaderWithResponse(ctx context.Context, params *GetHeaderParams) (*GetHeaderResponse, error) {
+func (c *ClientWithResponses) GetHeaderWithResponse(ctx context.Context, params *GetHeaderParams) (*OAPIGetHeaderResponse, error) {
 	rsp, err := c.GetHeader(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetHeaderResponse(rsp)
+	return ParseOAPIGetHeaderResponse(rsp)
 }
 
-// GetLabelExplodeArrayResponse is returned by Client.GetLabelExplodeArray()
-type GetLabelExplodeArrayResponse struct {
+// OAPIGetLabelExplodeArrayResponse is returned by Client.GetLabelExplodeArray()
+type OAPIGetLabelExplodeArrayResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetLabelExplodeArrayResponse) Status() string {
+func (r *OAPIGetLabelExplodeArrayResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -606,22 +606,22 @@ func (r *GetLabelExplodeArrayResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetLabelExplodeArrayResponse) StatusCode() int {
+func (r *OAPIGetLabelExplodeArrayResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetLabelExplodeArrayResponse parses an HTTP response from a GetLabelExplodeArrayWithResponse call
-func ParseGetLabelExplodeArrayResponse(rsp *http.Response) (*GetLabelExplodeArrayResponse, error) {
+// ParseOAPIGetLabelExplodeArrayResponse parses an HTTP response from a GetLabelExplodeArrayWithResponse call
+func ParseOAPIGetLabelExplodeArrayResponse(rsp *http.Response) (*OAPIGetLabelExplodeArrayResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetLabelExplodeArrayResponse{
+	response := &OAPIGetLabelExplodeArrayResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -635,22 +635,22 @@ func ParseGetLabelExplodeArrayResponse(rsp *http.Response) (*GetLabelExplodeArra
 }
 
 // GetLabelExplodeArray request returning *GetLabelExplodeArrayResponse
-func (c *ClientWithResponses) GetLabelExplodeArrayWithResponse(ctx context.Context, param []int32) (*GetLabelExplodeArrayResponse, error) {
+func (c *ClientWithResponses) GetLabelExplodeArrayWithResponse(ctx context.Context, param []int32) (*OAPIGetLabelExplodeArrayResponse, error) {
 	rsp, err := c.GetLabelExplodeArray(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetLabelExplodeArrayResponse(rsp)
+	return ParseOAPIGetLabelExplodeArrayResponse(rsp)
 }
 
-// GetLabelExplodeObjectResponse is returned by Client.GetLabelExplodeObject()
-type GetLabelExplodeObjectResponse struct {
+// OAPIGetLabelExplodeObjectResponse is returned by Client.GetLabelExplodeObject()
+type OAPIGetLabelExplodeObjectResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetLabelExplodeObjectResponse) Status() string {
+func (r *OAPIGetLabelExplodeObjectResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -658,22 +658,22 @@ func (r *GetLabelExplodeObjectResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetLabelExplodeObjectResponse) StatusCode() int {
+func (r *OAPIGetLabelExplodeObjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetLabelExplodeObjectResponse parses an HTTP response from a GetLabelExplodeObjectWithResponse call
-func ParseGetLabelExplodeObjectResponse(rsp *http.Response) (*GetLabelExplodeObjectResponse, error) {
+// ParseOAPIGetLabelExplodeObjectResponse parses an HTTP response from a GetLabelExplodeObjectWithResponse call
+func ParseOAPIGetLabelExplodeObjectResponse(rsp *http.Response) (*OAPIGetLabelExplodeObjectResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetLabelExplodeObjectResponse{
+	response := &OAPIGetLabelExplodeObjectResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -687,22 +687,22 @@ func ParseGetLabelExplodeObjectResponse(rsp *http.Response) (*GetLabelExplodeObj
 }
 
 // GetLabelExplodeObject request returning *GetLabelExplodeObjectResponse
-func (c *ClientWithResponses) GetLabelExplodeObjectWithResponse(ctx context.Context, param Object) (*GetLabelExplodeObjectResponse, error) {
+func (c *ClientWithResponses) GetLabelExplodeObjectWithResponse(ctx context.Context, param Object) (*OAPIGetLabelExplodeObjectResponse, error) {
 	rsp, err := c.GetLabelExplodeObject(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetLabelExplodeObjectResponse(rsp)
+	return ParseOAPIGetLabelExplodeObjectResponse(rsp)
 }
 
-// GetLabelNoExplodeArrayResponse is returned by Client.GetLabelNoExplodeArray()
-type GetLabelNoExplodeArrayResponse struct {
+// OAPIGetLabelNoExplodeArrayResponse is returned by Client.GetLabelNoExplodeArray()
+type OAPIGetLabelNoExplodeArrayResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetLabelNoExplodeArrayResponse) Status() string {
+func (r *OAPIGetLabelNoExplodeArrayResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -710,22 +710,22 @@ func (r *GetLabelNoExplodeArrayResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetLabelNoExplodeArrayResponse) StatusCode() int {
+func (r *OAPIGetLabelNoExplodeArrayResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetLabelNoExplodeArrayResponse parses an HTTP response from a GetLabelNoExplodeArrayWithResponse call
-func ParseGetLabelNoExplodeArrayResponse(rsp *http.Response) (*GetLabelNoExplodeArrayResponse, error) {
+// ParseOAPIGetLabelNoExplodeArrayResponse parses an HTTP response from a GetLabelNoExplodeArrayWithResponse call
+func ParseOAPIGetLabelNoExplodeArrayResponse(rsp *http.Response) (*OAPIGetLabelNoExplodeArrayResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetLabelNoExplodeArrayResponse{
+	response := &OAPIGetLabelNoExplodeArrayResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -739,22 +739,22 @@ func ParseGetLabelNoExplodeArrayResponse(rsp *http.Response) (*GetLabelNoExplode
 }
 
 // GetLabelNoExplodeArray request returning *GetLabelNoExplodeArrayResponse
-func (c *ClientWithResponses) GetLabelNoExplodeArrayWithResponse(ctx context.Context, param []int32) (*GetLabelNoExplodeArrayResponse, error) {
+func (c *ClientWithResponses) GetLabelNoExplodeArrayWithResponse(ctx context.Context, param []int32) (*OAPIGetLabelNoExplodeArrayResponse, error) {
 	rsp, err := c.GetLabelNoExplodeArray(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetLabelNoExplodeArrayResponse(rsp)
+	return ParseOAPIGetLabelNoExplodeArrayResponse(rsp)
 }
 
-// GetLabelNoExplodeObjectResponse is returned by Client.GetLabelNoExplodeObject()
-type GetLabelNoExplodeObjectResponse struct {
+// OAPIGetLabelNoExplodeObjectResponse is returned by Client.GetLabelNoExplodeObject()
+type OAPIGetLabelNoExplodeObjectResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetLabelNoExplodeObjectResponse) Status() string {
+func (r *OAPIGetLabelNoExplodeObjectResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -762,22 +762,22 @@ func (r *GetLabelNoExplodeObjectResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetLabelNoExplodeObjectResponse) StatusCode() int {
+func (r *OAPIGetLabelNoExplodeObjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetLabelNoExplodeObjectResponse parses an HTTP response from a GetLabelNoExplodeObjectWithResponse call
-func ParseGetLabelNoExplodeObjectResponse(rsp *http.Response) (*GetLabelNoExplodeObjectResponse, error) {
+// ParseOAPIGetLabelNoExplodeObjectResponse parses an HTTP response from a GetLabelNoExplodeObjectWithResponse call
+func ParseOAPIGetLabelNoExplodeObjectResponse(rsp *http.Response) (*OAPIGetLabelNoExplodeObjectResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetLabelNoExplodeObjectResponse{
+	response := &OAPIGetLabelNoExplodeObjectResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -791,22 +791,22 @@ func ParseGetLabelNoExplodeObjectResponse(rsp *http.Response) (*GetLabelNoExplod
 }
 
 // GetLabelNoExplodeObject request returning *GetLabelNoExplodeObjectResponse
-func (c *ClientWithResponses) GetLabelNoExplodeObjectWithResponse(ctx context.Context, param Object) (*GetLabelNoExplodeObjectResponse, error) {
+func (c *ClientWithResponses) GetLabelNoExplodeObjectWithResponse(ctx context.Context, param Object) (*OAPIGetLabelNoExplodeObjectResponse, error) {
 	rsp, err := c.GetLabelNoExplodeObject(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetLabelNoExplodeObjectResponse(rsp)
+	return ParseOAPIGetLabelNoExplodeObjectResponse(rsp)
 }
 
-// GetMatrixExplodeArrayResponse is returned by Client.GetMatrixExplodeArray()
-type GetMatrixExplodeArrayResponse struct {
+// OAPIGetMatrixExplodeArrayResponse is returned by Client.GetMatrixExplodeArray()
+type OAPIGetMatrixExplodeArrayResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetMatrixExplodeArrayResponse) Status() string {
+func (r *OAPIGetMatrixExplodeArrayResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -814,22 +814,22 @@ func (r *GetMatrixExplodeArrayResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetMatrixExplodeArrayResponse) StatusCode() int {
+func (r *OAPIGetMatrixExplodeArrayResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetMatrixExplodeArrayResponse parses an HTTP response from a GetMatrixExplodeArrayWithResponse call
-func ParseGetMatrixExplodeArrayResponse(rsp *http.Response) (*GetMatrixExplodeArrayResponse, error) {
+// ParseOAPIGetMatrixExplodeArrayResponse parses an HTTP response from a GetMatrixExplodeArrayWithResponse call
+func ParseOAPIGetMatrixExplodeArrayResponse(rsp *http.Response) (*OAPIGetMatrixExplodeArrayResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetMatrixExplodeArrayResponse{
+	response := &OAPIGetMatrixExplodeArrayResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -843,22 +843,22 @@ func ParseGetMatrixExplodeArrayResponse(rsp *http.Response) (*GetMatrixExplodeAr
 }
 
 // GetMatrixExplodeArray request returning *GetMatrixExplodeArrayResponse
-func (c *ClientWithResponses) GetMatrixExplodeArrayWithResponse(ctx context.Context, id []int32) (*GetMatrixExplodeArrayResponse, error) {
+func (c *ClientWithResponses) GetMatrixExplodeArrayWithResponse(ctx context.Context, id []int32) (*OAPIGetMatrixExplodeArrayResponse, error) {
 	rsp, err := c.GetMatrixExplodeArray(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetMatrixExplodeArrayResponse(rsp)
+	return ParseOAPIGetMatrixExplodeArrayResponse(rsp)
 }
 
-// GetMatrixExplodeObjectResponse is returned by Client.GetMatrixExplodeObject()
-type GetMatrixExplodeObjectResponse struct {
+// OAPIGetMatrixExplodeObjectResponse is returned by Client.GetMatrixExplodeObject()
+type OAPIGetMatrixExplodeObjectResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetMatrixExplodeObjectResponse) Status() string {
+func (r *OAPIGetMatrixExplodeObjectResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -866,22 +866,22 @@ func (r *GetMatrixExplodeObjectResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetMatrixExplodeObjectResponse) StatusCode() int {
+func (r *OAPIGetMatrixExplodeObjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetMatrixExplodeObjectResponse parses an HTTP response from a GetMatrixExplodeObjectWithResponse call
-func ParseGetMatrixExplodeObjectResponse(rsp *http.Response) (*GetMatrixExplodeObjectResponse, error) {
+// ParseOAPIGetMatrixExplodeObjectResponse parses an HTTP response from a GetMatrixExplodeObjectWithResponse call
+func ParseOAPIGetMatrixExplodeObjectResponse(rsp *http.Response) (*OAPIGetMatrixExplodeObjectResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetMatrixExplodeObjectResponse{
+	response := &OAPIGetMatrixExplodeObjectResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -895,22 +895,22 @@ func ParseGetMatrixExplodeObjectResponse(rsp *http.Response) (*GetMatrixExplodeO
 }
 
 // GetMatrixExplodeObject request returning *GetMatrixExplodeObjectResponse
-func (c *ClientWithResponses) GetMatrixExplodeObjectWithResponse(ctx context.Context, id Object) (*GetMatrixExplodeObjectResponse, error) {
+func (c *ClientWithResponses) GetMatrixExplodeObjectWithResponse(ctx context.Context, id Object) (*OAPIGetMatrixExplodeObjectResponse, error) {
 	rsp, err := c.GetMatrixExplodeObject(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetMatrixExplodeObjectResponse(rsp)
+	return ParseOAPIGetMatrixExplodeObjectResponse(rsp)
 }
 
-// GetMatrixNoExplodeArrayResponse is returned by Client.GetMatrixNoExplodeArray()
-type GetMatrixNoExplodeArrayResponse struct {
+// OAPIGetMatrixNoExplodeArrayResponse is returned by Client.GetMatrixNoExplodeArray()
+type OAPIGetMatrixNoExplodeArrayResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetMatrixNoExplodeArrayResponse) Status() string {
+func (r *OAPIGetMatrixNoExplodeArrayResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -918,22 +918,22 @@ func (r *GetMatrixNoExplodeArrayResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetMatrixNoExplodeArrayResponse) StatusCode() int {
+func (r *OAPIGetMatrixNoExplodeArrayResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetMatrixNoExplodeArrayResponse parses an HTTP response from a GetMatrixNoExplodeArrayWithResponse call
-func ParseGetMatrixNoExplodeArrayResponse(rsp *http.Response) (*GetMatrixNoExplodeArrayResponse, error) {
+// ParseOAPIGetMatrixNoExplodeArrayResponse parses an HTTP response from a GetMatrixNoExplodeArrayWithResponse call
+func ParseOAPIGetMatrixNoExplodeArrayResponse(rsp *http.Response) (*OAPIGetMatrixNoExplodeArrayResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetMatrixNoExplodeArrayResponse{
+	response := &OAPIGetMatrixNoExplodeArrayResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -947,22 +947,22 @@ func ParseGetMatrixNoExplodeArrayResponse(rsp *http.Response) (*GetMatrixNoExplo
 }
 
 // GetMatrixNoExplodeArray request returning *GetMatrixNoExplodeArrayResponse
-func (c *ClientWithResponses) GetMatrixNoExplodeArrayWithResponse(ctx context.Context, id []int32) (*GetMatrixNoExplodeArrayResponse, error) {
+func (c *ClientWithResponses) GetMatrixNoExplodeArrayWithResponse(ctx context.Context, id []int32) (*OAPIGetMatrixNoExplodeArrayResponse, error) {
 	rsp, err := c.GetMatrixNoExplodeArray(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetMatrixNoExplodeArrayResponse(rsp)
+	return ParseOAPIGetMatrixNoExplodeArrayResponse(rsp)
 }
 
-// GetMatrixNoExplodeObjectResponse is returned by Client.GetMatrixNoExplodeObject()
-type GetMatrixNoExplodeObjectResponse struct {
+// OAPIGetMatrixNoExplodeObjectResponse is returned by Client.GetMatrixNoExplodeObject()
+type OAPIGetMatrixNoExplodeObjectResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetMatrixNoExplodeObjectResponse) Status() string {
+func (r *OAPIGetMatrixNoExplodeObjectResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -970,22 +970,22 @@ func (r *GetMatrixNoExplodeObjectResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetMatrixNoExplodeObjectResponse) StatusCode() int {
+func (r *OAPIGetMatrixNoExplodeObjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetMatrixNoExplodeObjectResponse parses an HTTP response from a GetMatrixNoExplodeObjectWithResponse call
-func ParseGetMatrixNoExplodeObjectResponse(rsp *http.Response) (*GetMatrixNoExplodeObjectResponse, error) {
+// ParseOAPIGetMatrixNoExplodeObjectResponse parses an HTTP response from a GetMatrixNoExplodeObjectWithResponse call
+func ParseOAPIGetMatrixNoExplodeObjectResponse(rsp *http.Response) (*OAPIGetMatrixNoExplodeObjectResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetMatrixNoExplodeObjectResponse{
+	response := &OAPIGetMatrixNoExplodeObjectResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -999,22 +999,22 @@ func ParseGetMatrixNoExplodeObjectResponse(rsp *http.Response) (*GetMatrixNoExpl
 }
 
 // GetMatrixNoExplodeObject request returning *GetMatrixNoExplodeObjectResponse
-func (c *ClientWithResponses) GetMatrixNoExplodeObjectWithResponse(ctx context.Context, id Object) (*GetMatrixNoExplodeObjectResponse, error) {
+func (c *ClientWithResponses) GetMatrixNoExplodeObjectWithResponse(ctx context.Context, id Object) (*OAPIGetMatrixNoExplodeObjectResponse, error) {
 	rsp, err := c.GetMatrixNoExplodeObject(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetMatrixNoExplodeObjectResponse(rsp)
+	return ParseOAPIGetMatrixNoExplodeObjectResponse(rsp)
 }
 
-// GetPassThroughResponse is returned by Client.GetPassThrough()
-type GetPassThroughResponse struct {
+// OAPIGetPassThroughResponse is returned by Client.GetPassThrough()
+type OAPIGetPassThroughResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetPassThroughResponse) Status() string {
+func (r *OAPIGetPassThroughResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1022,22 +1022,22 @@ func (r *GetPassThroughResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetPassThroughResponse) StatusCode() int {
+func (r *OAPIGetPassThroughResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetPassThroughResponse parses an HTTP response from a GetPassThroughWithResponse call
-func ParseGetPassThroughResponse(rsp *http.Response) (*GetPassThroughResponse, error) {
+// ParseOAPIGetPassThroughResponse parses an HTTP response from a GetPassThroughWithResponse call
+func ParseOAPIGetPassThroughResponse(rsp *http.Response) (*OAPIGetPassThroughResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetPassThroughResponse{
+	response := &OAPIGetPassThroughResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1051,22 +1051,22 @@ func ParseGetPassThroughResponse(rsp *http.Response) (*GetPassThroughResponse, e
 }
 
 // GetPassThrough request returning *GetPassThroughResponse
-func (c *ClientWithResponses) GetPassThroughWithResponse(ctx context.Context, param string) (*GetPassThroughResponse, error) {
+func (c *ClientWithResponses) GetPassThroughWithResponse(ctx context.Context, param string) (*OAPIGetPassThroughResponse, error) {
 	rsp, err := c.GetPassThrough(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetPassThroughResponse(rsp)
+	return ParseOAPIGetPassThroughResponse(rsp)
 }
 
-// GetQueryFormResponse is returned by Client.GetQueryForm()
-type GetQueryFormResponse struct {
+// OAPIGetQueryFormResponse is returned by Client.GetQueryForm()
+type OAPIGetQueryFormResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetQueryFormResponse) Status() string {
+func (r *OAPIGetQueryFormResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1074,22 +1074,22 @@ func (r *GetQueryFormResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetQueryFormResponse) StatusCode() int {
+func (r *OAPIGetQueryFormResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetQueryFormResponse parses an HTTP response from a GetQueryFormWithResponse call
-func ParseGetQueryFormResponse(rsp *http.Response) (*GetQueryFormResponse, error) {
+// ParseOAPIGetQueryFormResponse parses an HTTP response from a GetQueryFormWithResponse call
+func ParseOAPIGetQueryFormResponse(rsp *http.Response) (*OAPIGetQueryFormResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetQueryFormResponse{
+	response := &OAPIGetQueryFormResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1103,22 +1103,22 @@ func ParseGetQueryFormResponse(rsp *http.Response) (*GetQueryFormResponse, error
 }
 
 // GetQueryForm request returning *GetQueryFormResponse
-func (c *ClientWithResponses) GetQueryFormWithResponse(ctx context.Context, params *GetQueryFormParams) (*GetQueryFormResponse, error) {
+func (c *ClientWithResponses) GetQueryFormWithResponse(ctx context.Context, params *GetQueryFormParams) (*OAPIGetQueryFormResponse, error) {
 	rsp, err := c.GetQueryForm(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetQueryFormResponse(rsp)
+	return ParseOAPIGetQueryFormResponse(rsp)
 }
 
-// GetSimpleExplodeArrayResponse is returned by Client.GetSimpleExplodeArray()
-type GetSimpleExplodeArrayResponse struct {
+// OAPIGetSimpleExplodeArrayResponse is returned by Client.GetSimpleExplodeArray()
+type OAPIGetSimpleExplodeArrayResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetSimpleExplodeArrayResponse) Status() string {
+func (r *OAPIGetSimpleExplodeArrayResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1126,22 +1126,22 @@ func (r *GetSimpleExplodeArrayResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetSimpleExplodeArrayResponse) StatusCode() int {
+func (r *OAPIGetSimpleExplodeArrayResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetSimpleExplodeArrayResponse parses an HTTP response from a GetSimpleExplodeArrayWithResponse call
-func ParseGetSimpleExplodeArrayResponse(rsp *http.Response) (*GetSimpleExplodeArrayResponse, error) {
+// ParseOAPIGetSimpleExplodeArrayResponse parses an HTTP response from a GetSimpleExplodeArrayWithResponse call
+func ParseOAPIGetSimpleExplodeArrayResponse(rsp *http.Response) (*OAPIGetSimpleExplodeArrayResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetSimpleExplodeArrayResponse{
+	response := &OAPIGetSimpleExplodeArrayResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1155,22 +1155,22 @@ func ParseGetSimpleExplodeArrayResponse(rsp *http.Response) (*GetSimpleExplodeAr
 }
 
 // GetSimpleExplodeArray request returning *GetSimpleExplodeArrayResponse
-func (c *ClientWithResponses) GetSimpleExplodeArrayWithResponse(ctx context.Context, param []int32) (*GetSimpleExplodeArrayResponse, error) {
+func (c *ClientWithResponses) GetSimpleExplodeArrayWithResponse(ctx context.Context, param []int32) (*OAPIGetSimpleExplodeArrayResponse, error) {
 	rsp, err := c.GetSimpleExplodeArray(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetSimpleExplodeArrayResponse(rsp)
+	return ParseOAPIGetSimpleExplodeArrayResponse(rsp)
 }
 
-// GetSimpleExplodeObjectResponse is returned by Client.GetSimpleExplodeObject()
-type GetSimpleExplodeObjectResponse struct {
+// OAPIGetSimpleExplodeObjectResponse is returned by Client.GetSimpleExplodeObject()
+type OAPIGetSimpleExplodeObjectResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetSimpleExplodeObjectResponse) Status() string {
+func (r *OAPIGetSimpleExplodeObjectResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1178,22 +1178,22 @@ func (r *GetSimpleExplodeObjectResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetSimpleExplodeObjectResponse) StatusCode() int {
+func (r *OAPIGetSimpleExplodeObjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetSimpleExplodeObjectResponse parses an HTTP response from a GetSimpleExplodeObjectWithResponse call
-func ParseGetSimpleExplodeObjectResponse(rsp *http.Response) (*GetSimpleExplodeObjectResponse, error) {
+// ParseOAPIGetSimpleExplodeObjectResponse parses an HTTP response from a GetSimpleExplodeObjectWithResponse call
+func ParseOAPIGetSimpleExplodeObjectResponse(rsp *http.Response) (*OAPIGetSimpleExplodeObjectResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetSimpleExplodeObjectResponse{
+	response := &OAPIGetSimpleExplodeObjectResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1207,22 +1207,22 @@ func ParseGetSimpleExplodeObjectResponse(rsp *http.Response) (*GetSimpleExplodeO
 }
 
 // GetSimpleExplodeObject request returning *GetSimpleExplodeObjectResponse
-func (c *ClientWithResponses) GetSimpleExplodeObjectWithResponse(ctx context.Context, param Object) (*GetSimpleExplodeObjectResponse, error) {
+func (c *ClientWithResponses) GetSimpleExplodeObjectWithResponse(ctx context.Context, param Object) (*OAPIGetSimpleExplodeObjectResponse, error) {
 	rsp, err := c.GetSimpleExplodeObject(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetSimpleExplodeObjectResponse(rsp)
+	return ParseOAPIGetSimpleExplodeObjectResponse(rsp)
 }
 
-// GetSimpleNoExplodeArrayResponse is returned by Client.GetSimpleNoExplodeArray()
-type GetSimpleNoExplodeArrayResponse struct {
+// OAPIGetSimpleNoExplodeArrayResponse is returned by Client.GetSimpleNoExplodeArray()
+type OAPIGetSimpleNoExplodeArrayResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetSimpleNoExplodeArrayResponse) Status() string {
+func (r *OAPIGetSimpleNoExplodeArrayResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1230,22 +1230,22 @@ func (r *GetSimpleNoExplodeArrayResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetSimpleNoExplodeArrayResponse) StatusCode() int {
+func (r *OAPIGetSimpleNoExplodeArrayResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetSimpleNoExplodeArrayResponse parses an HTTP response from a GetSimpleNoExplodeArrayWithResponse call
-func ParseGetSimpleNoExplodeArrayResponse(rsp *http.Response) (*GetSimpleNoExplodeArrayResponse, error) {
+// ParseOAPIGetSimpleNoExplodeArrayResponse parses an HTTP response from a GetSimpleNoExplodeArrayWithResponse call
+func ParseOAPIGetSimpleNoExplodeArrayResponse(rsp *http.Response) (*OAPIGetSimpleNoExplodeArrayResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetSimpleNoExplodeArrayResponse{
+	response := &OAPIGetSimpleNoExplodeArrayResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1259,22 +1259,22 @@ func ParseGetSimpleNoExplodeArrayResponse(rsp *http.Response) (*GetSimpleNoExplo
 }
 
 // GetSimpleNoExplodeArray request returning *GetSimpleNoExplodeArrayResponse
-func (c *ClientWithResponses) GetSimpleNoExplodeArrayWithResponse(ctx context.Context, param []int32) (*GetSimpleNoExplodeArrayResponse, error) {
+func (c *ClientWithResponses) GetSimpleNoExplodeArrayWithResponse(ctx context.Context, param []int32) (*OAPIGetSimpleNoExplodeArrayResponse, error) {
 	rsp, err := c.GetSimpleNoExplodeArray(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetSimpleNoExplodeArrayResponse(rsp)
+	return ParseOAPIGetSimpleNoExplodeArrayResponse(rsp)
 }
 
-// GetSimpleNoExplodeObjectResponse is returned by Client.GetSimpleNoExplodeObject()
-type GetSimpleNoExplodeObjectResponse struct {
+// OAPIGetSimpleNoExplodeObjectResponse is returned by Client.GetSimpleNoExplodeObject()
+type OAPIGetSimpleNoExplodeObjectResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetSimpleNoExplodeObjectResponse) Status() string {
+func (r *OAPIGetSimpleNoExplodeObjectResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1282,22 +1282,22 @@ func (r *GetSimpleNoExplodeObjectResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetSimpleNoExplodeObjectResponse) StatusCode() int {
+func (r *OAPIGetSimpleNoExplodeObjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetSimpleNoExplodeObjectResponse parses an HTTP response from a GetSimpleNoExplodeObjectWithResponse call
-func ParseGetSimpleNoExplodeObjectResponse(rsp *http.Response) (*GetSimpleNoExplodeObjectResponse, error) {
+// ParseOAPIGetSimpleNoExplodeObjectResponse parses an HTTP response from a GetSimpleNoExplodeObjectWithResponse call
+func ParseOAPIGetSimpleNoExplodeObjectResponse(rsp *http.Response) (*OAPIGetSimpleNoExplodeObjectResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetSimpleNoExplodeObjectResponse{
+	response := &OAPIGetSimpleNoExplodeObjectResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1311,22 +1311,22 @@ func ParseGetSimpleNoExplodeObjectResponse(rsp *http.Response) (*GetSimpleNoExpl
 }
 
 // GetSimpleNoExplodeObject request returning *GetSimpleNoExplodeObjectResponse
-func (c *ClientWithResponses) GetSimpleNoExplodeObjectWithResponse(ctx context.Context, param Object) (*GetSimpleNoExplodeObjectResponse, error) {
+func (c *ClientWithResponses) GetSimpleNoExplodeObjectWithResponse(ctx context.Context, param Object) (*OAPIGetSimpleNoExplodeObjectResponse, error) {
 	rsp, err := c.GetSimpleNoExplodeObject(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetSimpleNoExplodeObjectResponse(rsp)
+	return ParseOAPIGetSimpleNoExplodeObjectResponse(rsp)
 }
 
-// GetSimplePrimitiveResponse is returned by Client.GetSimplePrimitive()
-type GetSimplePrimitiveResponse struct {
+// OAPIGetSimplePrimitiveResponse is returned by Client.GetSimplePrimitive()
+type OAPIGetSimplePrimitiveResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *GetSimplePrimitiveResponse) Status() string {
+func (r *OAPIGetSimplePrimitiveResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1334,22 +1334,22 @@ func (r *GetSimplePrimitiveResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *GetSimplePrimitiveResponse) StatusCode() int {
+func (r *OAPIGetSimplePrimitiveResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseGetSimplePrimitiveResponse parses an HTTP response from a GetSimplePrimitiveWithResponse call
-func ParseGetSimplePrimitiveResponse(rsp *http.Response) (*GetSimplePrimitiveResponse, error) {
+// ParseOAPIGetSimplePrimitiveResponse parses an HTTP response from a GetSimplePrimitiveWithResponse call
+func ParseOAPIGetSimplePrimitiveResponse(rsp *http.Response) (*OAPIGetSimplePrimitiveResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetSimplePrimitiveResponse{
+	response := &OAPIGetSimplePrimitiveResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1363,12 +1363,12 @@ func ParseGetSimplePrimitiveResponse(rsp *http.Response) (*GetSimplePrimitiveRes
 }
 
 // GetSimplePrimitive request returning *GetSimplePrimitiveResponse
-func (c *ClientWithResponses) GetSimplePrimitiveWithResponse(ctx context.Context, param int32) (*GetSimplePrimitiveResponse, error) {
+func (c *ClientWithResponses) GetSimplePrimitiveWithResponse(ctx context.Context, param int32) (*OAPIGetSimplePrimitiveResponse, error) {
 	rsp, err := c.GetSimplePrimitive(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetSimplePrimitiveResponse(rsp)
+	return ParseOAPIGetSimplePrimitiveResponse(rsp)
 }
 
 // NewGetContentObjectRequest generates requests for GetContentObject

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -439,14 +439,14 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 	}
 }
 
-// OAPIGetContentObjectResponse is returned by Client.GetContentObject()
-type OAPIGetContentObjectResponse struct {
+// getContentObjectResponse is returned by Client.GetContentObject()
+type getContentObjectResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetContentObjectResponse) Status() string {
+func (r *getContentObjectResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -454,22 +454,22 @@ func (r *OAPIGetContentObjectResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetContentObjectResponse) StatusCode() int {
+func (r *getContentObjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetContentObjectResponse parses an HTTP response from a GetContentObjectWithResponse call
-func ParseOAPIGetContentObjectResponse(rsp *http.Response) (*OAPIGetContentObjectResponse, error) {
+// ParsegetContentObjectResponse parses an HTTP response from a GetContentObjectWithResponse call
+func ParsegetContentObjectResponse(rsp *http.Response) (*getContentObjectResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetContentObjectResponse{
+	response := &getContentObjectResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -483,22 +483,22 @@ func ParseOAPIGetContentObjectResponse(rsp *http.Response) (*OAPIGetContentObjec
 }
 
 // GetContentObject request returning *GetContentObjectResponse
-func (c *ClientWithResponses) GetContentObjectWithResponse(ctx context.Context, param ComplexObject) (*OAPIGetContentObjectResponse, error) {
+func (c *ClientWithResponses) GetContentObjectWithResponse(ctx context.Context, param ComplexObject) (*getContentObjectResponse, error) {
 	rsp, err := c.GetContentObject(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetContentObjectResponse(rsp)
+	return ParsegetContentObjectResponse(rsp)
 }
 
-// OAPIGetCookieResponse is returned by Client.GetCookie()
-type OAPIGetCookieResponse struct {
+// getCookieResponse is returned by Client.GetCookie()
+type getCookieResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetCookieResponse) Status() string {
+func (r *getCookieResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -506,22 +506,22 @@ func (r *OAPIGetCookieResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetCookieResponse) StatusCode() int {
+func (r *getCookieResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetCookieResponse parses an HTTP response from a GetCookieWithResponse call
-func ParseOAPIGetCookieResponse(rsp *http.Response) (*OAPIGetCookieResponse, error) {
+// ParsegetCookieResponse parses an HTTP response from a GetCookieWithResponse call
+func ParsegetCookieResponse(rsp *http.Response) (*getCookieResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetCookieResponse{
+	response := &getCookieResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -533,22 +533,22 @@ func ParseOAPIGetCookieResponse(rsp *http.Response) (*OAPIGetCookieResponse, err
 }
 
 // GetCookie request returning *GetCookieResponse
-func (c *ClientWithResponses) GetCookieWithResponse(ctx context.Context, params *GetCookieParams) (*OAPIGetCookieResponse, error) {
+func (c *ClientWithResponses) GetCookieWithResponse(ctx context.Context, params *GetCookieParams) (*getCookieResponse, error) {
 	rsp, err := c.GetCookie(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetCookieResponse(rsp)
+	return ParsegetCookieResponse(rsp)
 }
 
-// OAPIGetHeaderResponse is returned by Client.GetHeader()
-type OAPIGetHeaderResponse struct {
+// getHeaderResponse is returned by Client.GetHeader()
+type getHeaderResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetHeaderResponse) Status() string {
+func (r *getHeaderResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -556,22 +556,22 @@ func (r *OAPIGetHeaderResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetHeaderResponse) StatusCode() int {
+func (r *getHeaderResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetHeaderResponse parses an HTTP response from a GetHeaderWithResponse call
-func ParseOAPIGetHeaderResponse(rsp *http.Response) (*OAPIGetHeaderResponse, error) {
+// ParsegetHeaderResponse parses an HTTP response from a GetHeaderWithResponse call
+func ParsegetHeaderResponse(rsp *http.Response) (*getHeaderResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetHeaderResponse{
+	response := &getHeaderResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -583,22 +583,22 @@ func ParseOAPIGetHeaderResponse(rsp *http.Response) (*OAPIGetHeaderResponse, err
 }
 
 // GetHeader request returning *GetHeaderResponse
-func (c *ClientWithResponses) GetHeaderWithResponse(ctx context.Context, params *GetHeaderParams) (*OAPIGetHeaderResponse, error) {
+func (c *ClientWithResponses) GetHeaderWithResponse(ctx context.Context, params *GetHeaderParams) (*getHeaderResponse, error) {
 	rsp, err := c.GetHeader(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetHeaderResponse(rsp)
+	return ParsegetHeaderResponse(rsp)
 }
 
-// OAPIGetLabelExplodeArrayResponse is returned by Client.GetLabelExplodeArray()
-type OAPIGetLabelExplodeArrayResponse struct {
+// getLabelExplodeArrayResponse is returned by Client.GetLabelExplodeArray()
+type getLabelExplodeArrayResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetLabelExplodeArrayResponse) Status() string {
+func (r *getLabelExplodeArrayResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -606,22 +606,22 @@ func (r *OAPIGetLabelExplodeArrayResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetLabelExplodeArrayResponse) StatusCode() int {
+func (r *getLabelExplodeArrayResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetLabelExplodeArrayResponse parses an HTTP response from a GetLabelExplodeArrayWithResponse call
-func ParseOAPIGetLabelExplodeArrayResponse(rsp *http.Response) (*OAPIGetLabelExplodeArrayResponse, error) {
+// ParsegetLabelExplodeArrayResponse parses an HTTP response from a GetLabelExplodeArrayWithResponse call
+func ParsegetLabelExplodeArrayResponse(rsp *http.Response) (*getLabelExplodeArrayResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetLabelExplodeArrayResponse{
+	response := &getLabelExplodeArrayResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -635,22 +635,22 @@ func ParseOAPIGetLabelExplodeArrayResponse(rsp *http.Response) (*OAPIGetLabelExp
 }
 
 // GetLabelExplodeArray request returning *GetLabelExplodeArrayResponse
-func (c *ClientWithResponses) GetLabelExplodeArrayWithResponse(ctx context.Context, param []int32) (*OAPIGetLabelExplodeArrayResponse, error) {
+func (c *ClientWithResponses) GetLabelExplodeArrayWithResponse(ctx context.Context, param []int32) (*getLabelExplodeArrayResponse, error) {
 	rsp, err := c.GetLabelExplodeArray(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetLabelExplodeArrayResponse(rsp)
+	return ParsegetLabelExplodeArrayResponse(rsp)
 }
 
-// OAPIGetLabelExplodeObjectResponse is returned by Client.GetLabelExplodeObject()
-type OAPIGetLabelExplodeObjectResponse struct {
+// getLabelExplodeObjectResponse is returned by Client.GetLabelExplodeObject()
+type getLabelExplodeObjectResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetLabelExplodeObjectResponse) Status() string {
+func (r *getLabelExplodeObjectResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -658,22 +658,22 @@ func (r *OAPIGetLabelExplodeObjectResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetLabelExplodeObjectResponse) StatusCode() int {
+func (r *getLabelExplodeObjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetLabelExplodeObjectResponse parses an HTTP response from a GetLabelExplodeObjectWithResponse call
-func ParseOAPIGetLabelExplodeObjectResponse(rsp *http.Response) (*OAPIGetLabelExplodeObjectResponse, error) {
+// ParsegetLabelExplodeObjectResponse parses an HTTP response from a GetLabelExplodeObjectWithResponse call
+func ParsegetLabelExplodeObjectResponse(rsp *http.Response) (*getLabelExplodeObjectResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetLabelExplodeObjectResponse{
+	response := &getLabelExplodeObjectResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -687,22 +687,22 @@ func ParseOAPIGetLabelExplodeObjectResponse(rsp *http.Response) (*OAPIGetLabelEx
 }
 
 // GetLabelExplodeObject request returning *GetLabelExplodeObjectResponse
-func (c *ClientWithResponses) GetLabelExplodeObjectWithResponse(ctx context.Context, param Object) (*OAPIGetLabelExplodeObjectResponse, error) {
+func (c *ClientWithResponses) GetLabelExplodeObjectWithResponse(ctx context.Context, param Object) (*getLabelExplodeObjectResponse, error) {
 	rsp, err := c.GetLabelExplodeObject(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetLabelExplodeObjectResponse(rsp)
+	return ParsegetLabelExplodeObjectResponse(rsp)
 }
 
-// OAPIGetLabelNoExplodeArrayResponse is returned by Client.GetLabelNoExplodeArray()
-type OAPIGetLabelNoExplodeArrayResponse struct {
+// getLabelNoExplodeArrayResponse is returned by Client.GetLabelNoExplodeArray()
+type getLabelNoExplodeArrayResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetLabelNoExplodeArrayResponse) Status() string {
+func (r *getLabelNoExplodeArrayResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -710,22 +710,22 @@ func (r *OAPIGetLabelNoExplodeArrayResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetLabelNoExplodeArrayResponse) StatusCode() int {
+func (r *getLabelNoExplodeArrayResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetLabelNoExplodeArrayResponse parses an HTTP response from a GetLabelNoExplodeArrayWithResponse call
-func ParseOAPIGetLabelNoExplodeArrayResponse(rsp *http.Response) (*OAPIGetLabelNoExplodeArrayResponse, error) {
+// ParsegetLabelNoExplodeArrayResponse parses an HTTP response from a GetLabelNoExplodeArrayWithResponse call
+func ParsegetLabelNoExplodeArrayResponse(rsp *http.Response) (*getLabelNoExplodeArrayResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetLabelNoExplodeArrayResponse{
+	response := &getLabelNoExplodeArrayResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -739,22 +739,22 @@ func ParseOAPIGetLabelNoExplodeArrayResponse(rsp *http.Response) (*OAPIGetLabelN
 }
 
 // GetLabelNoExplodeArray request returning *GetLabelNoExplodeArrayResponse
-func (c *ClientWithResponses) GetLabelNoExplodeArrayWithResponse(ctx context.Context, param []int32) (*OAPIGetLabelNoExplodeArrayResponse, error) {
+func (c *ClientWithResponses) GetLabelNoExplodeArrayWithResponse(ctx context.Context, param []int32) (*getLabelNoExplodeArrayResponse, error) {
 	rsp, err := c.GetLabelNoExplodeArray(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetLabelNoExplodeArrayResponse(rsp)
+	return ParsegetLabelNoExplodeArrayResponse(rsp)
 }
 
-// OAPIGetLabelNoExplodeObjectResponse is returned by Client.GetLabelNoExplodeObject()
-type OAPIGetLabelNoExplodeObjectResponse struct {
+// getLabelNoExplodeObjectResponse is returned by Client.GetLabelNoExplodeObject()
+type getLabelNoExplodeObjectResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetLabelNoExplodeObjectResponse) Status() string {
+func (r *getLabelNoExplodeObjectResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -762,22 +762,22 @@ func (r *OAPIGetLabelNoExplodeObjectResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetLabelNoExplodeObjectResponse) StatusCode() int {
+func (r *getLabelNoExplodeObjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetLabelNoExplodeObjectResponse parses an HTTP response from a GetLabelNoExplodeObjectWithResponse call
-func ParseOAPIGetLabelNoExplodeObjectResponse(rsp *http.Response) (*OAPIGetLabelNoExplodeObjectResponse, error) {
+// ParsegetLabelNoExplodeObjectResponse parses an HTTP response from a GetLabelNoExplodeObjectWithResponse call
+func ParsegetLabelNoExplodeObjectResponse(rsp *http.Response) (*getLabelNoExplodeObjectResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetLabelNoExplodeObjectResponse{
+	response := &getLabelNoExplodeObjectResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -791,22 +791,22 @@ func ParseOAPIGetLabelNoExplodeObjectResponse(rsp *http.Response) (*OAPIGetLabel
 }
 
 // GetLabelNoExplodeObject request returning *GetLabelNoExplodeObjectResponse
-func (c *ClientWithResponses) GetLabelNoExplodeObjectWithResponse(ctx context.Context, param Object) (*OAPIGetLabelNoExplodeObjectResponse, error) {
+func (c *ClientWithResponses) GetLabelNoExplodeObjectWithResponse(ctx context.Context, param Object) (*getLabelNoExplodeObjectResponse, error) {
 	rsp, err := c.GetLabelNoExplodeObject(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetLabelNoExplodeObjectResponse(rsp)
+	return ParsegetLabelNoExplodeObjectResponse(rsp)
 }
 
-// OAPIGetMatrixExplodeArrayResponse is returned by Client.GetMatrixExplodeArray()
-type OAPIGetMatrixExplodeArrayResponse struct {
+// getMatrixExplodeArrayResponse is returned by Client.GetMatrixExplodeArray()
+type getMatrixExplodeArrayResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetMatrixExplodeArrayResponse) Status() string {
+func (r *getMatrixExplodeArrayResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -814,22 +814,22 @@ func (r *OAPIGetMatrixExplodeArrayResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetMatrixExplodeArrayResponse) StatusCode() int {
+func (r *getMatrixExplodeArrayResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetMatrixExplodeArrayResponse parses an HTTP response from a GetMatrixExplodeArrayWithResponse call
-func ParseOAPIGetMatrixExplodeArrayResponse(rsp *http.Response) (*OAPIGetMatrixExplodeArrayResponse, error) {
+// ParsegetMatrixExplodeArrayResponse parses an HTTP response from a GetMatrixExplodeArrayWithResponse call
+func ParsegetMatrixExplodeArrayResponse(rsp *http.Response) (*getMatrixExplodeArrayResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetMatrixExplodeArrayResponse{
+	response := &getMatrixExplodeArrayResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -843,22 +843,22 @@ func ParseOAPIGetMatrixExplodeArrayResponse(rsp *http.Response) (*OAPIGetMatrixE
 }
 
 // GetMatrixExplodeArray request returning *GetMatrixExplodeArrayResponse
-func (c *ClientWithResponses) GetMatrixExplodeArrayWithResponse(ctx context.Context, id []int32) (*OAPIGetMatrixExplodeArrayResponse, error) {
+func (c *ClientWithResponses) GetMatrixExplodeArrayWithResponse(ctx context.Context, id []int32) (*getMatrixExplodeArrayResponse, error) {
 	rsp, err := c.GetMatrixExplodeArray(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetMatrixExplodeArrayResponse(rsp)
+	return ParsegetMatrixExplodeArrayResponse(rsp)
 }
 
-// OAPIGetMatrixExplodeObjectResponse is returned by Client.GetMatrixExplodeObject()
-type OAPIGetMatrixExplodeObjectResponse struct {
+// getMatrixExplodeObjectResponse is returned by Client.GetMatrixExplodeObject()
+type getMatrixExplodeObjectResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetMatrixExplodeObjectResponse) Status() string {
+func (r *getMatrixExplodeObjectResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -866,22 +866,22 @@ func (r *OAPIGetMatrixExplodeObjectResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetMatrixExplodeObjectResponse) StatusCode() int {
+func (r *getMatrixExplodeObjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetMatrixExplodeObjectResponse parses an HTTP response from a GetMatrixExplodeObjectWithResponse call
-func ParseOAPIGetMatrixExplodeObjectResponse(rsp *http.Response) (*OAPIGetMatrixExplodeObjectResponse, error) {
+// ParsegetMatrixExplodeObjectResponse parses an HTTP response from a GetMatrixExplodeObjectWithResponse call
+func ParsegetMatrixExplodeObjectResponse(rsp *http.Response) (*getMatrixExplodeObjectResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetMatrixExplodeObjectResponse{
+	response := &getMatrixExplodeObjectResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -895,22 +895,22 @@ func ParseOAPIGetMatrixExplodeObjectResponse(rsp *http.Response) (*OAPIGetMatrix
 }
 
 // GetMatrixExplodeObject request returning *GetMatrixExplodeObjectResponse
-func (c *ClientWithResponses) GetMatrixExplodeObjectWithResponse(ctx context.Context, id Object) (*OAPIGetMatrixExplodeObjectResponse, error) {
+func (c *ClientWithResponses) GetMatrixExplodeObjectWithResponse(ctx context.Context, id Object) (*getMatrixExplodeObjectResponse, error) {
 	rsp, err := c.GetMatrixExplodeObject(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetMatrixExplodeObjectResponse(rsp)
+	return ParsegetMatrixExplodeObjectResponse(rsp)
 }
 
-// OAPIGetMatrixNoExplodeArrayResponse is returned by Client.GetMatrixNoExplodeArray()
-type OAPIGetMatrixNoExplodeArrayResponse struct {
+// getMatrixNoExplodeArrayResponse is returned by Client.GetMatrixNoExplodeArray()
+type getMatrixNoExplodeArrayResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetMatrixNoExplodeArrayResponse) Status() string {
+func (r *getMatrixNoExplodeArrayResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -918,22 +918,22 @@ func (r *OAPIGetMatrixNoExplodeArrayResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetMatrixNoExplodeArrayResponse) StatusCode() int {
+func (r *getMatrixNoExplodeArrayResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetMatrixNoExplodeArrayResponse parses an HTTP response from a GetMatrixNoExplodeArrayWithResponse call
-func ParseOAPIGetMatrixNoExplodeArrayResponse(rsp *http.Response) (*OAPIGetMatrixNoExplodeArrayResponse, error) {
+// ParsegetMatrixNoExplodeArrayResponse parses an HTTP response from a GetMatrixNoExplodeArrayWithResponse call
+func ParsegetMatrixNoExplodeArrayResponse(rsp *http.Response) (*getMatrixNoExplodeArrayResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetMatrixNoExplodeArrayResponse{
+	response := &getMatrixNoExplodeArrayResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -947,22 +947,22 @@ func ParseOAPIGetMatrixNoExplodeArrayResponse(rsp *http.Response) (*OAPIGetMatri
 }
 
 // GetMatrixNoExplodeArray request returning *GetMatrixNoExplodeArrayResponse
-func (c *ClientWithResponses) GetMatrixNoExplodeArrayWithResponse(ctx context.Context, id []int32) (*OAPIGetMatrixNoExplodeArrayResponse, error) {
+func (c *ClientWithResponses) GetMatrixNoExplodeArrayWithResponse(ctx context.Context, id []int32) (*getMatrixNoExplodeArrayResponse, error) {
 	rsp, err := c.GetMatrixNoExplodeArray(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetMatrixNoExplodeArrayResponse(rsp)
+	return ParsegetMatrixNoExplodeArrayResponse(rsp)
 }
 
-// OAPIGetMatrixNoExplodeObjectResponse is returned by Client.GetMatrixNoExplodeObject()
-type OAPIGetMatrixNoExplodeObjectResponse struct {
+// getMatrixNoExplodeObjectResponse is returned by Client.GetMatrixNoExplodeObject()
+type getMatrixNoExplodeObjectResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetMatrixNoExplodeObjectResponse) Status() string {
+func (r *getMatrixNoExplodeObjectResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -970,22 +970,22 @@ func (r *OAPIGetMatrixNoExplodeObjectResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetMatrixNoExplodeObjectResponse) StatusCode() int {
+func (r *getMatrixNoExplodeObjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetMatrixNoExplodeObjectResponse parses an HTTP response from a GetMatrixNoExplodeObjectWithResponse call
-func ParseOAPIGetMatrixNoExplodeObjectResponse(rsp *http.Response) (*OAPIGetMatrixNoExplodeObjectResponse, error) {
+// ParsegetMatrixNoExplodeObjectResponse parses an HTTP response from a GetMatrixNoExplodeObjectWithResponse call
+func ParsegetMatrixNoExplodeObjectResponse(rsp *http.Response) (*getMatrixNoExplodeObjectResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetMatrixNoExplodeObjectResponse{
+	response := &getMatrixNoExplodeObjectResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -999,22 +999,22 @@ func ParseOAPIGetMatrixNoExplodeObjectResponse(rsp *http.Response) (*OAPIGetMatr
 }
 
 // GetMatrixNoExplodeObject request returning *GetMatrixNoExplodeObjectResponse
-func (c *ClientWithResponses) GetMatrixNoExplodeObjectWithResponse(ctx context.Context, id Object) (*OAPIGetMatrixNoExplodeObjectResponse, error) {
+func (c *ClientWithResponses) GetMatrixNoExplodeObjectWithResponse(ctx context.Context, id Object) (*getMatrixNoExplodeObjectResponse, error) {
 	rsp, err := c.GetMatrixNoExplodeObject(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetMatrixNoExplodeObjectResponse(rsp)
+	return ParsegetMatrixNoExplodeObjectResponse(rsp)
 }
 
-// OAPIGetPassThroughResponse is returned by Client.GetPassThrough()
-type OAPIGetPassThroughResponse struct {
+// getPassThroughResponse is returned by Client.GetPassThrough()
+type getPassThroughResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetPassThroughResponse) Status() string {
+func (r *getPassThroughResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1022,22 +1022,22 @@ func (r *OAPIGetPassThroughResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetPassThroughResponse) StatusCode() int {
+func (r *getPassThroughResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetPassThroughResponse parses an HTTP response from a GetPassThroughWithResponse call
-func ParseOAPIGetPassThroughResponse(rsp *http.Response) (*OAPIGetPassThroughResponse, error) {
+// ParsegetPassThroughResponse parses an HTTP response from a GetPassThroughWithResponse call
+func ParsegetPassThroughResponse(rsp *http.Response) (*getPassThroughResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetPassThroughResponse{
+	response := &getPassThroughResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1051,22 +1051,22 @@ func ParseOAPIGetPassThroughResponse(rsp *http.Response) (*OAPIGetPassThroughRes
 }
 
 // GetPassThrough request returning *GetPassThroughResponse
-func (c *ClientWithResponses) GetPassThroughWithResponse(ctx context.Context, param string) (*OAPIGetPassThroughResponse, error) {
+func (c *ClientWithResponses) GetPassThroughWithResponse(ctx context.Context, param string) (*getPassThroughResponse, error) {
 	rsp, err := c.GetPassThrough(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetPassThroughResponse(rsp)
+	return ParsegetPassThroughResponse(rsp)
 }
 
-// OAPIGetQueryFormResponse is returned by Client.GetQueryForm()
-type OAPIGetQueryFormResponse struct {
+// getQueryFormResponse is returned by Client.GetQueryForm()
+type getQueryFormResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetQueryFormResponse) Status() string {
+func (r *getQueryFormResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1074,22 +1074,22 @@ func (r *OAPIGetQueryFormResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetQueryFormResponse) StatusCode() int {
+func (r *getQueryFormResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetQueryFormResponse parses an HTTP response from a GetQueryFormWithResponse call
-func ParseOAPIGetQueryFormResponse(rsp *http.Response) (*OAPIGetQueryFormResponse, error) {
+// ParsegetQueryFormResponse parses an HTTP response from a GetQueryFormWithResponse call
+func ParsegetQueryFormResponse(rsp *http.Response) (*getQueryFormResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetQueryFormResponse{
+	response := &getQueryFormResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1103,22 +1103,22 @@ func ParseOAPIGetQueryFormResponse(rsp *http.Response) (*OAPIGetQueryFormRespons
 }
 
 // GetQueryForm request returning *GetQueryFormResponse
-func (c *ClientWithResponses) GetQueryFormWithResponse(ctx context.Context, params *GetQueryFormParams) (*OAPIGetQueryFormResponse, error) {
+func (c *ClientWithResponses) GetQueryFormWithResponse(ctx context.Context, params *GetQueryFormParams) (*getQueryFormResponse, error) {
 	rsp, err := c.GetQueryForm(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetQueryFormResponse(rsp)
+	return ParsegetQueryFormResponse(rsp)
 }
 
-// OAPIGetSimpleExplodeArrayResponse is returned by Client.GetSimpleExplodeArray()
-type OAPIGetSimpleExplodeArrayResponse struct {
+// getSimpleExplodeArrayResponse is returned by Client.GetSimpleExplodeArray()
+type getSimpleExplodeArrayResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetSimpleExplodeArrayResponse) Status() string {
+func (r *getSimpleExplodeArrayResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1126,22 +1126,22 @@ func (r *OAPIGetSimpleExplodeArrayResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetSimpleExplodeArrayResponse) StatusCode() int {
+func (r *getSimpleExplodeArrayResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetSimpleExplodeArrayResponse parses an HTTP response from a GetSimpleExplodeArrayWithResponse call
-func ParseOAPIGetSimpleExplodeArrayResponse(rsp *http.Response) (*OAPIGetSimpleExplodeArrayResponse, error) {
+// ParsegetSimpleExplodeArrayResponse parses an HTTP response from a GetSimpleExplodeArrayWithResponse call
+func ParsegetSimpleExplodeArrayResponse(rsp *http.Response) (*getSimpleExplodeArrayResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetSimpleExplodeArrayResponse{
+	response := &getSimpleExplodeArrayResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1155,22 +1155,22 @@ func ParseOAPIGetSimpleExplodeArrayResponse(rsp *http.Response) (*OAPIGetSimpleE
 }
 
 // GetSimpleExplodeArray request returning *GetSimpleExplodeArrayResponse
-func (c *ClientWithResponses) GetSimpleExplodeArrayWithResponse(ctx context.Context, param []int32) (*OAPIGetSimpleExplodeArrayResponse, error) {
+func (c *ClientWithResponses) GetSimpleExplodeArrayWithResponse(ctx context.Context, param []int32) (*getSimpleExplodeArrayResponse, error) {
 	rsp, err := c.GetSimpleExplodeArray(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetSimpleExplodeArrayResponse(rsp)
+	return ParsegetSimpleExplodeArrayResponse(rsp)
 }
 
-// OAPIGetSimpleExplodeObjectResponse is returned by Client.GetSimpleExplodeObject()
-type OAPIGetSimpleExplodeObjectResponse struct {
+// getSimpleExplodeObjectResponse is returned by Client.GetSimpleExplodeObject()
+type getSimpleExplodeObjectResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetSimpleExplodeObjectResponse) Status() string {
+func (r *getSimpleExplodeObjectResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1178,22 +1178,22 @@ func (r *OAPIGetSimpleExplodeObjectResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetSimpleExplodeObjectResponse) StatusCode() int {
+func (r *getSimpleExplodeObjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetSimpleExplodeObjectResponse parses an HTTP response from a GetSimpleExplodeObjectWithResponse call
-func ParseOAPIGetSimpleExplodeObjectResponse(rsp *http.Response) (*OAPIGetSimpleExplodeObjectResponse, error) {
+// ParsegetSimpleExplodeObjectResponse parses an HTTP response from a GetSimpleExplodeObjectWithResponse call
+func ParsegetSimpleExplodeObjectResponse(rsp *http.Response) (*getSimpleExplodeObjectResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetSimpleExplodeObjectResponse{
+	response := &getSimpleExplodeObjectResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1207,22 +1207,22 @@ func ParseOAPIGetSimpleExplodeObjectResponse(rsp *http.Response) (*OAPIGetSimple
 }
 
 // GetSimpleExplodeObject request returning *GetSimpleExplodeObjectResponse
-func (c *ClientWithResponses) GetSimpleExplodeObjectWithResponse(ctx context.Context, param Object) (*OAPIGetSimpleExplodeObjectResponse, error) {
+func (c *ClientWithResponses) GetSimpleExplodeObjectWithResponse(ctx context.Context, param Object) (*getSimpleExplodeObjectResponse, error) {
 	rsp, err := c.GetSimpleExplodeObject(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetSimpleExplodeObjectResponse(rsp)
+	return ParsegetSimpleExplodeObjectResponse(rsp)
 }
 
-// OAPIGetSimpleNoExplodeArrayResponse is returned by Client.GetSimpleNoExplodeArray()
-type OAPIGetSimpleNoExplodeArrayResponse struct {
+// getSimpleNoExplodeArrayResponse is returned by Client.GetSimpleNoExplodeArray()
+type getSimpleNoExplodeArrayResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetSimpleNoExplodeArrayResponse) Status() string {
+func (r *getSimpleNoExplodeArrayResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1230,22 +1230,22 @@ func (r *OAPIGetSimpleNoExplodeArrayResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetSimpleNoExplodeArrayResponse) StatusCode() int {
+func (r *getSimpleNoExplodeArrayResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetSimpleNoExplodeArrayResponse parses an HTTP response from a GetSimpleNoExplodeArrayWithResponse call
-func ParseOAPIGetSimpleNoExplodeArrayResponse(rsp *http.Response) (*OAPIGetSimpleNoExplodeArrayResponse, error) {
+// ParsegetSimpleNoExplodeArrayResponse parses an HTTP response from a GetSimpleNoExplodeArrayWithResponse call
+func ParsegetSimpleNoExplodeArrayResponse(rsp *http.Response) (*getSimpleNoExplodeArrayResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetSimpleNoExplodeArrayResponse{
+	response := &getSimpleNoExplodeArrayResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1259,22 +1259,22 @@ func ParseOAPIGetSimpleNoExplodeArrayResponse(rsp *http.Response) (*OAPIGetSimpl
 }
 
 // GetSimpleNoExplodeArray request returning *GetSimpleNoExplodeArrayResponse
-func (c *ClientWithResponses) GetSimpleNoExplodeArrayWithResponse(ctx context.Context, param []int32) (*OAPIGetSimpleNoExplodeArrayResponse, error) {
+func (c *ClientWithResponses) GetSimpleNoExplodeArrayWithResponse(ctx context.Context, param []int32) (*getSimpleNoExplodeArrayResponse, error) {
 	rsp, err := c.GetSimpleNoExplodeArray(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetSimpleNoExplodeArrayResponse(rsp)
+	return ParsegetSimpleNoExplodeArrayResponse(rsp)
 }
 
-// OAPIGetSimpleNoExplodeObjectResponse is returned by Client.GetSimpleNoExplodeObject()
-type OAPIGetSimpleNoExplodeObjectResponse struct {
+// getSimpleNoExplodeObjectResponse is returned by Client.GetSimpleNoExplodeObject()
+type getSimpleNoExplodeObjectResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetSimpleNoExplodeObjectResponse) Status() string {
+func (r *getSimpleNoExplodeObjectResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1282,22 +1282,22 @@ func (r *OAPIGetSimpleNoExplodeObjectResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetSimpleNoExplodeObjectResponse) StatusCode() int {
+func (r *getSimpleNoExplodeObjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetSimpleNoExplodeObjectResponse parses an HTTP response from a GetSimpleNoExplodeObjectWithResponse call
-func ParseOAPIGetSimpleNoExplodeObjectResponse(rsp *http.Response) (*OAPIGetSimpleNoExplodeObjectResponse, error) {
+// ParsegetSimpleNoExplodeObjectResponse parses an HTTP response from a GetSimpleNoExplodeObjectWithResponse call
+func ParsegetSimpleNoExplodeObjectResponse(rsp *http.Response) (*getSimpleNoExplodeObjectResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetSimpleNoExplodeObjectResponse{
+	response := &getSimpleNoExplodeObjectResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1311,22 +1311,22 @@ func ParseOAPIGetSimpleNoExplodeObjectResponse(rsp *http.Response) (*OAPIGetSimp
 }
 
 // GetSimpleNoExplodeObject request returning *GetSimpleNoExplodeObjectResponse
-func (c *ClientWithResponses) GetSimpleNoExplodeObjectWithResponse(ctx context.Context, param Object) (*OAPIGetSimpleNoExplodeObjectResponse, error) {
+func (c *ClientWithResponses) GetSimpleNoExplodeObjectWithResponse(ctx context.Context, param Object) (*getSimpleNoExplodeObjectResponse, error) {
 	rsp, err := c.GetSimpleNoExplodeObject(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetSimpleNoExplodeObjectResponse(rsp)
+	return ParsegetSimpleNoExplodeObjectResponse(rsp)
 }
 
-// OAPIGetSimplePrimitiveResponse is returned by Client.GetSimplePrimitive()
-type OAPIGetSimplePrimitiveResponse struct {
+// getSimplePrimitiveResponse is returned by Client.GetSimplePrimitive()
+type getSimplePrimitiveResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIGetSimplePrimitiveResponse) Status() string {
+func (r *getSimplePrimitiveResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1334,22 +1334,22 @@ func (r *OAPIGetSimplePrimitiveResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIGetSimplePrimitiveResponse) StatusCode() int {
+func (r *getSimplePrimitiveResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIGetSimplePrimitiveResponse parses an HTTP response from a GetSimplePrimitiveWithResponse call
-func ParseOAPIGetSimplePrimitiveResponse(rsp *http.Response) (*OAPIGetSimplePrimitiveResponse, error) {
+// ParsegetSimplePrimitiveResponse parses an HTTP response from a GetSimplePrimitiveWithResponse call
+func ParsegetSimplePrimitiveResponse(rsp *http.Response) (*getSimplePrimitiveResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIGetSimplePrimitiveResponse{
+	response := &getSimplePrimitiveResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -1363,12 +1363,12 @@ func ParseOAPIGetSimplePrimitiveResponse(rsp *http.Response) (*OAPIGetSimplePrim
 }
 
 // GetSimplePrimitive request returning *GetSimplePrimitiveResponse
-func (c *ClientWithResponses) GetSimplePrimitiveWithResponse(ctx context.Context, param int32) (*OAPIGetSimplePrimitiveResponse, error) {
+func (c *ClientWithResponses) GetSimplePrimitiveWithResponse(ctx context.Context, param int32) (*getSimplePrimitiveResponse, error) {
 	rsp, err := c.GetSimplePrimitive(ctx, param)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIGetSimplePrimitiveResponse(rsp)
+	return ParsegetSimplePrimitiveResponse(rsp)
 }
 
 // NewGetContentObjectRequest generates requests for GetContentObject

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -90,14 +90,14 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 	}
 }
 
-// Issue9Response is returned by Client.Issue9()
-type Issue9Response struct {
+// OAPIIssue9Response is returned by Client.Issue9()
+type OAPIIssue9Response struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *Issue9Response) Status() string {
+func (r *OAPIIssue9Response) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -105,22 +105,22 @@ func (r *Issue9Response) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *Issue9Response) StatusCode() int {
+func (r *OAPIIssue9Response) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseIssue9Response parses an HTTP response from a Issue9WithResponse call
-func ParseIssue9Response(rsp *http.Response) (*Issue9Response, error) {
+// ParseOAPIIssue9Response parses an HTTP response from a Issue9WithResponse call
+func ParseOAPIIssue9Response(rsp *http.Response) (*OAPIIssue9Response, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &Issue9Response{
+	response := &OAPIIssue9Response{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -132,12 +132,12 @@ func ParseIssue9Response(rsp *http.Response) (*Issue9Response, error) {
 }
 
 // Issue9 request with JSON body returning *Issue9Response
-func (c *ClientWithResponses) Issue9WithResponse(ctx context.Context, params *Issue9Params, body *Issue9RequestBody) (*Issue9Response, error) {
+func (c *ClientWithResponses) Issue9WithResponse(ctx context.Context, params *Issue9Params, body *Issue9RequestBody) (*OAPIIssue9Response, error) {
 	rsp, err := c.Issue9(ctx, params, body)
 	if err != nil {
 		return nil, err
 	}
-	return ParseIssue9Response(rsp)
+	return ParseOAPIIssue9Response(rsp)
 }
 
 // NewIssue9Request generates requests for Issue9 with JSON body

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -90,14 +90,14 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 	}
 }
 
-// OAPIIssue9Response is returned by Client.Issue9()
-type OAPIIssue9Response struct {
+// issue9Response is returned by Client.Issue9()
+type issue9Response struct {
 	Body         []byte
 	HTTPResponse *http.Response
 }
 
 // Status returns HTTPResponse.Status
-func (r *OAPIIssue9Response) Status() string {
+func (r *issue9Response) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -105,22 +105,22 @@ func (r *OAPIIssue9Response) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r *OAPIIssue9Response) StatusCode() int {
+func (r *issue9Response) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
 }
 
-// ParseOAPIIssue9Response parses an HTTP response from a Issue9WithResponse call
-func ParseOAPIIssue9Response(rsp *http.Response) (*OAPIIssue9Response, error) {
+// Parseissue9Response parses an HTTP response from a Issue9WithResponse call
+func Parseissue9Response(rsp *http.Response) (*issue9Response, error) {
 	bodyBytes, err := ioutil.ReadAll(rsp.Body)
 	defer rsp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &OAPIIssue9Response{
+	response := &issue9Response{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -132,12 +132,12 @@ func ParseOAPIIssue9Response(rsp *http.Response) (*OAPIIssue9Response, error) {
 }
 
 // Issue9 request with JSON body returning *Issue9Response
-func (c *ClientWithResponses) Issue9WithResponse(ctx context.Context, params *Issue9Params, body *Issue9RequestBody) (*OAPIIssue9Response, error) {
+func (c *ClientWithResponses) Issue9WithResponse(ctx context.Context, params *Issue9Params, body *Issue9RequestBody) (*issue9Response, error) {
 	rsp, err := c.Issue9(ctx, params, body)
 	if err != nil {
 		return nil, err
 	}
-	return ParseOAPIIssue9Response(rsp)
+	return Parseissue9Response(rsp)
 }
 
 // NewIssue9Request generates requests for Issue9 with JSON body

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -62,7 +62,7 @@ func TestExamplePetStoreParseFunction(t *testing.T) {
 	}
 	cannedResponse.Header.Add("Content-type", "application/json")
 
-	findPetByIDResponse, err := examplePetstore.ParseFindPetByIdResponse(cannedResponse)
+	findPetByIDResponse, err := examplePetstore.ParseOAPIFindPetByIdResponse(cannedResponse)
 	assert.NoError(t, err)
 	assert.NotNil(t, findPetByIDResponse.JSON200)
 	assert.Equal(t, int64(5), findPetByIDResponse.JSON200.Id)
@@ -99,16 +99,16 @@ func TestExampleOpenAPICodeGeneration(t *testing.T) {
 	assert.Contains(t, code, "package testswagger")
 
 	// Check that response structs are generated correctly:
-	assert.Contains(t, code, "type GetTestByNameResponse struct {")
+	assert.Contains(t, code, "type OAPIGetTestByNameResponse struct {")
 
 	// Check that the helper methods are generated correctly:
-	assert.Contains(t, code, "func (r *GetTestByNameResponse) Status() string {")
-	assert.Contains(t, code, "func (r *GetTestByNameResponse) StatusCode() int {")
-	assert.Contains(t, code, "func ParseGetTestByNameResponse(rsp *http.Response) (*GetTestByNameResponse, error) {")
+	assert.Contains(t, code, "func (r *OAPIGetTestByNameResponse) Status() string {")
+	assert.Contains(t, code, "func (r *OAPIGetTestByNameResponse) StatusCode() int {")
+	assert.Contains(t, code, "func ParseOAPIGetTestByNameResponse(rsp *http.Response) (*OAPIGetTestByNameResponse, error) {")
 
 	// Check the client method signatures:
 	assert.Contains(t, code, "func (c *Client) GetTestByName(ctx context.Context, name string) (*http.Response, error) {")
-	assert.Contains(t, code, "func (c *ClientWithResponses) GetTestByNameWithResponse(ctx context.Context, name string) (*GetTestByNameResponse, error) {")
+	assert.Contains(t, code, "func (c *ClientWithResponses) GetTestByNameWithResponse(ctx context.Context, name string) (*OAPIGetTestByNameResponse, error) {")
 
 	// Make sure the generated code is valid:
 	linter := new(lint.Linter)

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -62,7 +62,7 @@ func TestExamplePetStoreParseFunction(t *testing.T) {
 	}
 	cannedResponse.Header.Add("Content-type", "application/json")
 
-	findPetByIDResponse, err := examplePetstore.ParseOAPIFindPetByIdResponse(cannedResponse)
+	findPetByIDResponse, err := examplePetstore.ParsefindPetByIdResponse(cannedResponse)
 	assert.NoError(t, err)
 	assert.NotNil(t, findPetByIDResponse.JSON200)
 	assert.Equal(t, int64(5), findPetByIDResponse.JSON200.Id)
@@ -99,16 +99,16 @@ func TestExampleOpenAPICodeGeneration(t *testing.T) {
 	assert.Contains(t, code, "package testswagger")
 
 	// Check that response structs are generated correctly:
-	assert.Contains(t, code, "type OAPIGetTestByNameResponse struct {")
+	assert.Contains(t, code, "type getTestByNameResponse struct {")
 
 	// Check that the helper methods are generated correctly:
-	assert.Contains(t, code, "func (r *OAPIGetTestByNameResponse) Status() string {")
-	assert.Contains(t, code, "func (r *OAPIGetTestByNameResponse) StatusCode() int {")
-	assert.Contains(t, code, "func ParseOAPIGetTestByNameResponse(rsp *http.Response) (*OAPIGetTestByNameResponse, error) {")
+	assert.Contains(t, code, "func (r *getTestByNameResponse) Status() string {")
+	assert.Contains(t, code, "func (r *getTestByNameResponse) StatusCode() int {")
+	assert.Contains(t, code, "func ParsegetTestByNameResponse(rsp *http.Response) (*getTestByNameResponse, error) {")
 
 	// Check the client method signatures:
 	assert.Contains(t, code, "func (c *Client) GetTestByName(ctx context.Context, name string) (*http.Response, error) {")
-	assert.Contains(t, code, "func (c *ClientWithResponses) GetTestByNameWithResponse(ctx context.Context, name string) (*OAPIGetTestByNameResponse, error) {")
+	assert.Contains(t, code, "func (c *ClientWithResponses) GetTestByNameWithResponse(ctx context.Context, name string) (*getTestByNameResponse, error) {")
 
 	// Make sure the generated code is valid:
 	linter := new(lint.Linter)

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -25,10 +25,12 @@ import (
 )
 
 var (
-	payloadPrefix    = "payload"
-	contentTypesJSON = []string{echo.MIMEApplicationJSON, "text/x-json"}
-	contentTypesYAML = []string{"application/yaml", "application/x-yaml", "text/yaml", "text/x-yaml"}
-	contentTypesXML  = []string{echo.MIMEApplicationXML, echo.MIMETextXML}
+	payloadPrefix      = "payload"
+	contentTypesJSON   = []string{echo.MIMEApplicationJSON, "text/x-json"}
+	contentTypesYAML   = []string{"application/yaml", "application/x-yaml", "text/yaml", "text/x-yaml"}
+	contentTypesXML    = []string{echo.MIMEApplicationXML, echo.MIMETextXML}
+	responseTypePrefix = "OAPI"
+	responseTypeSuffix = "Response"
 )
 
 // This function takes an array of Parameter definition, and generates a valid
@@ -86,7 +88,7 @@ func genResponsePayload(operationID string) string {
 	var buffer = bytes.NewBufferString("")
 
 	// Here is where we build up a response:
-	fmt.Fprintf(buffer, "&%sResponse{\n", operationID)
+	fmt.Fprintf(buffer, "&%s{\n", genResponseTypeName(operationID))
 	fmt.Fprintf(buffer, "Body: bodyBytes,\n")
 	fmt.Fprintf(buffer, "HTTPResponse: rsp,\n")
 	fmt.Fprintf(buffer, "}")
@@ -99,8 +101,8 @@ func genResponseType(operationID string, responses openapi3.Responses) string {
 	var buffer = bytes.NewBufferString("")
 
 	// The header and standard struct attributes:
-	fmt.Fprintf(buffer, "// %sResponse is returned by Client.%s()\n", operationID, operationID)
-	fmt.Fprintf(buffer, "type %sResponse struct {\n", operationID)
+	fmt.Fprintf(buffer, "// %s is returned by Client.%s()\n", genResponseTypeName(operationID), operationID)
+	fmt.Fprintf(buffer, "type %s struct {\n", genResponseTypeName(operationID))
 	fmt.Fprintf(buffer, "Body []byte\n")
 	fmt.Fprintf(buffer, "HTTPResponse *http.Response\n")
 
@@ -163,7 +165,7 @@ func genResponseType(operationID string, responses openapi3.Responses) string {
 
 	// Status() provides an easy way to get the Status:
 	fmt.Fprintf(buffer, "// Status returns HTTPResponse.Status\n")
-	fmt.Fprintf(buffer, "func (r *%sResponse) Status() string {\n", operationID)
+	fmt.Fprintf(buffer, "func (r *%s) Status() string {\n", genResponseTypeName(operationID))
 	fmt.Fprintf(buffer, "	if r.HTTPResponse != nil {\n")
 	fmt.Fprintf(buffer, "		return r.HTTPResponse.Status\n")
 	fmt.Fprintf(buffer, "	}\n")
@@ -172,7 +174,7 @@ func genResponseType(operationID string, responses openapi3.Responses) string {
 
 	// StatusCode() provides an easy way to get the StatusCode:
 	fmt.Fprintf(buffer, "// StatusCode returns HTTPResponse.StatusCode\n")
-	fmt.Fprintf(buffer, "func (r *%sResponse) StatusCode() int {\n", operationID)
+	fmt.Fprintf(buffer, "func (r *%s) StatusCode() int {\n", genResponseTypeName(operationID))
 	fmt.Fprintf(buffer, "	if r.HTTPResponse != nil {\n")
 	fmt.Fprintf(buffer, "		return r.HTTPResponse.StatusCode\n")
 	fmt.Fprintf(buffer, "	}\n")
@@ -312,6 +314,11 @@ func genResponseUnmarshal(operationID string, responses openapi3.Responses) stri
 	return buffer.String()
 }
 
+// genResponseTypeName creates the name of generated response types (given the operationID):
+func genResponseTypeName(operationID string) string {
+	return fmt.Sprintf("%s%s%s", responseTypePrefix, operationID, responseTypeSuffix)
+}
+
 // contains tells us if a string is found in a slice of strings:
 func contains(strings []string, s string) bool {
 	for _, stringInSlice := range strings {
@@ -334,5 +341,6 @@ var TemplateFunctions = template.FuncMap{
 	"camelCase":            ToCamelCase,
 	"genResponsePayload":   genResponsePayload,
 	"genResponseType":      genResponseType,
+	"genResponseTypeName":  genResponseTypeName,
 	"genResponseUnmarshal": genResponseUnmarshal,
 }

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -29,7 +29,6 @@ var (
 	contentTypesJSON   = []string{echo.MIMEApplicationJSON, "text/x-json"}
 	contentTypesYAML   = []string{"application/yaml", "application/x-yaml", "text/yaml", "text/x-yaml"}
 	contentTypesXML    = []string{echo.MIMEApplicationXML, echo.MIMETextXML}
-	responseTypePrefix = "OAPI"
 	responseTypeSuffix = "Response"
 )
 
@@ -316,7 +315,7 @@ func genResponseUnmarshal(operationID string, responses openapi3.Responses) stri
 
 // genResponseTypeName creates the name of generated response types (given the operationID):
 func genResponseTypeName(operationID string) string {
-	return fmt.Sprintf("%s%s%s", responseTypePrefix, operationID, responseTypeSuffix)
+	return fmt.Sprintf("%s%s", LowercaseFirstCharacter(operationID), responseTypeSuffix)
 }
 
 // contains tells us if a string is found in a slice of strings:

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -143,17 +143,17 @@ func genResponseType(operationID string, responses openapi3.Responses) string {
 					// JSON:
 					case contains(contentTypesJSON, contentTypeName):
 						attributeName := fmt.Sprintf("JSON%s", ToCamelCase(responseName))
-						fmt.Fprintf(buffer, "%s *%s // '%s' (%s)\n", attributeName, goType, responseRef.Value.Description, contentType.Schema.Ref)
+						fmt.Fprintf(buffer, "%s *%s\n", attributeName, goType)
 
 					// YAML:
 					case contains(contentTypesYAML, contentTypeName):
 						attributeName := fmt.Sprintf("YAML%s", ToCamelCase(responseName))
-						fmt.Fprintf(buffer, "%s *%s // '%s' (%s)\n", attributeName, goType, responseRef.Value.Description, contentType.Schema.Ref)
+						fmt.Fprintf(buffer, "%s *%s\n", attributeName, goType)
 
 					// XML:
 					case contains(contentTypesXML, contentTypeName):
 						attributeName := fmt.Sprintf("XML%s", ToCamelCase(responseName))
-						fmt.Fprintf(buffer, "%s *%s // '%s' (%s)\n", attributeName, goType, responseRef.Value.Description, contentType.Schema.Ref)
+						fmt.Fprintf(buffer, "%s *%s\n", attributeName, goType)
 					}
 				}
 			}

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -83,8 +83,8 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 {{range .}}{{$opid := .OperationId}}
 {{genResponseType $opid .Spec.Responses}}
 
-// Parse{{$opid}}Response parses an HTTP response from a {{$opid}}WithResponse call
-func Parse{{$opid}}Response(rsp *http.Response) (*{{$opid}}Response, error) {
+// Parse{{genResponseTypeName $opid}} parses an HTTP response from a {{$opid}}WithResponse call
+func Parse{{genResponseTypeName $opid}}(rsp *http.Response) (*{{genResponseTypeName $opid}}, error) {
     bodyBytes, err := ioutil.ReadAll(rsp.Body)
     defer rsp.Body.Close()
     if err != nil {
@@ -101,23 +101,23 @@ func Parse{{$opid}}Response(rsp *http.Response) (*{{$opid}}Response, error) {
 {{/* Generate client methods (with responses)*/}}
 {{if .HasBody}}
 // {{$opid}} request with JSON body returning *{{$opid}}Response
-func (c *ClientWithResponses) {{$opid}}WithResponse(ctx context.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params *{{$opid}}Params{{end}}, body {{if not .GetBodyDefinition.Required}}*{{end}}{{if .GetBodyDefinition.CustomType}}{{$opid}}RequestBody{{else}}{{.GetBodyDefinition.TypeDef}}{{end}}) (*{{$opid}}Response, error){
+func (c *ClientWithResponses) {{$opid}}WithResponse(ctx context.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params *{{$opid}}Params{{end}}, body {{if not .GetBodyDefinition.Required}}*{{end}}{{if .GetBodyDefinition.CustomType}}{{$opid}}RequestBody{{else}}{{.GetBodyDefinition.TypeDef}}{{end}}) (*{{genResponseTypeName $opid}}, error){
     rsp, err := c.{{$opid}}(ctx{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}}, body)
 	if err != nil {
 		return nil, err
 	}
-    return Parse{{$opid}}Response(rsp)
+    return Parse{{genResponseTypeName $opid}}(rsp)
 }
 {{end}}{{/* if .HasBody */}}
 
 {{if .GenerateGenericForm}}
 // {{$opid}}{{if .HasAnyBody}}WithBody{{end}} request{{if .HasAnyBody}} with arbitrary body{{end}} returning *{{$opid}}Response
-func (c *ClientWithResponses) {{$opid}}{{if .HasAnyBody}}WithBody{{end}}WithResponse(ctx context.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params *{{$opid}}Params{{end}}{{if .HasAnyBody}}, contentType string, body io.Reader{{end}}) (*{{$opid}}Response, error){
+func (c *ClientWithResponses) {{$opid}}{{if .HasAnyBody}}WithBody{{end}}WithResponse(ctx context.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params *{{$opid}}Params{{end}}{{if .HasAnyBody}}, contentType string, body io.Reader{{end}}) (*{{genResponseTypeName $opid}}, error){
     rsp, err := c.{{$opid}}(ctx{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}}{{if .HasAnyBody}}, contentType, body{{end}})
     if err != nil {
         return nil, err
     }
-    return Parse{{$opid}}Response(rsp)
+    return Parse{{genResponseTypeName $opid}}(rsp)
 }
 {{end}}{{/* if .GenerateGenericForm */}}
 {{end}}{{/* range . $opid := .OperationId */}}

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -87,8 +87,8 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 {{range .}}{{$opid := .OperationId}}
 {{genResponseType $opid .Spec.Responses}}
 
-// Parse{{$opid}}Response parses an HTTP response from a {{$opid}}WithResponse call
-func Parse{{$opid}}Response(rsp *http.Response) (*{{$opid}}Response, error) {
+// Parse{{genResponseTypeName $opid}} parses an HTTP response from a {{$opid}}WithResponse call
+func Parse{{genResponseTypeName $opid}}(rsp *http.Response) (*{{genResponseTypeName $opid}}, error) {
     bodyBytes, err := ioutil.ReadAll(rsp.Body)
     defer rsp.Body.Close()
     if err != nil {
@@ -105,23 +105,23 @@ func Parse{{$opid}}Response(rsp *http.Response) (*{{$opid}}Response, error) {
 {{/* Generate client methods (with responses)*/}}
 {{if .HasBody}}
 // {{$opid}} request with JSON body returning *{{$opid}}Response
-func (c *ClientWithResponses) {{$opid}}WithResponse(ctx context.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params *{{$opid}}Params{{end}}, body {{if not .GetBodyDefinition.Required}}*{{end}}{{if .GetBodyDefinition.CustomType}}{{$opid}}RequestBody{{else}}{{.GetBodyDefinition.TypeDef}}{{end}}) (*{{$opid}}Response, error){
+func (c *ClientWithResponses) {{$opid}}WithResponse(ctx context.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params *{{$opid}}Params{{end}}, body {{if not .GetBodyDefinition.Required}}*{{end}}{{if .GetBodyDefinition.CustomType}}{{$opid}}RequestBody{{else}}{{.GetBodyDefinition.TypeDef}}{{end}}) (*{{genResponseTypeName $opid}}, error){
     rsp, err := c.{{$opid}}(ctx{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}}, body)
 	if err != nil {
 		return nil, err
 	}
-    return Parse{{$opid}}Response(rsp)
+    return Parse{{genResponseTypeName $opid}}(rsp)
 }
 {{end}}{{/* if .HasBody */}}
 
 {{if .GenerateGenericForm}}
 // {{$opid}}{{if .HasAnyBody}}WithBody{{end}} request{{if .HasAnyBody}} with arbitrary body{{end}} returning *{{$opid}}Response
-func (c *ClientWithResponses) {{$opid}}{{if .HasAnyBody}}WithBody{{end}}WithResponse(ctx context.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params *{{$opid}}Params{{end}}{{if .HasAnyBody}}, contentType string, body io.Reader{{end}}) (*{{$opid}}Response, error){
+func (c *ClientWithResponses) {{$opid}}{{if .HasAnyBody}}WithBody{{end}}WithResponse(ctx context.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params *{{$opid}}Params{{end}}{{if .HasAnyBody}}, contentType string, body io.Reader{{end}}) (*{{genResponseTypeName $opid}}, error){
     rsp, err := c.{{$opid}}(ctx{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}}{{if .HasAnyBody}}, contentType, body{{end}})
     if err != nil {
         return nil, err
     }
-    return Parse{{$opid}}Response(rsp)
+    return Parse{{genResponseTypeName $opid}}(rsp)
 }
 {{end}}{{/* if .GenerateGenericForm */}}
 {{end}}{{/* range . $opid := .OperationId */}}


### PR DESCRIPTION
* Removed comments from generated types (they weren't always populated, plus they could have unsafe characters)
* Changed the name of the generated response structs (prefixed with "OAPI"), to make them less likely to clash with user-defined model names