### PR TITLE
Meaningful validation error responses

### DIFF
--- a/pkg/middleware/oapi_validate.go
+++ b/pkg/middleware/oapi_validate.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
@@ -116,7 +117,10 @@ func ValidateRequestFromContext(ctx echo.Context, router *openapi3filter.Router,
 		switch e := err.(type) {
 		case *openapi3filter.RequestError:
 			// We've got a bad request
-			return echo.NewHTTPError(http.StatusBadRequest, e.Reason)
+			// Split up the verbose error by lines and return the first one
+			// openapi errors seem to be multi-line with a decent message on the first
+			errorLines := strings.Split(e.Error(), "\n")
+			return echo.NewHTTPError(http.StatusBadRequest, errorLines[0])
 		case *openapi3filter.SecurityRequirementsError:
 			return echo.NewHTTPError(http.StatusForbidden, e.Error())
 		default:


### PR DESCRIPTION
I've found the validation errors returned are not that helpful. Consider the following examples:

1. Request with a missing path parameter: `{"message":"must have a value"}`
2. Request with an invalid enum value for a path parameter: `{"message":""}`
3. Request with a missing required attribute in the request body: `{"message":"doesn't match the schema"}`
4. Request with an invalid enum value for an attribute in the request body: `{"message":"doesn't match the schema"}`

This PR makes use of the **Error** attribute, which comes back as (overly verbose) multi-line text. However, the first line contains a useful amount of detail. The results (for the same scenarios) are as follows:

1. Request with a missing path parameter: `{"message":"Parameter 'someEnumValue' in path has an error: must have a value: must have a value"}`
2. Request with an invalid enum value for a path parameter: `{"message":"Parameter 'someEnumValue' in path has an error: JSON value is not one of the allowed values"}`
3. Request with a missing required attribute in the request body: `{"message":"Request body has an error: doesn't match the schema: Property 'someProperty' is missing"}`
4. Request with an invalid enum value for an attribute in the request body: `{"message":"Request body has an error: doesn't match the schema: Error at \"/somePropery\": JSON value is not one of the allowed values"}`

The full error text contains way too much information, including escaped JSON objects to describe the actual schema. I think this is too much info, so the first line seems like an easy way to get a good balance.