### PR TITLE
Added a NewClientWithResponsesAndRequestEditorFunc function and updated the RequestEditor to use a type

### DIFF
--- a/examples/petstore-expanded/api/petstore-client.gen.go
+++ b/examples/petstore-expanded/api/petstore-client.gen.go
@@ -15,6 +15,9 @@ import (
 	"strings"
 )
 
+// RequestEditorFn  is the function signature for the RequestEditor callback function
+type RequestEditorFn func(req *http.Request, ctx context.Context) error
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -26,7 +29,7 @@ type Client struct {
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
-	RequestEditor func(req *http.Request, ctx context.Context) error
+	RequestEditor RequestEditorFn
 }
 
 // The interface specification for the client above.
@@ -242,6 +245,17 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 		ClientInterface: &Client{
 			Client: http.Client{},
 			Server: server,
+		},
+	}
+}
+
+// NewClientWithResponsesAndRequestEditorFunc takes in a RequestEditorFn callback function and returns a ClientWithResponses with a default Client:
+func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
+	return &ClientWithResponses{
+		ClientInterface: &Client{
+			Client:        http.Client{},
+			Server:        server,
+			RequestEditor: reqEditorFn,
 		},
 	}
 }

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -31,6 +31,9 @@ type PostBothJSONRequestBody SchemaObject
 // PostJsonRequestBody defines body for PostJson for application/json ContentType.
 type PostJsonJSONRequestBody SchemaObject
 
+// RequestEditorFn  is the function signature for the RequestEditor callback function
+type RequestEditorFn func(req *http.Request, ctx context.Context) error
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -42,7 +45,7 @@ type Client struct {
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
-	RequestEditor func(req *http.Request, ctx context.Context) error
+	RequestEditor RequestEditorFn
 }
 
 // The interface specification for the client above.
@@ -310,6 +313,17 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 		ClientInterface: &Client{
 			Client: http.Client{},
 			Server: server,
+		},
+	}
+}
+
+// NewClientWithResponsesAndRequestEditorFunc takes in a RequestEditorFn callback function and returns a ClientWithResponses with a default Client:
+func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
+	return &ClientWithResponses{
+		ClientInterface: &Client{
+			Client:        http.Client{},
+			Server:        server,
+			RequestEditor: reqEditorFn,
 		},
 	}
 }

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -713,6 +713,9 @@ func (a AdditionalPropertiesObject5) MarshalJSON() ([]byte, error) {
 	return json.Marshal(object)
 }
 
+// RequestEditorFn  is the function signature for the RequestEditor callback function
+type RequestEditorFn func(req *http.Request, ctx context.Context) error
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -724,7 +727,7 @@ type Client struct {
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
-	RequestEditor func(req *http.Request, ctx context.Context) error
+	RequestEditor RequestEditorFn
 }
 
 // The interface specification for the client above.
@@ -858,6 +861,17 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 		ClientInterface: &Client{
 			Client: http.Client{},
 			Server: server,
+		},
+	}
+}
+
+// NewClientWithResponsesAndRequestEditorFunc takes in a RequestEditorFn callback function and returns a ClientWithResponses with a default Client:
+func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
+	return &ClientWithResponses{
+		ClientInterface: &Client{
+			Client:        http.Client{},
+			Server:        server,
+			RequestEditor: reqEditorFn,
 		},
 	}
 }

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -64,6 +64,9 @@ type GetQueryFormParams struct {
 	Co *ComplexObject `json:"co,omitempty"`
 }
 
+// RequestEditorFn  is the function signature for the RequestEditor callback function
+type RequestEditorFn func(req *http.Request, ctx context.Context) error
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -75,7 +78,7 @@ type Client struct {
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
-	RequestEditor func(req *http.Request, ctx context.Context) error
+	RequestEditor RequestEditorFn
 }
 
 // The interface specification for the client above.
@@ -1043,6 +1046,17 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 		ClientInterface: &Client{
 			Client: http.Client{},
 			Server: server,
+		},
+	}
+}
+
+// NewClientWithResponsesAndRequestEditorFunc takes in a RequestEditorFn callback function and returns a ClientWithResponses with a default Client:
+func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
+	return &ClientWithResponses{
+		ClientInterface: &Client{
+			Client:        http.Client{},
+			Server:        server,
+			RequestEditor: reqEditorFn,
 		},
 	}
 }

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -42,6 +42,9 @@ type Issue9Params struct {
 // Issue9RequestBody defines body for Issue9 for application/json ContentType.
 type Issue9JSONRequestBody Issue9JSONBody
 
+// RequestEditorFn  is the function signature for the RequestEditor callback function
+type RequestEditorFn func(req *http.Request, ctx context.Context) error
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -53,7 +56,7 @@ type Client struct {
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
-	RequestEditor func(req *http.Request, ctx context.Context) error
+	RequestEditor RequestEditorFn
 }
 
 // The interface specification for the client above.
@@ -185,6 +188,17 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 		ClientInterface: &Client{
 			Client: http.Client{},
 			Server: server,
+		},
+	}
+}
+
+// NewClientWithResponsesAndRequestEditorFunc takes in a RequestEditorFn callback function and returns a ClientWithResponses with a default Client:
+func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
+	return &ClientWithResponses{
+		ClientInterface: &Client{
+			Client:        http.Client{},
+			Server:        server,
+			RequestEditor: reqEditorFn,
 		},
 	}
 }

--- a/pkg/codegen/templates/client-with-responses.tmpl
+++ b/pkg/codegen/templates/client-with-responses.tmpl
@@ -13,6 +13,18 @@ func NewClientWithResponses(server string) *ClientWithResponses {
     }
 }
 
+// NewClientWithResponsesAndRequestEditorFunc takes in a RequestEditorFn callback function and returns a ClientWithResponses with a default Client:
+func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
+	return &ClientWithResponses{
+		ClientInterface: &Client{
+			Client: http.Client{},
+			Server: server,
+			RequestEditor: reqEditorFn,
+		},
+	}
+}
+
+
 {{range .}}{{$opid := .OperationId}}{{$op := .}}
 type {{$opid | lcFirst}}Response struct {
     Body         []byte

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -1,3 +1,6 @@
+// RequestEditorFn  is the function signature for the RequestEditor callback function
+type RequestEditorFn func(req *http.Request, ctx context.Context) error
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
     // The endpoint of the server conforming to this interface, with scheme,
@@ -9,7 +12,7 @@ type Client struct {
 
     // A callback for modifying requests which are generated before sending over
     // the network.
-    RequestEditor func(req *http.Request, ctx context.Context) error
+    RequestEditor RequestEditorFn
 }
 
 // The interface specification for the client above.

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -88,6 +88,18 @@ func NewClientWithResponses(server string) *ClientWithResponses {
     }
 }
 
+// NewClientWithResponsesAndRequestEditorFunc takes in a RequestEditorFn callback function and returns a ClientWithResponses with a default Client:
+func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
+	return &ClientWithResponses{
+		ClientInterface: &Client{
+			Client: http.Client{},
+			Server: server,
+			RequestEditor: reqEditorFn,
+		},
+	}
+}
+
+
 {{range .}}{{$opid := .OperationId}}{{$op := .}}
 type {{$opid | lcFirst}}Response struct {
     Body         []byte
@@ -163,7 +175,10 @@ func Parse{{genResponseTypeName $opid}}(rsp *http.Response) (*{{genResponseTypeN
 {{end}}{{/* range . $opid := .OperationId */}}
 
 `,
-	"client.tmpl": `// Client which conforms to the OpenAPI3 specification for this service.
+	"client.tmpl": `// RequestEditorFn  is the function signature for the RequestEditor callback function
+type RequestEditorFn func(req *http.Request, ctx context.Context) error
+
+// Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
     // The endpoint of the server conforming to this interface, with scheme,
     // https://api.deepmap.com for example.
@@ -174,7 +189,7 @@ type Client struct {
 
     // A callback for modifying requests which are generated before sending over
     // the network.
-    RequestEditor func(req *http.Request, ctx context.Context) error
+    RequestEditor RequestEditorFn
 }
 
 // The interface specification for the client above.


### PR DESCRIPTION
* Added a type definition for the RequestEditor function for easy reuse
* Added a new NewClientWithResponsesAndRequestEditorFunc function to be able to pass a custom callback function during the client creation.

This should be a non-breaking change. Please review. 