### PR TITLE
Fix a bug that cause generated code shows invalid reference

### DIFF
--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -452,7 +452,12 @@ func GenerateBodyDefinitions(operationID string, bodyOrRef *openapi3.RequestBody
 
 		// If the body is a pre-defined type
 		if bodyOrRef.Ref != "" {
-			bodySchema.RefType = bodyOrRef.Ref
+			// Convert the reference path to Go type
+			refType, err := RefPathToGoType(bodyOrRef.Ref)
+			if err != nil {
+				return nil, nil, errors.Wrap(err, fmt.Sprintf("error turning reference (%s) into a Go type", bodyOrRef.Ref))
+			}
+			bodySchema.RefType = refType
 		}
 
 		// If the request has a body, but it's not a user defined


### PR DESCRIPTION
Hi,

I come around at a small problem that cause generated code is unusable.
First, if you have:
```yaml
paths:
  /pets:
    post:
      requestBody:
        description: Pet to add to the store
        required: true
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/NewPet'
```

It is working fine as it generates: 
```go
// AddPetRequestBody defines body for AddPet for application/json ContentType.
type AddPetJSONRequestBody NewPet
```

But, when I change it this way: 
```yaml
paths:
  /pets:
    post:
      requestBody:
        $ref: '#/components/requestBodies/PetRequest'
components:
  requestBodies:
    PetRequest:
      description: Pet to add to the store
      required: true
      content:
        application/json:
          schema:
            $ref: '#/components/schemas/NewPet'
```
It will generates: 
```go
// AddPetRequestBody defines body for AddPet for application/json ContentType.
type AddPetJSONRequestBody #/components/requestBodies/PetRequest
```

Thanks for the utils, I implements small fix to resolve the problem. Now the result is like this: 
```go
// AddPetRequestBody defines body for AddPet for application/json ContentType.
type AddPetJSONRequestBody PetRequest
```
Now it's working for us.
This is rather a small fix, but I am open to suggestion to make it better.

Thanks!