### PR TITLE
Include path parameters in param types

### DIFF
--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -79,6 +79,9 @@ func FindPetsCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
+		// Parameter object where we will unmarshal all parameters from the context
+		var params FindPetsParams
+
 		var err error
 
 		// ------------- Optional query parameter "tags" -------------
@@ -123,6 +126,9 @@ func DeletePetCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
+		// Parameter object where we will unmarshal all parameters from the context
+		var params DeletePetParams
+
 		// ------------- Path parameter "id" -------------
 		var pathErr error
 		var id int64
@@ -133,7 +139,7 @@ func DeletePetCtx(next http.Handler) http.Handler {
 			return
 		}
 
-		ctx = context.WithValue(r.Context(), "id", id)
+		params.Id = id
 
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
@@ -144,6 +150,9 @@ func FindPetByIdCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
+		// Parameter object where we will unmarshal all parameters from the context
+		var params FindPetByIdParams
+
 		// ------------- Path parameter "id" -------------
 		var pathErr error
 		var id int64
@@ -154,7 +163,7 @@ func FindPetByIdCtx(next http.Handler) http.Handler {
 			return
 		}
 
-		ctx = context.WithValue(r.Context(), "id", id)
+		params.Id = id
 
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -45,6 +45,16 @@ type FindPetsParams struct {
 // addPetJSONBody defines parameters for AddPet.
 type addPetJSONBody NewPet
 
+// DeletePetParams defines parameters for DeletePet.
+type DeletePetParams struct {
+	Id int64 `json:"id"`
+}
+
+// FindPetByIdParams defines parameters for FindPetById.
+type FindPetByIdParams struct {
+	Id int64 `json:"id"`
+}
+
 // AddPetRequestBody defines body for AddPet for application/json ContentType.
 type AddPetJSONRequestBody addPetJSONBody
 
@@ -70,8 +80,6 @@ func FindPetsCtx(next http.Handler) http.Handler {
 		ctx := r.Context()
 
 		var err error
-		// Parameter object where we will unmarshal all parameters from the context
-		var params FindPetsParams
 
 		// ------------- Optional query parameter "tags" -------------
 		if paramValue := r.URL.Query().Get("tags"); paramValue != "" {

--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -106,7 +106,7 @@ func FindPetsCtx(next http.Handler) http.Handler {
 			return
 		}
 
-		ctx = context.WithValue(r.Context(), "FindPetsParams", &params)
+		ctx = context.WithValue(ctx, "FindPetsParams", &params)
 
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
@@ -119,6 +119,11 @@ func AddPetCtx(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// ParamsForDeletePet operation parameters from context
+func ParamsForDeletePet(ctx context.Context) *DeletePetParams {
+	return ctx.Value("DeletePetParams").(*DeletePetParams)
 }
 
 // DeletePet operation middleware
@@ -141,8 +146,15 @@ func DeletePetCtx(next http.Handler) http.Handler {
 
 		params.Id = id
 
+		ctx = context.WithValue(ctx, "DeletePetParams", &params)
+
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// ParamsForFindPetById operation parameters from context
+func ParamsForFindPetById(ctx context.Context) *FindPetByIdParams {
+	return ctx.Value("FindPetByIdParams").(*FindPetByIdParams)
 }
 
 // FindPetById operation middleware
@@ -164,6 +176,8 @@ func FindPetByIdCtx(next http.Handler) http.Handler {
 		}
 
 		params.Id = id
+
+		ctx = context.WithValue(ctx, "FindPetByIdParams", &params)
 
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/examples/petstore-expanded/chi/api/petstore.go
+++ b/examples/petstore-expanded/chi/api/petstore.go
@@ -98,7 +98,7 @@ func (p *PetStore) AddPet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *PetStore) FindPetById(w http.ResponseWriter, r *http.Request) {
-	id := r.Context().Value("id").(int64)
+	id := ParamsForFindPetById(r.Context()).Id
 
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
@@ -114,7 +114,7 @@ func (p *PetStore) FindPetById(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *PetStore) DeletePet(w http.ResponseWriter, r *http.Request) {
-	id := r.Context().Value("id").(int64)
+	id := ParamsForDeletePet(r.Context()).Id
 
 	p.Lock.Lock()
 	defer p.Lock.Unlock()

--- a/examples/petstore-expanded/echo/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/echo/api/petstore-types.gen.go
@@ -32,5 +32,15 @@ type FindPetsParams struct {
 // addPetJSONBody defines parameters for AddPet.
 type addPetJSONBody NewPet
 
+// DeletePetParams defines parameters for DeletePet.
+type DeletePetParams struct {
+	Id int64 `json:"id"`
+}
+
+// FindPetByIdParams defines parameters for FindPetById.
+type FindPetByIdParams struct {
+	Id int64 `json:"id"`
+}
+
 // AddPetRequestBody defines body for AddPet for application/json ContentType.
 type AddPetJSONRequestBody addPetJSONBody

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -44,6 +44,16 @@ type FindPetsParams struct {
 // addPetJSONBody defines parameters for AddPet.
 type addPetJSONBody NewPet
 
+// DeletePetParams defines parameters for DeletePet.
+type DeletePetParams struct {
+	Id int64 `json:"id"`
+}
+
+// FindPetByIdParams defines parameters for FindPetById.
+type FindPetByIdParams struct {
+	Id int64 `json:"id"`
+}
+
 // AddPetRequestBody defines body for AddPet for application/json ContentType.
 type AddPetJSONRequestBody addPetJSONBody
 

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -31,6 +31,11 @@ type Object struct {
 	Role      string `json:"role"`
 }
 
+// GetContentObjectParams defines parameters for GetContentObject.
+type GetContentObjectParams struct {
+	Param ComplexObject `json:"param"`
+}
+
 // GetCookieParams defines parameters for GetCookie.
 type GetCookieParams struct {
 	P  *int32         `json:"p,omitempty"`
@@ -53,6 +58,51 @@ type GetHeaderParams struct {
 	XComplexObject     *ComplexObject `json:"X-Complex-Object,omitempty"`
 }
 
+// GetLabelExplodeArrayParams defines parameters for GetLabelExplodeArray.
+type GetLabelExplodeArrayParams struct {
+	Param []int32 `json:"param"`
+}
+
+// GetLabelExplodeObjectParams defines parameters for GetLabelExplodeObject.
+type GetLabelExplodeObjectParams struct {
+	Param Object `json:"param"`
+}
+
+// GetLabelNoExplodeArrayParams defines parameters for GetLabelNoExplodeArray.
+type GetLabelNoExplodeArrayParams struct {
+	Param []int32 `json:"param"`
+}
+
+// GetLabelNoExplodeObjectParams defines parameters for GetLabelNoExplodeObject.
+type GetLabelNoExplodeObjectParams struct {
+	Param Object `json:"param"`
+}
+
+// GetMatrixExplodeArrayParams defines parameters for GetMatrixExplodeArray.
+type GetMatrixExplodeArrayParams struct {
+	Id []int32 `json:"id"`
+}
+
+// GetMatrixExplodeObjectParams defines parameters for GetMatrixExplodeObject.
+type GetMatrixExplodeObjectParams struct {
+	Id Object `json:"id"`
+}
+
+// GetMatrixNoExplodeArrayParams defines parameters for GetMatrixNoExplodeArray.
+type GetMatrixNoExplodeArrayParams struct {
+	Id []int32 `json:"id"`
+}
+
+// GetMatrixNoExplodeObjectParams defines parameters for GetMatrixNoExplodeObject.
+type GetMatrixNoExplodeObjectParams struct {
+	Id Object `json:"id"`
+}
+
+// GetPassThroughParams defines parameters for GetPassThrough.
+type GetPassThroughParams struct {
+	Param string `json:"param"`
+}
+
 // GetQueryFormParams defines parameters for GetQueryForm.
 type GetQueryFormParams struct {
 	Ea *[]int32       `json:"ea,omitempty"`
@@ -62,6 +112,31 @@ type GetQueryFormParams struct {
 	Ep *int32         `json:"ep,omitempty"`
 	P  *int32         `json:"p,omitempty"`
 	Co *ComplexObject `json:"co,omitempty"`
+}
+
+// GetSimpleExplodeArrayParams defines parameters for GetSimpleExplodeArray.
+type GetSimpleExplodeArrayParams struct {
+	Param []int32 `json:"param"`
+}
+
+// GetSimpleExplodeObjectParams defines parameters for GetSimpleExplodeObject.
+type GetSimpleExplodeObjectParams struct {
+	Param Object `json:"param"`
+}
+
+// GetSimpleNoExplodeArrayParams defines parameters for GetSimpleNoExplodeArray.
+type GetSimpleNoExplodeArrayParams struct {
+	Param []int32 `json:"param"`
+}
+
+// GetSimpleNoExplodeObjectParams defines parameters for GetSimpleNoExplodeObject.
+type GetSimpleNoExplodeObjectParams struct {
+	Param Object `json:"param"`
+}
+
+// GetSimplePrimitiveParams defines parameters for GetSimplePrimitive.
+type GetSimplePrimitiveParams struct {
+	Param int32 `json:"param"`
 }
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -34,6 +34,16 @@ type CustomStringType string
 // GenericObject defines model for GenericObject.
 type GenericObject map[string]interface{}
 
+// Issue30Params defines parameters for Issue30.
+type Issue30Params struct {
+	Fallthrough string `json:"fallthrough"`
+}
+
+// Issue41Params defines parameters for Issue41.
+type Issue41Params struct {
+	N1param N5StartsWithNumber `json:"1param"`
+}
+
 // Issue9JSONBody defines parameters for Issue9.
 type Issue9JSONBody interface{}
 

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -514,7 +514,7 @@ func GenerateBodyDefinitions(operationID string, bodyOrRef *openapi3.RequestBody
 func GenerateTypeDefsForOperation(op OperationDefinition) []TypeDefinition {
 	var typeDefs []TypeDefinition
 	// Start with the params object itself
-	if len(op.Params()) != 0 {
+	if len(op.AllParams()) != 0 {
 		typeDefs = append(typeDefs, GenerateParamsTypes(op)...)
 	}
 
@@ -535,6 +535,7 @@ func GenerateParamsTypes(op OperationDefinition) []TypeDefinition {
 	var typeDefs []TypeDefinition
 
 	objectParams := op.QueryParams
+	objectParams = append(objectParams, op.PathParams...)
 	objectParams = append(objectParams, op.HeaderParams...)
 	objectParams = append(objectParams, op.CookieParams...)
 

--- a/pkg/codegen/templates/chi-middleware.tmpl
+++ b/pkg/codegen/templates/chi-middleware.tmpl
@@ -40,8 +40,6 @@ func {{$opid}}Ctx(next http.Handler) http.Handler {
 
     {{if .RequiresParamObject}}
       var err error
-      // Parameter object where we will unmarshal all parameters from the context
-      var params {{.OperationId}}Params
 
       {{range $paramIdx, $param := .QueryParams}}// ------------- {{if .Required}}Required{{else}}Optional{{end}} query parameter "{{.ParamName}}" -------------
         if paramValue := r.URL.Query().Get("{{.ParamName}}"); paramValue != "" {

--- a/pkg/codegen/templates/chi-middleware.tmpl
+++ b/pkg/codegen/templates/chi-middleware.tmpl
@@ -1,7 +1,8 @@
 
 {{range .}}{{$opid := .OperationId}}
+{{ $totalParams := len .AllParams }}
 
-{{if .RequiresParamObject}}
+{{if gt $totalParams 0 }}
 // ParamsFor{{.OperationId}} operation parameters from context
 func ParamsFor{{.OperationId}}(ctx context.Context) *{{.OperationId}}Params {
   return ctx.Value("{{.OperationId}}Params").(*{{.OperationId}}Params)
@@ -13,7 +14,7 @@ func {{$opid}}Ctx(next http.Handler) http.Handler {
   return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
     ctx := r.Context()
 
-    {{ $paramLen := len .AllParams }} {{ if gt $paramLen 0 }}
+    {{if gt $totalParams 0 }}
     // Parameter object where we will unmarshal all parameters from the context
     var params {{.OperationId}}Params
     {{end}}
@@ -161,8 +162,10 @@ func {{$opid}}Ctx(next http.Handler) http.Handler {
         }
         {{- end}}
       {{end}}
+    {{end}}
 
-      ctx = context.WithValue(r.Context(), "{{.OperationId}}Params", &params)
+    {{if gt $totalParams 0 }}
+    ctx = context.WithValue(ctx, "{{.OperationId}}Params", &params)
     {{end}}
     next.ServeHTTP(w, r.WithContext(ctx))
   })

--- a/pkg/codegen/templates/chi-middleware.tmpl
+++ b/pkg/codegen/templates/chi-middleware.tmpl
@@ -13,6 +13,11 @@ func {{$opid}}Ctx(next http.Handler) http.Handler {
   return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
     ctx := r.Context()
 
+    {{ $paramLen := len .AllParams }} {{ if gt $paramLen 0 }}
+    // Parameter object where we will unmarshal all parameters from the context
+    var params {{.OperationId}}Params
+    {{end}}
+
     {{range .PathParams}}// ------------- Path parameter "{{.ParamName}}" -------------
     var pathErr error
     var {{$varName := .GoVariableName}}{{$varName}} {{.TypeDef}}
@@ -35,7 +40,7 @@ func {{$opid}}Ctx(next http.Handler) http.Handler {
     }
     {{end}}
 
-    ctx = context.WithValue(r.Context(), "{{$varName}}", {{$varName}})
+    params.{{.GoName}} = {{$varName}}
     {{end}}
 
     {{if .RequiresParamObject}}

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -106,6 +106,11 @@ func {{$opid}}Ctx(next http.Handler) http.Handler {
   return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
     ctx := r.Context()
 
+    {{ $paramLen := len .AllParams }} {{ if gt $paramLen 0 }}
+    // Parameter object where we will unmarshal all parameters from the context
+    var params {{.OperationId}}Params
+    {{end}}
+
     {{range .PathParams}}// ------------- Path parameter "{{.ParamName}}" -------------
     var pathErr error
     var {{$varName := .GoVariableName}}{{$varName}} {{.TypeDef}}
@@ -128,7 +133,7 @@ func {{$opid}}Ctx(next http.Handler) http.Handler {
     }
     {{end}}
 
-    ctx = context.WithValue(r.Context(), "{{$varName}}", {{$varName}})
+    params.{{.GoName}} = {{$varName}}
     {{end}}
 
     {{if .RequiresParamObject}}

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -133,8 +133,6 @@ func {{$opid}}Ctx(next http.Handler) http.Handler {
 
     {{if .RequiresParamObject}}
       var err error
-      // Parameter object where we will unmarshal all parameters from the context
-      var params {{.OperationId}}Params
 
       {{range $paramIdx, $param := .QueryParams}}// ------------- {{if .Required}}Required{{else}}Optional{{end}} query parameter "{{.ParamName}}" -------------
         if paramValue := r.URL.Query().Get("{{.ParamName}}"); paramValue != "" {


### PR DESCRIPTION
This change generates param types for all operations with request parameters. By doing this it makes for a cleaner calling interface for pulling out path parameters in chi-context based handler functions.

Here's a contrived example but should hopefully help illustrate.

Before
```go
var pets map[int]Pet

func UpdatePet(w http.ResponseWriter, r *http.Request) {
  id := r.Context().Value("id").(int)
  params := ParamsForUpdatePet(r.Context())

  pets[id].Name = params.Name
}
```

Now:

```go
var pets map[int]Pet

func UpdatePet(w http.ResponseWriter, r *http.Request) {
  params := ParamsForUpdatePet(r.Context())

  pets[params.Id].Name = params.Name
}
```