### PR TITLE
generate const if schema type is string and integer with enum

### DIFF
--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -111,6 +111,14 @@ func TestExampleOpenAPICodeGeneration(t *testing.T) {
 	assert.Contains(t, code, "func (c *Client) GetTestByName(ctx context.Context, name string) (*http.Response, error) {")
 	assert.Contains(t, code, "func (c *ClientWithResponses) GetTestByNameWithResponse(ctx context.Context, name string) (*getTestByNameResponse, error) {")
 
+	// Check if Enum contain
+	assert.Contains(t, code, "CatSleepRem CatSleep = \"rem\"")
+	assert.Contains(t, code, "CatSleepNonRem CatSleep = \"non_rem\"")
+	assert.Contains(t, code, "CatCode0 CatCode = 0")
+	assert.Contains(t, code, "CatCode1 CatCode = 1")
+	assert.Contains(t, code, "CatBlessNormal CatBless = 0")
+	assert.Contains(t, code, "CatBlessSnore CatBless = 1")
+
 	// Make sure the generated code is valid:
 	linter := new(lint.Linter)
 	problems, err := linter.Lint("test.gen.go", []byte(code))
@@ -240,4 +248,18 @@ components:
         cause:
           type: string
           enum: [car, dog, oldage]
+
+    CatSleep:
+      type: string
+      enum: [rem, non_rem]
+
+    CatCode:
+      type: integer
+      enum: [0, 1]
+
+    CatBless:
+      type: integer
+      enum: [0, 1]
+      x-enum-varnames: [normal, snore]
+
 `

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -648,6 +648,14 @@ type ServerInterface interface {
 	"typedef.tmpl": `{{range .Types}}
 // {{.TypeName}} defines model for {{.JsonName}}.
 type {{.TypeName}} {{.Schema.TypeDecl}}
+{{ if .Schema.EnumValues }}
+const (
+{{$typeName := .TypeName}}
+{{range .Schema.EnumValues}}
+  {{$typeName | camelCase}}{{.Name | camelCase}} {{$typeName | camelCase}} = {{.Value}}
+{{end}}
+)
+{{end}}
 {{end}}
 `,
 	"wrappers.tmpl": `// ServerInterfaceWrapper converts echo contexts to parameters.

--- a/pkg/codegen/templates/typedef.tmpl
+++ b/pkg/codegen/templates/typedef.tmpl
@@ -1,4 +1,12 @@
 {{range .Types}}
 // {{.TypeName}} defines model for {{.JsonName}}.
 type {{.TypeName}} {{.Schema.TypeDecl}}
+{{ if .Schema.EnumValues }}
+const (
+{{$typeName := .TypeName}}
+{{range .Schema.EnumValues}}
+  {{$typeName | camelCase}}{{.Name | camelCase}} {{$typeName | camelCase}} = {{.Value}}
+{{end}}
+)
+{{end}}
 {{end}}


### PR DESCRIPTION
Hi.

Thanks for your awesome package.
I want to generate const if I use enums in `#/components/schemas`
So, I modify schema.go to have `openapi3.ExtensionProps` in codegen.Schema,
and have EnumValues method for generate.

But I wonder my implamentation according codegen design policy.
Please Review this PR.

Thank you.

ref: https://github.com/deepmap/oapi-codegen/issues/54