### PR TITLE
Fix #69 - Add skip-fmt cli-param

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,9 @@ you can specify any combination of those.
 - `client`: generate the client boilerplate. It, too, requires the types to be
  present in its package.
 - `spec`: embed the OpenAPI spec into the generated code as a gzipped blob. This
- is useful for creating runtime validators.
- 
+- `skip-fmt`: skip running `go fmt` on the generated code. This is useful for debugging
+ the generated file in case the spec contains weird strings.
+
 So, for example, if you would like to produce only the server code, you could
 run `oapi-generate --generate types,server`. You could generate `types` and `server`
 into separate files, but both are required for the server code.  

--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -38,7 +38,7 @@ func main() {
 	)
 	flag.StringVar(&packageName, "package", "", "The package name for generated code")
 	flag.StringVar(&generate, "generate", "types,client,server,spec",
-		`Comma-separated list of code to generate; valid options: "types", client", "server", "spec"  (default types,client,server,"spec")`)
+		`Comma-separated list of code to generate; valid options: "types", client", "chi-server", "server", "skip-fmt", '"spec"  (default types,client,server,"spec")`)
 	flag.StringVar(&outputFile, "o", "", "Where to output generated code, stdout is default")
 	flag.Parse()
 
@@ -70,6 +70,8 @@ func main() {
 			opts.GenerateTypes = true
 		case "spec":
 			opts.EmbedSpec = true
+		case "skip-fmt":
+			opts.SkipFmt = true
 		default:
 			fmt.Printf("unknown generate option %s\n", g)
 			flag.PrintDefaults()

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -36,6 +36,7 @@ type Options struct {
 	GenerateClient     bool // GenerateClient specifies whether to generate client boilerplate
 	GenerateTypes      bool // GenerateTypes specifies whether to generate type definitions
 	EmbedSpec          bool // Whether to embed the swagger spec in the generated code
+	SkipFmt            bool // Whether to skip go fmt on the generated code
 }
 
 // Uses the Go templating engine to generate all of our server wrappers from
@@ -232,6 +233,9 @@ func Generate(swagger *openapi3.Swagger, packageName string, opts Options) (stri
 
 	// The generation code produces unindented horrors. Use the Go formatter
 	// to make it all pretty.
+	if opts.SkipFmt {
+		return goCode, nil
+	}
 	outBytes, err := format.Source([]byte(goCode))
 	if err != nil {
 		fmt.Println(goCode)


### PR DESCRIPTION
This adds a skip-fmt param to the cli options of the
generator.

Also the options during `--help` get the new `skip-fmt` param

Fixes:

- #69 