### PR TITLE
Fix #73: interface{} type as fallback for invalid type

### DIFF
--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -102,6 +102,19 @@ func TestExampleOpenAPICodeGeneration(t *testing.T) {
 	// Check that response structs are generated correctly:
 	assert.Contains(t, code, "type getTestByNameResponse struct {")
 
+	// Check that response structs contains fallbacks to interface for invalid types:
+	// Here an invalid array with no items.
+	assert.Contains(t, code, `
+type getTestByNameResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]Test
+	XML200       *[]Test
+	JSON422      *[]interface{}
+	XML422       *[]interface{}
+	JSONDefault  *Error
+}`)
+
 	// Check that the helper methods are generated correctly:
 	assert.Contains(t, code, "func (r getTestByNameResponse) Status() string {")
 	assert.Contains(t, code, "func (r getTestByNameResponse) StatusCode() int {")
@@ -157,6 +170,15 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Test'
+        422:
+          description: InvalidArray
+          content:
+            application/xml:
+              schema:
+                type: array
+            application/json:
+              schema:
+                type: array
         default:
           description: Error
           content:

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -82,11 +82,19 @@ func PropertiesEqual(a, b Property) bool {
 }
 
 func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
-	schema := sref.Value
-
 	// If Ref is set on the SchemaRef, it means that this type is actually a reference to
 	// another type. We're not de-referencing, so simply use the referenced type.
 	var refType string
+
+	// Add a fallback value in case the sref is nil.
+	// i.e. the parent schema defines a type:array, but the array has
+	// no items defined. Therefore we have at least valid Go-Code.
+	if sref == nil {
+		return Schema{GoType: "interface{}", RefType: refType}, nil
+	}
+
+	schema := sref.Value
+
 	if sref.Ref != "" {
 		var err error
 		// Convert the reference path to Go type


### PR DESCRIPTION
This adds a fallback behaviour in case a type cannot
be determined, where one should be expected.

This is for example the case if one defines a type `array`
but does not add any `items` definitions to it.

Fixes:

- #73