### PR TITLE
Fix #75 - Add support to print description for field

### DIFF
--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -38,8 +38,12 @@ type Pet struct {
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
-	Tags  *[]string `json:"tags,omitempty"`
-	Limit *int32    `json:"limit,omitempty"`
+
+	// tags to filter by
+	Tags *[]string `json:"tags,omitempty"`
+
+	// maximum number of results to return
+	Limit *int32 `json:"limit,omitempty"`
 }
 
 // addPetJSONBody defines parameters for AddPet.

--- a/examples/petstore-expanded/echo/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/echo/api/petstore-types.gen.go
@@ -25,8 +25,12 @@ type Pet struct {
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
-	Tags  *[]string `json:"tags,omitempty"`
-	Limit *int32    `json:"limit,omitempty"`
+
+	// tags to filter by
+	Tags *[]string `json:"tags,omitempty"`
+
+	// maximum number of results to return
+	Limit *int32 `json:"limit,omitempty"`
 }
 
 // addPetJSONBody defines parameters for AddPet.

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -37,8 +37,12 @@ type Pet struct {
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
-	Tags  *[]string `json:"tags,omitempty"`
-	Limit *int32    `json:"limit,omitempty"`
+
+	// tags to filter by
+	Tags *[]string `json:"tags,omitempty"`
+
+	// maximum number of results to return
+	Limit *int32 `json:"limit,omitempty"`
 }
 
 // addPetJSONBody defines parameters for AddPet.

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -91,7 +91,12 @@ type ParamsWithAddPropsParams_P1 struct {
 
 // ParamsWithAddPropsParams defines parameters for ParamsWithAddProps.
 type ParamsWithAddPropsParams struct {
+
+	// This parameter has additional properties
 	P1 ParamsWithAddPropsParams_P1 `json:"p1"`
+
+	// This parameter has an anonymous inner property which needs to be
+	// turned into a proper type for additionalProperties to work
 	P2 struct {
 		Inner ParamsWithAddPropsParams_P2_Inner `json:"inner"`
 	} `json:"p2"`

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -33,34 +33,76 @@ type Object struct {
 
 // GetCookieParams defines parameters for GetCookie.
 type GetCookieParams struct {
-	P  *int32         `json:"p,omitempty"`
-	Ep *int32         `json:"ep,omitempty"`
-	Ea *[]int32       `json:"ea,omitempty"`
-	A  *[]int32       `json:"a,omitempty"`
-	Eo *Object        `json:"eo,omitempty"`
-	O  *Object        `json:"o,omitempty"`
+
+	// primitive
+	P *int32 `json:"p,omitempty"`
+
+	// primitive
+	Ep *int32 `json:"ep,omitempty"`
+
+	// exploded array
+	Ea *[]int32 `json:"ea,omitempty"`
+
+	// array
+	A *[]int32 `json:"a,omitempty"`
+
+	// exploded object
+	Eo *Object `json:"eo,omitempty"`
+
+	// object
+	O *Object `json:"o,omitempty"`
+
+	// complex object
 	Co *ComplexObject `json:"co,omitempty"`
 }
 
 // GetHeaderParams defines parameters for GetHeader.
 type GetHeaderParams struct {
-	XPrimitive         *int32         `json:"X-Primitive,omitempty"`
-	XPrimitiveExploded *int32         `json:"X-Primitive-Exploded,omitempty"`
-	XArrayExploded     *[]int32       `json:"X-Array-Exploded,omitempty"`
-	XArray             *[]int32       `json:"X-Array,omitempty"`
-	XObjectExploded    *Object        `json:"X-Object-Exploded,omitempty"`
-	XObject            *Object        `json:"X-Object,omitempty"`
-	XComplexObject     *ComplexObject `json:"X-Complex-Object,omitempty"`
+
+	// primitive
+	XPrimitive *int32 `json:"X-Primitive,omitempty"`
+
+	// primitive
+	XPrimitiveExploded *int32 `json:"X-Primitive-Exploded,omitempty"`
+
+	// exploded array
+	XArrayExploded *[]int32 `json:"X-Array-Exploded,omitempty"`
+
+	// array
+	XArray *[]int32 `json:"X-Array,omitempty"`
+
+	// exploded object
+	XObjectExploded *Object `json:"X-Object-Exploded,omitempty"`
+
+	// object
+	XObject *Object `json:"X-Object,omitempty"`
+
+	// complex object
+	XComplexObject *ComplexObject `json:"X-Complex-Object,omitempty"`
 }
 
 // GetQueryFormParams defines parameters for GetQueryForm.
 type GetQueryFormParams struct {
-	Ea *[]int32       `json:"ea,omitempty"`
-	A  *[]int32       `json:"a,omitempty"`
-	Eo *Object        `json:"eo,omitempty"`
-	O  *Object        `json:"o,omitempty"`
-	Ep *int32         `json:"ep,omitempty"`
-	P  *int32         `json:"p,omitempty"`
+
+	// exploded array
+	Ea *[]int32 `json:"ea,omitempty"`
+
+	// array
+	A *[]int32 `json:"a,omitempty"`
+
+	// exploded object
+	Eo *Object `json:"eo,omitempty"`
+
+	// object
+	O *Object `json:"o,omitempty"`
+
+	// exploded primitive
+	Ep *int32 `json:"ep,omitempty"`
+
+	// primitive
+	P *int32 `json:"p,omitempty"`
+
+	// complex object
 	Co *ComplexObject `json:"co,omitempty"`
 }
 

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -577,6 +577,7 @@ func GenerateParamsTypes(op OperationDefinition) []TypeDefinition {
 			})
 		}
 		prop := Property{
+			Description:   param.Spec.Description,
 			JsonFieldName: param.ParamName,
 			Required:      param.Required,
 			Schema:        pSchema,

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -53,6 +53,7 @@ func (s Schema) GetAdditionalTypeDefs() []TypeDefinition {
 }
 
 type Property struct {
+	Description   string
 	JsonFieldName string
 	Schema        Schema
 	Required      bool
@@ -273,7 +274,14 @@ type FieldDescriptor struct {
 func GenFieldsFromProperties(props []Property) []string {
 	var fields []string
 	for _, p := range props {
-		field := fmt.Sprintf("    %s %s", p.GoFieldName(), p.GoTypeDef())
+		field := ""
+		// Add a comment to a field in case we have one, otherwise skip.
+		if p.Description != "" {
+			// Separate the comment from a previous-defined, unrelated field.
+			// Make sure the actual field is separated by a newline.
+			field += fmt.Sprintf("\n%s\n", StringToGoComment(p.Description))
+		}
+		field += fmt.Sprintf("    %s %s", p.GoFieldName(), p.GoTypeDef())
 		if p.Required {
 			field += fmt.Sprintf(" `json:\"%s\"`", p.JsonFieldName)
 		} else {

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -344,3 +344,23 @@ func PathToTypeName(path []string) string {
 	}
 	return strings.Join(path, "_")
 }
+
+// StringToGoComment renders a possible multi-line string as a valid Go-Comment.
+// Each line is prefixed as a comment.
+func StringToGoComment(in string) string {
+	// Normalize newlines from Windows/Mac to Linux
+	in = strings.Replace(in, "\r\n", "\n", -1)
+	in = strings.Replace(in, "\r", "\n", -1)
+
+	// Add comment to each line
+	var lines []string
+	for _, line := range strings.Split(in, "\n") {
+		lines = append(lines, fmt.Sprintf("// %s", line))
+	}
+	in = strings.Join(lines, "\n")
+
+	// in case we have a multiline string which ends with \n, we would generate
+	// empty-line-comments, like `// `. Therefore remove this line comment.
+	in = strings.TrimSuffix(in, "\n// ")
+	return in
+}

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -181,3 +181,55 @@ func TestReplacePathParamsWithStr(t *testing.T) {
 	result := ReplacePathParamsWithStr("/path/{param1}/{.param2}/{;param3*}/foo")
 	assert.EqualValues(t, "/path/%s/%s/%s/foo", result)
 }
+
+func TestStringToGoComment(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+		message  string
+	}{
+		{
+			input:    "",
+			expected: "// ",
+			message:  "blank string should be preserved with comment",
+		},
+		{
+			input:    " ",
+			expected: "//  ",
+			message:  "whitespace should be preserved with comment",
+		},
+		{
+			input:    "Single Line",
+			expected: "// Single Line",
+			message:  "single line comment",
+		},
+		{
+			input:    "    Single Line",
+			expected: "//     Single Line",
+			message:  "single line comment preserving whitespace",
+		},
+		{
+			input: `Multi
+Line
+  With
+    Spaces
+	And
+		Tabs
+`,
+			expected: `// Multi
+// Line
+//   With
+//     Spaces
+// 	And
+// 		Tabs`,
+			message: "multi line preserving whitespaces using tabs or spaces",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.message, func(t *testing.T) {
+			result := StringToGoComment(testCase.input)
+			assert.EqualValues(t, testCase.expected, result, testCase.message)
+		})
+	}
+
+}


### PR DESCRIPTION
This feature allows printing description of a field
of a type prior when printing the field itself.

e.g.:

Old Version:

```go
// GetAlertemailSettingParams defines parameters for GetAlertemailSetting.
type GetAlertemailSettingParams struct {
	Format *[]string `json:"format,omitempty"`
	Filter *[]string `json:"filter,omitempty"`
}
```

New Version/This feature

```go
// GetAlertemailSettingParams defines parameters for GetAlertemailSetting.
type GetAlertemailSettingParams struct {

	// List of property names to include in results, separated by | (i.e. policyid|srcintf).
	Format *[]string `json:"format,omitempty"`

	// Filtering multiple key/value pairs
	// Operator     |   Description
	// ==     |   Case insensitive match with pattern.
	// !=     |    Does not match with pattern (case insensitive).
	// =@     |    Pattern found in object value (case insensitive).
	// !@     |    Pattern not found in object value (case insensitive).
	// <=     |    Value must be less than or equal to pattern.
	// <     |    Value must be less than pattern.
	// .>=    |    Value must be greater than or equal to pattern.
	// .>     |    Value must be greater than pattern.
	// Logical OR    |    Separate filters using commas ','
	// Logical AND    |    Filter strings can be combined to create logical AND queries by including multiple filters in the request.
	// Combining AND and OR    |    You can combine AND and OR filters together to create more complex filters.
	Filter *[]string `json:"filter,omitempty"`
}
```