### PR TITLE
Feature/81 client security scheme runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,68 @@ There are some caveats to using this code.
  for anything other than trivial objects, they can marshal to arbitrary JSON
  structures. When you send them as cookie (`in: cookie`) arguments, we will
  URL encode them, since JSON delimiters aren't allowed in cookies.
- 
+
+## Using SecurityProviders
+
+If you generate client-code, you can use some default-provided security providers
+which help you to use the various OpenAPI 3 Authentication mechanism.
+
+
+```
+    import (
+        "github.com/deepmap/oapi-codegen/pkg/securityprovider"
+    )
+
+    func CreateSampleProviders() error {
+        // Example BasicAuth
+        // See: https://swagger.io/docs/specification/authentication/basic-authentication/
+        basicAuthProvider, basicAuthProviderErr := securityprovider.NewSecurityProviderBasicAuth("MY_USER", "MY_PASS")
+        if basicAuthProviderErr != nil {
+            panic(basicAuthProviderErr)
+        }
+
+        // Example BearerToken
+        // See: https://swagger.io/docs/specification/authentication/bearer-authentication/
+        bearerTokenProvider, bearerTokenProviderErr := securityprovider.NewSecurityProviderBearerToken("MY_TOKEN")
+        if bearerTokenProviderErr != nil {
+            panic(bearerTokenProviderErr)
+        }
+
+        // Example ApiKey provider
+        // See: https://swagger.io/docs/specification/authentication/api-keys/
+        apiKeyProvider, apiKeyProviderErr := securityprovider.NewSecurityProviderApiKey("query", "myApiKeyParam", "MY_API_KEY")
+        if apiKeyProviderErr != nil {
+            panic(apiKeyProviderErr)
+        }
+
+        // Example providing your own provider using an anonymous function wrapping in the
+        // InterceptoFn adapter. The behaviour between the InterceptorFn and the Interceptor interface
+        // are the same as http.HandlerFunc and http.Handler.
+        customProvider := func(req *http.Request, ctx context.Context) error {
+            // Just log the request header, nothing else.
+            log.Println(req.Header)
+            return nil
+        }
+
+        // Exhaustive list of some defaults you can use to initialize a Client.
+        // If you need to override the underlying httpClient, you can use the option
+        //
+        // WithHTTPClient(httpClient *http.Client)
+        //
+        client, clientErr := NewClient(context.Background(), []ClientOption{
+            WithBaseURL("https://api.deepmap.com"),
+            WithUserAgent("MY_USER_AGENT"),
+            WithMaxIdleConnections(10),
+            WithIdleTimeout(10 * time.Second),
+            WithRequestTimeout(1 * time.Second),
+            WithRequestEditorFn(apiKeyProvider.Edit),
+        }...,
+        )
+
+        return nil
+    }
+```
+
 ## Using `oapi-codegen`
 
 The default options for `oapi-codegen` will generate everything; client, server,

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -12,7 +12,9 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
 )
 
 // Error defines model for Error.
@@ -61,12 +63,27 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client http.Client
+	Client *http.Client
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
 	RequestEditor RequestEditorFn
+
+	// userAgent to use
+	userAgent string
+
+	// timeout of single request
+	requestTimeout time.Duration
+
+	// timeout of idle http connections
+	idleTimeout time.Duration
+
+	// maxium idle connections of the underlying http-client.
+	maxIdleConns int
 }
+
+// ClientOption allows setting custom parameters during construction
+type ClientOption func(*Client) error
 
 // The interface specification for the client above.
 type ClientInterface interface {
@@ -275,11 +292,116 @@ type ClientWithResponses struct {
 	ClientInterface
 }
 
+// NewClient creates a new Client.
+func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses, error) {
+	// create a client with sane default values
+	client := Client{
+		// must have a slash in order to resolve relative paths correctly.
+		Server:         "",
+		userAgent:      "oapi-codegen",
+		maxIdleConns:   10,
+		requestTimeout: 5 * time.Second,
+		idleTimeout:    30 * time.Second,
+	}
+	// mutate defaultClient and add all optional params
+	for _, o := range opts {
+		if err := o(&client); err != nil {
+			return nil, err
+		}
+	}
+
+	// create httpClient, if not already present
+	if client.Client == nil {
+		client.Client = client.newHTTPClient()
+	}
+
+	return &ClientWithResponses{
+		ClientInterface: &client,
+	}, nil
+}
+
+// WithBaseURL overrides the baseURL.
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) error {
+		if !strings.HasSuffix(baseURL, "/") {
+			baseURL += "/"
+		}
+		newBaseURL, err := url.Parse(baseURL)
+		if err != nil {
+			return err
+		}
+		c.Server = newBaseURL.String()
+		return nil
+	}
+}
+
+// WithUserAgent allows setting the userAgent
+func WithUserAgent(userAgent string) ClientOption {
+	return func(c *Client) error {
+		c.userAgent = userAgent
+		return nil
+	}
+}
+
+// WithIdleTimeout overrides the timeout of idle connections.
+func WithIdleTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.idleTimeout = timeout
+		return nil
+	}
+}
+
+// WithRequestTimeout overrides the timeout of individual requests.
+func WithRequestTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.requestTimeout = timeout
+		return nil
+	}
+}
+
+// WithMaxIdleConnections overrides the amount of idle connections of the
+// underlying http-client.
+func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
+	return func(c *Client) error {
+		c.maxIdleConns = int(maxIdleConns)
+		return nil
+	}
+}
+
+// WithHTTPClient allows overriding the default httpClient, which is
+// automatically created. This is useful for tests.
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(c *Client) error {
+		c.Client = httpClient
+		return nil
+	}
+}
+
+// WithRequestEditorFn allows setting up a callback function, which will be
+// called right before sending the request. This can be used to mutate the request.
+func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
+	return func(c *Client) error {
+		c.RequestEditor = fn
+		return nil
+	}
+}
+
+// newHTTPClient creates a httpClient for the current connection options.
+func (c *Client) newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: c.requestTimeout,
+		Transport: &http.Transport{
+			MaxIdleConns:    c.maxIdleConns,
+			IdleConnTimeout: c.idleTimeout,
+		},
+	}
+}
+
 // NewClientWithResponses returns a ClientWithResponses with a default Client:
 func NewClientWithResponses(server string) *ClientWithResponses {
 	return &ClientWithResponses{
 		ClientInterface: &Client{
-			Client: http.Client{},
+			Client: &http.Client{},
 			Server: server,
 		},
 	}
@@ -289,7 +411,7 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
 	return &ClientWithResponses{
 		ClientInterface: &Client{
-			Client:        http.Client{},
+			Client:        &http.Client{},
 			Server:        server,
 			RequestEditor: reqEditorFn,
 		},

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -16,7 +16,9 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
 )
 
 // SchemaObject defines model for SchemaObject.
@@ -47,12 +49,27 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client http.Client
+	Client *http.Client
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
 	RequestEditor RequestEditorFn
+
+	// userAgent to use
+	userAgent string
+
+	// timeout of single request
+	requestTimeout time.Duration
+
+	// timeout of idle http connections
+	idleTimeout time.Duration
+
+	// maxium idle connections of the underlying http-client.
+	maxIdleConns int
 }
+
+// ClientOption allows setting custom parameters during construction
+type ClientOption func(*Client) error
 
 // The interface specification for the client above.
 type ClientInterface interface {
@@ -313,11 +330,116 @@ type ClientWithResponses struct {
 	ClientInterface
 }
 
+// NewClient creates a new Client.
+func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses, error) {
+	// create a client with sane default values
+	client := Client{
+		// must have a slash in order to resolve relative paths correctly.
+		Server:         "",
+		userAgent:      "oapi-codegen",
+		maxIdleConns:   10,
+		requestTimeout: 5 * time.Second,
+		idleTimeout:    30 * time.Second,
+	}
+	// mutate defaultClient and add all optional params
+	for _, o := range opts {
+		if err := o(&client); err != nil {
+			return nil, err
+		}
+	}
+
+	// create httpClient, if not already present
+	if client.Client == nil {
+		client.Client = client.newHTTPClient()
+	}
+
+	return &ClientWithResponses{
+		ClientInterface: &client,
+	}, nil
+}
+
+// WithBaseURL overrides the baseURL.
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) error {
+		if !strings.HasSuffix(baseURL, "/") {
+			baseURL += "/"
+		}
+		newBaseURL, err := url.Parse(baseURL)
+		if err != nil {
+			return err
+		}
+		c.Server = newBaseURL.String()
+		return nil
+	}
+}
+
+// WithUserAgent allows setting the userAgent
+func WithUserAgent(userAgent string) ClientOption {
+	return func(c *Client) error {
+		c.userAgent = userAgent
+		return nil
+	}
+}
+
+// WithIdleTimeout overrides the timeout of idle connections.
+func WithIdleTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.idleTimeout = timeout
+		return nil
+	}
+}
+
+// WithRequestTimeout overrides the timeout of individual requests.
+func WithRequestTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.requestTimeout = timeout
+		return nil
+	}
+}
+
+// WithMaxIdleConnections overrides the amount of idle connections of the
+// underlying http-client.
+func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
+	return func(c *Client) error {
+		c.maxIdleConns = int(maxIdleConns)
+		return nil
+	}
+}
+
+// WithHTTPClient allows overriding the default httpClient, which is
+// automatically created. This is useful for tests.
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(c *Client) error {
+		c.Client = httpClient
+		return nil
+	}
+}
+
+// WithRequestEditorFn allows setting up a callback function, which will be
+// called right before sending the request. This can be used to mutate the request.
+func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
+	return func(c *Client) error {
+		c.RequestEditor = fn
+		return nil
+	}
+}
+
+// newHTTPClient creates a httpClient for the current connection options.
+func (c *Client) newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: c.requestTimeout,
+		Transport: &http.Transport{
+			MaxIdleConns:    c.maxIdleConns,
+			IdleConnTimeout: c.idleTimeout,
+		},
+	}
+}
+
 // NewClientWithResponses returns a ClientWithResponses with a default Client:
 func NewClientWithResponses(server string) *ClientWithResponses {
 	return &ClientWithResponses{
 		ClientInterface: &Client{
-			Client: http.Client{},
+			Client: &http.Client{},
 			Server: server,
 		},
 	}
@@ -327,7 +449,7 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
 	return &ClientWithResponses{
 		ClientInterface: &Client{
-			Client:        http.Client{},
+			Client:        &http.Client{},
 			Server:        server,
 			RequestEditor: reqEditorFn,
 		},

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -17,7 +17,9 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
 )
 
 // AdditionalPropertiesObject1 defines model for AdditionalPropertiesObject1.
@@ -728,12 +730,27 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client http.Client
+	Client *http.Client
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
 	RequestEditor RequestEditorFn
+
+	// userAgent to use
+	userAgent string
+
+	// timeout of single request
+	requestTimeout time.Duration
+
+	// timeout of idle http connections
+	idleTimeout time.Duration
+
+	// maxium idle connections of the underlying http-client.
+	maxIdleConns int
 }
+
+// ClientOption allows setting custom parameters during construction
+type ClientOption func(*Client) error
 
 // The interface specification for the client above.
 type ClientInterface interface {
@@ -860,11 +877,116 @@ type ClientWithResponses struct {
 	ClientInterface
 }
 
+// NewClient creates a new Client.
+func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses, error) {
+	// create a client with sane default values
+	client := Client{
+		// must have a slash in order to resolve relative paths correctly.
+		Server:         "",
+		userAgent:      "oapi-codegen",
+		maxIdleConns:   10,
+		requestTimeout: 5 * time.Second,
+		idleTimeout:    30 * time.Second,
+	}
+	// mutate defaultClient and add all optional params
+	for _, o := range opts {
+		if err := o(&client); err != nil {
+			return nil, err
+		}
+	}
+
+	// create httpClient, if not already present
+	if client.Client == nil {
+		client.Client = client.newHTTPClient()
+	}
+
+	return &ClientWithResponses{
+		ClientInterface: &client,
+	}, nil
+}
+
+// WithBaseURL overrides the baseURL.
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) error {
+		if !strings.HasSuffix(baseURL, "/") {
+			baseURL += "/"
+		}
+		newBaseURL, err := url.Parse(baseURL)
+		if err != nil {
+			return err
+		}
+		c.Server = newBaseURL.String()
+		return nil
+	}
+}
+
+// WithUserAgent allows setting the userAgent
+func WithUserAgent(userAgent string) ClientOption {
+	return func(c *Client) error {
+		c.userAgent = userAgent
+		return nil
+	}
+}
+
+// WithIdleTimeout overrides the timeout of idle connections.
+func WithIdleTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.idleTimeout = timeout
+		return nil
+	}
+}
+
+// WithRequestTimeout overrides the timeout of individual requests.
+func WithRequestTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.requestTimeout = timeout
+		return nil
+	}
+}
+
+// WithMaxIdleConnections overrides the amount of idle connections of the
+// underlying http-client.
+func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
+	return func(c *Client) error {
+		c.maxIdleConns = int(maxIdleConns)
+		return nil
+	}
+}
+
+// WithHTTPClient allows overriding the default httpClient, which is
+// automatically created. This is useful for tests.
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(c *Client) error {
+		c.Client = httpClient
+		return nil
+	}
+}
+
+// WithRequestEditorFn allows setting up a callback function, which will be
+// called right before sending the request. This can be used to mutate the request.
+func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
+	return func(c *Client) error {
+		c.RequestEditor = fn
+		return nil
+	}
+}
+
+// newHTTPClient creates a httpClient for the current connection options.
+func (c *Client) newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: c.requestTimeout,
+		Transport: &http.Transport{
+			MaxIdleConns:    c.maxIdleConns,
+			IdleConnTimeout: c.idleTimeout,
+		},
+	}
+}
+
 // NewClientWithResponses returns a ClientWithResponses with a default Client:
 func NewClientWithResponses(server string) *ClientWithResponses {
 	return &ClientWithResponses{
 		ClientInterface: &Client{
-			Client: http.Client{},
+			Client: &http.Client{},
 			Server: server,
 		},
 	}
@@ -874,7 +996,7 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
 	return &ClientWithResponses{
 		ClientInterface: &Client{
-			Client:        http.Client{},
+			Client:        &http.Client{},
 			Server:        server,
 			RequestEditor: reqEditorFn,
 		},

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -16,7 +16,9 @@ import (
 	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
 )
 
 // ArrayValue defines model for ArrayValue.
@@ -101,12 +103,27 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client http.Client
+	Client *http.Client
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
 	RequestEditor RequestEditorFn
+
+	// userAgent to use
+	userAgent string
+
+	// timeout of single request
+	requestTimeout time.Duration
+
+	// timeout of idle http connections
+	idleTimeout time.Duration
+
+	// maxium idle connections of the underlying http-client.
+	maxIdleConns int
 }
+
+// ClientOption allows setting custom parameters during construction
+type ClientOption func(*Client) error
 
 // The interface specification for the client above.
 type ClientInterface interface {
@@ -148,11 +165,116 @@ type ClientWithResponses struct {
 	ClientInterface
 }
 
+// NewClient creates a new Client.
+func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses, error) {
+	// create a client with sane default values
+	client := Client{
+		// must have a slash in order to resolve relative paths correctly.
+		Server:         "",
+		userAgent:      "oapi-codegen",
+		maxIdleConns:   10,
+		requestTimeout: 5 * time.Second,
+		idleTimeout:    30 * time.Second,
+	}
+	// mutate defaultClient and add all optional params
+	for _, o := range opts {
+		if err := o(&client); err != nil {
+			return nil, err
+		}
+	}
+
+	// create httpClient, if not already present
+	if client.Client == nil {
+		client.Client = client.newHTTPClient()
+	}
+
+	return &ClientWithResponses{
+		ClientInterface: &client,
+	}, nil
+}
+
+// WithBaseURL overrides the baseURL.
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) error {
+		if !strings.HasSuffix(baseURL, "/") {
+			baseURL += "/"
+		}
+		newBaseURL, err := url.Parse(baseURL)
+		if err != nil {
+			return err
+		}
+		c.Server = newBaseURL.String()
+		return nil
+	}
+}
+
+// WithUserAgent allows setting the userAgent
+func WithUserAgent(userAgent string) ClientOption {
+	return func(c *Client) error {
+		c.userAgent = userAgent
+		return nil
+	}
+}
+
+// WithIdleTimeout overrides the timeout of idle connections.
+func WithIdleTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.idleTimeout = timeout
+		return nil
+	}
+}
+
+// WithRequestTimeout overrides the timeout of individual requests.
+func WithRequestTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.requestTimeout = timeout
+		return nil
+	}
+}
+
+// WithMaxIdleConnections overrides the amount of idle connections of the
+// underlying http-client.
+func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
+	return func(c *Client) error {
+		c.maxIdleConns = int(maxIdleConns)
+		return nil
+	}
+}
+
+// WithHTTPClient allows overriding the default httpClient, which is
+// automatically created. This is useful for tests.
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(c *Client) error {
+		c.Client = httpClient
+		return nil
+	}
+}
+
+// WithRequestEditorFn allows setting up a callback function, which will be
+// called right before sending the request. This can be used to mutate the request.
+func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
+	return func(c *Client) error {
+		c.RequestEditor = fn
+		return nil
+	}
+}
+
+// newHTTPClient creates a httpClient for the current connection options.
+func (c *Client) newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: c.requestTimeout,
+		Transport: &http.Transport{
+			MaxIdleConns:    c.maxIdleConns,
+			IdleConnTimeout: c.idleTimeout,
+		},
+	}
+}
+
 // NewClientWithResponses returns a ClientWithResponses with a default Client:
 func NewClientWithResponses(server string) *ClientWithResponses {
 	return &ClientWithResponses{
 		ClientInterface: &Client{
-			Client: http.Client{},
+			Client: &http.Client{},
 			Server: server,
 		},
 	}
@@ -162,7 +284,7 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
 	return &ClientWithResponses{
 		ClientInterface: &Client{
-			Client:        http.Client{},
+			Client:        &http.Client{},
 			Server:        server,
 			RequestEditor: reqEditorFn,
 		},

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 // ComplexObject defines model for ComplexObject.
@@ -116,12 +117,27 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client http.Client
+	Client *http.Client
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
 	RequestEditor RequestEditorFn
+
+	// userAgent to use
+	userAgent string
+
+	// timeout of single request
+	requestTimeout time.Duration
+
+	// timeout of idle http connections
+	idleTimeout time.Duration
+
+	// maxium idle connections of the underlying http-client.
+	maxIdleConns int
 }
+
+// ClientOption allows setting custom parameters during construction
+type ClientOption func(*Client) error
 
 // The interface specification for the client above.
 type ClientInterface interface {
@@ -1082,11 +1098,116 @@ type ClientWithResponses struct {
 	ClientInterface
 }
 
+// NewClient creates a new Client.
+func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses, error) {
+	// create a client with sane default values
+	client := Client{
+		// must have a slash in order to resolve relative paths correctly.
+		Server:         "",
+		userAgent:      "oapi-codegen",
+		maxIdleConns:   10,
+		requestTimeout: 5 * time.Second,
+		idleTimeout:    30 * time.Second,
+	}
+	// mutate defaultClient and add all optional params
+	for _, o := range opts {
+		if err := o(&client); err != nil {
+			return nil, err
+		}
+	}
+
+	// create httpClient, if not already present
+	if client.Client == nil {
+		client.Client = client.newHTTPClient()
+	}
+
+	return &ClientWithResponses{
+		ClientInterface: &client,
+	}, nil
+}
+
+// WithBaseURL overrides the baseURL.
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) error {
+		if !strings.HasSuffix(baseURL, "/") {
+			baseURL += "/"
+		}
+		newBaseURL, err := url.Parse(baseURL)
+		if err != nil {
+			return err
+		}
+		c.Server = newBaseURL.String()
+		return nil
+	}
+}
+
+// WithUserAgent allows setting the userAgent
+func WithUserAgent(userAgent string) ClientOption {
+	return func(c *Client) error {
+		c.userAgent = userAgent
+		return nil
+	}
+}
+
+// WithIdleTimeout overrides the timeout of idle connections.
+func WithIdleTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.idleTimeout = timeout
+		return nil
+	}
+}
+
+// WithRequestTimeout overrides the timeout of individual requests.
+func WithRequestTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.requestTimeout = timeout
+		return nil
+	}
+}
+
+// WithMaxIdleConnections overrides the amount of idle connections of the
+// underlying http-client.
+func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
+	return func(c *Client) error {
+		c.maxIdleConns = int(maxIdleConns)
+		return nil
+	}
+}
+
+// WithHTTPClient allows overriding the default httpClient, which is
+// automatically created. This is useful for tests.
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(c *Client) error {
+		c.Client = httpClient
+		return nil
+	}
+}
+
+// WithRequestEditorFn allows setting up a callback function, which will be
+// called right before sending the request. This can be used to mutate the request.
+func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
+	return func(c *Client) error {
+		c.RequestEditor = fn
+		return nil
+	}
+}
+
+// newHTTPClient creates a httpClient for the current connection options.
+func (c *Client) newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: c.requestTimeout,
+		Transport: &http.Transport{
+			MaxIdleConns:    c.maxIdleConns,
+			IdleConnTimeout: c.idleTimeout,
+		},
+	}
+}
+
 // NewClientWithResponses returns a ClientWithResponses with a default Client:
 func NewClientWithResponses(server string) *ClientWithResponses {
 	return &ClientWithResponses{
 		ClientInterface: &Client{
-			Client: http.Client{},
+			Client: &http.Client{},
 			Server: server,
 		},
 	}
@@ -1096,7 +1217,7 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
 	return &ClientWithResponses{
 		ClientInterface: &Client{
-			Client:        http.Client{},
+			Client:        &http.Client{},
 			Server:        server,
 			RequestEditor: reqEditorFn,
 		},

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -16,7 +16,9 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
 )
 
 // N5StartsWithNumber defines model for 5StartsWithNumber.
@@ -55,12 +57,27 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client http.Client
+	Client *http.Client
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
 	RequestEditor RequestEditorFn
+
+	// userAgent to use
+	userAgent string
+
+	// timeout of single request
+	requestTimeout time.Duration
+
+	// timeout of idle http connections
+	idleTimeout time.Duration
+
+	// maxium idle connections of the underlying http-client.
+	maxIdleConns int
 }
+
+// ClientOption allows setting custom parameters during construction
+type ClientOption func(*Client) error
 
 // The interface specification for the client above.
 type ClientInterface interface {
@@ -224,11 +241,116 @@ type ClientWithResponses struct {
 	ClientInterface
 }
 
+// NewClient creates a new Client.
+func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses, error) {
+	// create a client with sane default values
+	client := Client{
+		// must have a slash in order to resolve relative paths correctly.
+		Server:         "",
+		userAgent:      "oapi-codegen",
+		maxIdleConns:   10,
+		requestTimeout: 5 * time.Second,
+		idleTimeout:    30 * time.Second,
+	}
+	// mutate defaultClient and add all optional params
+	for _, o := range opts {
+		if err := o(&client); err != nil {
+			return nil, err
+		}
+	}
+
+	// create httpClient, if not already present
+	if client.Client == nil {
+		client.Client = client.newHTTPClient()
+	}
+
+	return &ClientWithResponses{
+		ClientInterface: &client,
+	}, nil
+}
+
+// WithBaseURL overrides the baseURL.
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) error {
+		if !strings.HasSuffix(baseURL, "/") {
+			baseURL += "/"
+		}
+		newBaseURL, err := url.Parse(baseURL)
+		if err != nil {
+			return err
+		}
+		c.Server = newBaseURL.String()
+		return nil
+	}
+}
+
+// WithUserAgent allows setting the userAgent
+func WithUserAgent(userAgent string) ClientOption {
+	return func(c *Client) error {
+		c.userAgent = userAgent
+		return nil
+	}
+}
+
+// WithIdleTimeout overrides the timeout of idle connections.
+func WithIdleTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.idleTimeout = timeout
+		return nil
+	}
+}
+
+// WithRequestTimeout overrides the timeout of individual requests.
+func WithRequestTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.requestTimeout = timeout
+		return nil
+	}
+}
+
+// WithMaxIdleConnections overrides the amount of idle connections of the
+// underlying http-client.
+func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
+	return func(c *Client) error {
+		c.maxIdleConns = int(maxIdleConns)
+		return nil
+	}
+}
+
+// WithHTTPClient allows overriding the default httpClient, which is
+// automatically created. This is useful for tests.
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(c *Client) error {
+		c.Client = httpClient
+		return nil
+	}
+}
+
+// WithRequestEditorFn allows setting up a callback function, which will be
+// called right before sending the request. This can be used to mutate the request.
+func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
+	return func(c *Client) error {
+		c.RequestEditor = fn
+		return nil
+	}
+}
+
+// newHTTPClient creates a httpClient for the current connection options.
+func (c *Client) newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: c.requestTimeout,
+		Transport: &http.Transport{
+			MaxIdleConns:    c.maxIdleConns,
+			IdleConnTimeout: c.idleTimeout,
+		},
+	}
+}
+
 // NewClientWithResponses returns a ClientWithResponses with a default Client:
 func NewClientWithResponses(server string) *ClientWithResponses {
 	return &ClientWithResponses{
 		ClientInterface: &Client{
-			Client: http.Client{},
+			Client: &http.Client{},
 			Server: server,
 		},
 	}
@@ -238,7 +360,7 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
 	return &ClientWithResponses{
 		ClientInterface: &Client{
-			Client:        http.Client{},
+			Client:        &http.Client{},
 			Server:        server,
 			RequestEditor: reqEditorFn,
 		},

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -114,6 +114,9 @@ func Generate(swagger *openapi3.Swagger, packageName string, opts Options) (stri
 	// Based on module prefixes, figure out which optional imports are required.
 	// TODO: this is error prone, use tighter matches
 	for _, str := range []string{typeDefinitions, chiServerOut, echoServerOut, clientOut, clientWithResponsesOut, inlinedSpec} {
+		if strings.Contains(str, "time.Duration") {
+			imports = append(imports, "time")
+		}
 		if strings.Contains(str, "time.Time") {
 			imports = append(imports, "time")
 		}

--- a/pkg/codegen/templates/client-with-responses.tmpl
+++ b/pkg/codegen/templates/client-with-responses.tmpl
@@ -3,11 +3,116 @@ type ClientWithResponses struct {
     ClientInterface
 }
 
+// NewClient creates a new Client.
+func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses, error) {
+	// create a client with sane default values
+	client := Client{
+		// must have a slash in order to resolve relative paths correctly.
+		Server:         "",
+		userAgent:      "oapi-codegen",
+		maxIdleConns:   10,
+		requestTimeout: 5 * time.Second,
+		idleTimeout:    30 * time.Second,
+	}
+	// mutate defaultClient and add all optional params
+	for _, o := range opts {
+		if err := o(&client); err != nil {
+			return nil, err
+		}
+	}
+
+	// create httpClient, if not already present
+	if client.Client == nil {
+		client.Client = client.newHTTPClient()
+	}
+
+	return &ClientWithResponses{
+		ClientInterface: &client,
+	}, nil
+}
+
+// WithBaseURL overrides the baseURL.
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) error {
+		if !strings.HasSuffix(baseURL, "/") {
+			baseURL += "/"
+		}
+		newBaseURL, err := url.Parse(baseURL)
+		if err != nil {
+			return err
+		}
+		c.Server = newBaseURL.String()
+		return nil
+	}
+}
+
+// WithUserAgent allows setting the userAgent
+func WithUserAgent(userAgent string) ClientOption {
+	return func(c *Client) error {
+		c.userAgent = userAgent
+		return nil
+	}
+}
+
+// WithIdleTimeout overrides the timeout of idle connections.
+func WithIdleTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.idleTimeout = timeout
+		return nil
+	}
+}
+
+// WithRequestTimeout overrides the timeout of individual requests.
+func WithRequestTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.requestTimeout = timeout
+		return nil
+	}
+}
+
+// WithMaxIdleConnections overrides the amount of idle connections of the
+// underlying http-client.
+func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
+	return func(c *Client) error {
+		c.maxIdleConns = int(maxIdleConns)
+		return nil
+	}
+}
+
+// WithHTTPClient allows overriding the default httpClient, which is
+// automatically created. This is useful for tests.
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(c *Client) error {
+		c.Client = httpClient
+		return nil
+	}
+}
+
+// WithRequestEditorFn allows setting up a callback function, which will be
+// called right before sending the request. This can be used to mutate the request.
+func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
+	return func(c *Client) error {
+		c.RequestEditor = fn
+		return nil
+	}
+}
+
+// newHTTPClient creates a httpClient for the current connection options.
+func (c *Client) newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: c.requestTimeout,
+		Transport: &http.Transport{
+			MaxIdleConns:    c.maxIdleConns,
+			IdleConnTimeout: c.idleTimeout,
+		},
+	}
+}
+
 // NewClientWithResponses returns a ClientWithResponses with a default Client:
 func NewClientWithResponses(server string) *ClientWithResponses {
     return &ClientWithResponses{
         ClientInterface: &Client{
-            Client: http.Client{},
+            Client: &http.Client{},
             Server: server,
         },
     }
@@ -17,7 +122,7 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
 	return &ClientWithResponses{
 		ClientInterface: &Client{
-			Client: http.Client{},
+			Client: &http.Client{},
 			Server: server,
 			RequestEditor: reqEditorFn,
 		},

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -3,17 +3,32 @@ type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
-    // The endpoint of the server conforming to this interface, with scheme,
-    // https://api.deepmap.com for example.
-    Server string
+	// The endpoint of the server conforming to this interface, with scheme,
+	// https://api.deepmap.com for example.
+	Server string
 
-    // HTTP client with any customized settings, such as certificate chains.
-    Client http.Client
+	// HTTP client with any customized settings, such as certificate chains.
+	Client *http.Client
 
-    // A callback for modifying requests which are generated before sending over
-    // the network.
-    RequestEditor RequestEditorFn
+	// A callback for modifying requests which are generated before sending over
+	// the network.
+	RequestEditor RequestEditorFn
+
+	// userAgent to use
+	userAgent string
+
+	// timeout of single request
+	requestTimeout time.Duration
+
+	// timeout of idle http connections
+	idleTimeout time.Duration
+
+	// maxium idle connections of the underlying http-client.
+	maxIdleConns int
 }
+
+// ClientOption allows setting custom parameters during construction
+type ClientOption func(*Client) error
 
 // The interface specification for the client above.
 type ClientInterface interface {

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -267,11 +267,116 @@ type ClientWithResponses struct {
     ClientInterface
 }
 
+// NewClient creates a new Client.
+func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses, error) {
+	// create a client with sane default values
+	client := Client{
+		// must have a slash in order to resolve relative paths correctly.
+		Server:         "",
+		userAgent:      "oapi-codegen",
+		maxIdleConns:   10,
+		requestTimeout: 5 * time.Second,
+		idleTimeout:    30 * time.Second,
+	}
+	// mutate defaultClient and add all optional params
+	for _, o := range opts {
+		if err := o(&client); err != nil {
+			return nil, err
+		}
+	}
+
+	// create httpClient, if not already present
+	if client.Client == nil {
+		client.Client = client.newHTTPClient()
+	}
+
+	return &ClientWithResponses{
+		ClientInterface: &client,
+	}, nil
+}
+
+// WithBaseURL overrides the baseURL.
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) error {
+		if !strings.HasSuffix(baseURL, "/") {
+			baseURL += "/"
+		}
+		newBaseURL, err := url.Parse(baseURL)
+		if err != nil {
+			return err
+		}
+		c.Server = newBaseURL.String()
+		return nil
+	}
+}
+
+// WithUserAgent allows setting the userAgent
+func WithUserAgent(userAgent string) ClientOption {
+	return func(c *Client) error {
+		c.userAgent = userAgent
+		return nil
+	}
+}
+
+// WithIdleTimeout overrides the timeout of idle connections.
+func WithIdleTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.idleTimeout = timeout
+		return nil
+	}
+}
+
+// WithRequestTimeout overrides the timeout of individual requests.
+func WithRequestTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.requestTimeout = timeout
+		return nil
+	}
+}
+
+// WithMaxIdleConnections overrides the amount of idle connections of the
+// underlying http-client.
+func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
+	return func(c *Client) error {
+		c.maxIdleConns = int(maxIdleConns)
+		return nil
+	}
+}
+
+// WithHTTPClient allows overriding the default httpClient, which is
+// automatically created. This is useful for tests.
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(c *Client) error {
+		c.Client = httpClient
+		return nil
+	}
+}
+
+// WithRequestEditorFn allows setting up a callback function, which will be
+// called right before sending the request. This can be used to mutate the request.
+func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
+	return func(c *Client) error {
+		c.RequestEditor = fn
+		return nil
+	}
+}
+
+// newHTTPClient creates a httpClient for the current connection options.
+func (c *Client) newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: c.requestTimeout,
+		Transport: &http.Transport{
+			MaxIdleConns:    c.maxIdleConns,
+			IdleConnTimeout: c.idleTimeout,
+		},
+	}
+}
+
 // NewClientWithResponses returns a ClientWithResponses with a default Client:
 func NewClientWithResponses(server string) *ClientWithResponses {
     return &ClientWithResponses{
         ClientInterface: &Client{
-            Client: http.Client{},
+            Client: &http.Client{},
             Server: server,
         },
     }
@@ -281,7 +386,7 @@ func NewClientWithResponses(server string) *ClientWithResponses {
 func NewClientWithResponsesAndRequestEditorFunc(server string, reqEditorFn RequestEditorFn) *ClientWithResponses {
 	return &ClientWithResponses{
 		ClientInterface: &Client{
-			Client: http.Client{},
+			Client: &http.Client{},
 			Server: server,
 			RequestEditor: reqEditorFn,
 		},
@@ -369,17 +474,32 @@ type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
-    // The endpoint of the server conforming to this interface, with scheme,
-    // https://api.deepmap.com for example.
-    Server string
+	// The endpoint of the server conforming to this interface, with scheme,
+	// https://api.deepmap.com for example.
+	Server string
 
-    // HTTP client with any customized settings, such as certificate chains.
-    Client http.Client
+	// HTTP client with any customized settings, such as certificate chains.
+	Client *http.Client
 
-    // A callback for modifying requests which are generated before sending over
-    // the network.
-    RequestEditor RequestEditorFn
+	// A callback for modifying requests which are generated before sending over
+	// the network.
+	RequestEditor RequestEditorFn
+
+	// userAgent to use
+	userAgent string
+
+	// timeout of single request
+	requestTimeout time.Duration
+
+	// timeout of idle http connections
+	idleTimeout time.Duration
+
+	// maxium idle connections of the underlying http-client.
+	maxIdleConns int
 }
+
+// ClientOption allows setting custom parameters during construction
+type ClientOption func(*Client) error
 
 // The interface specification for the client above.
 type ClientInterface interface {

--- a/pkg/securityprovider/securityprovider.go
+++ b/pkg/securityprovider/securityprovider.go
@@ -1,0 +1,110 @@
+// Package securityprovider contains some default securityprovider
+// implementations, which can be used as a RequestEditorFn of a
+// client.
+package securityprovider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const (
+	// ErrSecurityProviderApiKeyInvalidIn indicates a usage of an invalid In.
+	// Should be cookie, header or query
+	ErrSecurityProviderApiKeyInvalidIn = SecurityProviderError("invalid 'in' specified for apiKey")
+)
+
+// SecurityProviderError defines error values of a security provider.
+type SecurityProviderError string
+
+// Error implements the error interface.
+func (e SecurityProviderError) Error() string {
+	return string(e)
+}
+
+// NewSecurityProviderBasicAuth provides a SecurityProvider, which can solve
+// the BasicAuth challenge for api-calls.
+func NewSecurityProviderBasicAuth(username, password string) (*SecurityProviderBasicAuth, error) {
+	return &SecurityProviderBasicAuth{
+		username: username,
+		password: password,
+	}, nil
+}
+
+// SecurityProviderBasicAuth sends a base64-encoded combination of
+// username, password along with a request.
+type SecurityProviderBasicAuth struct {
+	username string
+	password string
+}
+
+// Intercept will attach an Authorization header to the request and ensures that
+// the username, password are base64 encoded and attached to the header.
+func (s *SecurityProviderBasicAuth) Intercept(req *http.Request, ctx context.Context) error {
+	req.SetBasicAuth(s.username, s.password)
+	return nil
+}
+
+// NewSecurityProviderBearerToken provides a SecurityProvider, which can solve
+// the Bearer Auth challende for api-calls.
+func NewSecurityProviderBearerToken(token string) (*SecurityProviderBearerToken, error) {
+	return &SecurityProviderBearerToken{
+		token: token,
+	}, nil
+}
+
+// SecurityProviderBearerToken sends a token as part of an
+// Authorization: Bearer header along with a request.
+type SecurityProviderBearerToken struct {
+	token string
+}
+
+// Intercept will attach an Authorization header to the request
+// and ensures that the bearer token is attached to the header.
+func (s *SecurityProviderBearerToken) Intercept(req *http.Request, ctx context.Context) error {
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.token))
+	return nil
+}
+
+// NewSecurityProviderApiKey will attach a generic apiKey for a given name
+// either to a cookie, header or as a query parameter.
+func NewSecurityProviderApiKey(in, name, apiKey string) (*SecurityProviderApiKey, error) {
+	interceptors := map[string]func(req *http.Request, ctx context.Context) error{
+		"cookie": func(req *http.Request, ctx context.Context) error {
+			req.AddCookie(&http.Cookie{Name: name, Value: apiKey})
+			return nil
+		},
+		"header": func(req *http.Request, ctx context.Context) error {
+			req.Header.Add(name, apiKey)
+			return nil
+		},
+		"query": func(req *http.Request, ctx context.Context) error {
+			query := req.URL.Query()
+			query.Add(name, apiKey)
+			req.URL.RawQuery = query.Encode()
+			return nil
+		},
+	}
+
+	interceptor, ok := interceptors[in]
+	if !ok {
+		return nil, ErrSecurityProviderApiKeyInvalidIn
+	}
+
+	return &SecurityProviderApiKey{
+		interceptor: interceptor,
+	}, nil
+}
+
+// SecurityProviderApiKey will attach an apiKey either to a
+// cookie, header or query.
+type SecurityProviderApiKey struct {
+	interceptor func(req *http.Request, ctx context.Context) error
+}
+
+// Intercept will attach a cookie, header or query param for the configured
+// name and apiKey.
+func (s *SecurityProviderApiKey) Intercept(req *http.Request, ctx context.Context) error {
+	return s.interceptor(req, ctx)
+}


### PR DESCRIPTION
Fix #81 Add NewClient() constructor with Interceptors

This adds a new client constructor and adds some
fields to the client to extend its usage to have
multiple request-interceptors, which can be used
to help use the client for some securitySchemes.

Please look at the separate commits.


## What this does

It adds some default securityproviders, which are optional to use. It also adds `Interceptors` to a client


## Using SecurityProviders

If you generate client-code, you can use some default-provided security providers
which help you to use the various OpenAPI 3 Authentication mechanism.


```
	// Example BasicAuth
	// See: https://swagger.io/docs/specification/authentication/basic-authentication/
	basicAuthProvider, basicAuthProviderErr := runtime.NewSecurityProviderBasicAuth("MY_USER", "MY_PASS")
	if basicAuthProviderErr != nil {
		panic(basicAuthProviderErr)
	}

	// Example BearerToken
	// See: https://swagger.io/docs/specification/authentication/bearer-authentication/
	bearerTokenProvider, bearerTokenProviderErr := runtime.NewSecurityProviderBearerToken("MY_TOKEN")
	if bearerTokenProviderErr != nil {
		panic(bearerTokenProviderErr)
	}

	// Example ApiKey provider
	// See: https://swagger.io/docs/specification/authentication/api-keys/
	apiKeyProvider, apiKeyProviderErr := runtime.NewSecurityProviderApiKey("query", "myApiKeyParam", "MY_API_KEY")
	if apiKeyProviderErr != nil {
		panic(apiKeyProviderErr)
	}

	// Example providing your own provider using an anonymous function wrapping in the
    // InterceptoFn adapter. The behaviour between the InterceptorFn and the Interceptor interface
    // are the same as http.HandlerFunc and http.Handler.
	customProvider := InterceptorFn(func(req *http.Request, ctx context.Context) error {
		// Just log the request header, nothing else.
		log.Println(req.Header)
		return nil
	})

	// Exhaustive list of some defaults you can use to initialize a Client.
	// If you need to override the underlying httpClient, you can use the option
	//
	// WithHTTPClient(httpClient *http.Client)
	//
	client, clientErr := NewClient(context.Background(), []Option{
		WithBaseURL("https://api.deepmap.com"),
		WithUserAgent("MY_USER_AGENT"),
		WithMaxIdleConnections(10),
		WithIdleTimeout(10 * time.Second),
		WithRequestTimeout(1 * time.Second),
		// You can register multiple providers.
		// They will be called in insertion order.
		// If a provider fails, the call-chain stops
		// an does not continue the request.
		WithInterceptors([]Interceptor{
			basicAuthProvider,
			bearerTokenProvider,
			apiKeyProvider,
			customProvider,
		}...,
		),
	}...,
	)
 ```
