### PR TITLE
improvement: Use interface for the HTTP Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,10 +371,6 @@ which help you to use the various OpenAPI 3 Authentication mechanism.
         //
         client, clientErr := NewClient(context.Background(), []ClientOption{
             WithBaseURL("https://api.deepmap.com"),
-            WithUserAgent("MY_USER_AGENT"),
-            WithMaxIdleConnections(10),
-            WithIdleTimeout(10 * time.Second),
-            WithRequestTimeout(1 * time.Second),
             WithRequestEditorFn(apiKeyProvider.Edit),
         }...,
         )

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 )
 
 // Error defines model for Error.
@@ -76,18 +75,6 @@ type Client struct {
 	// A callback for modifying requests which are generated before sending over
 	// the network.
 	RequestEditor RequestEditorFn
-
-	// userAgent to use
-	userAgent string
-
-	// timeout of single request
-	requestTimeout time.Duration
-
-	// timeout of idle http connections
-	idleTimeout time.Duration
-
-	// maxium idle connections of the underlying http-client.
-	maxIdleConns int
 }
 
 // ClientOption allows setting custom parameters during construction
@@ -305,11 +292,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 	// create a client with sane default values
 	client := Client{
 		// must have a slash in order to resolve relative paths correctly.
-		Server:         "",
-		userAgent:      "oapi-codegen",
-		maxIdleConns:   10,
-		requestTimeout: 5 * time.Second,
-		idleTimeout:    30 * time.Second,
+		Server: "",
 	}
 	// mutate defaultClient and add all optional params
 	for _, o := range opts {
@@ -320,7 +303,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 
 	// create httpClient, if not already present
 	if client.Client == nil {
-		client.Client = client.newHTTPClient()
+		client.Client = http.DefaultClient
 	}
 
 	return &ClientWithResponses{
@@ -343,44 +326,11 @@ func WithBaseURL(baseURL string) ClientOption {
 	}
 }
 
-// WithUserAgent allows setting the userAgent
-func WithUserAgent(userAgent string) ClientOption {
+// WithHTTPClient allows overriding the default Doer, which is
+// automatically created using http.Client. This is useful for tests.
+func WithHTTPClient(doer Doer) ClientOption {
 	return func(c *Client) error {
-		c.userAgent = userAgent
-		return nil
-	}
-}
-
-// WithIdleTimeout overrides the timeout of idle connections.
-func WithIdleTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.idleTimeout = timeout
-		return nil
-	}
-}
-
-// WithRequestTimeout overrides the timeout of individual requests.
-func WithRequestTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.requestTimeout = timeout
-		return nil
-	}
-}
-
-// WithMaxIdleConnections overrides the amount of idle connections of the
-// underlying http-client.
-func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
-	return func(c *Client) error {
-		c.maxIdleConns = int(maxIdleConns)
-		return nil
-	}
-}
-
-// WithHTTPClient allows overriding the default httpClient, which is
-// automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
-	return func(c *Client) error {
-		c.Client = httpClient
+		c.Client = doer
 		return nil
 	}
 }
@@ -391,17 +341,6 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 	return func(c *Client) error {
 		c.RequestEditor = fn
 		return nil
-	}
-}
-
-// newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
-	return &http.Client{
-		Timeout: c.requestTimeout,
-		Transport: &http.Transport{
-			MaxIdleConns:    c.maxIdleConns,
-			IdleConnTimeout: c.idleTimeout,
-		},
 	}
 }
 

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -56,6 +56,11 @@ type AddPetJSONRequestBody addPetJSONBody
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
+// Doer performs HTTP requests
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -63,7 +68,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client Doer
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -56,7 +56,9 @@ type AddPetJSONRequestBody addPetJSONBody
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
-// Doer performs HTTP requests
+// Doer performs HTTP requests.
+//
+// The standard http.Client implements this interface.
 type Doer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -67,7 +69,8 @@ type Client struct {
 	// https://api.deepmap.com for example.
 	Server string
 
-	// HTTP client with any customized settings, such as certificate chains.
+	// Doer for performing requests, typically a *http.Client with any
+	// customized settings, such as certificate chains.
 	Client Doer
 
 	// A callback for modifying requests which are generated before sending over

--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,5 @@ require (
 	golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 // indirect
 	golang.org/x/tools v0.0.0-20190724185037-8aa4eac1a7c1 // indirect
 )
+
+go 1.13

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 )
 
 // SchemaObject defines model for SchemaObject.
@@ -62,18 +61,6 @@ type Client struct {
 	// A callback for modifying requests which are generated before sending over
 	// the network.
 	RequestEditor RequestEditorFn
-
-	// userAgent to use
-	userAgent string
-
-	// timeout of single request
-	requestTimeout time.Duration
-
-	// timeout of idle http connections
-	idleTimeout time.Duration
-
-	// maxium idle connections of the underlying http-client.
-	maxIdleConns int
 }
 
 // ClientOption allows setting custom parameters during construction
@@ -343,11 +330,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 	// create a client with sane default values
 	client := Client{
 		// must have a slash in order to resolve relative paths correctly.
-		Server:         "",
-		userAgent:      "oapi-codegen",
-		maxIdleConns:   10,
-		requestTimeout: 5 * time.Second,
-		idleTimeout:    30 * time.Second,
+		Server: "",
 	}
 	// mutate defaultClient and add all optional params
 	for _, o := range opts {
@@ -358,7 +341,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 
 	// create httpClient, if not already present
 	if client.Client == nil {
-		client.Client = client.newHTTPClient()
+		client.Client = http.DefaultClient
 	}
 
 	return &ClientWithResponses{
@@ -381,44 +364,11 @@ func WithBaseURL(baseURL string) ClientOption {
 	}
 }
 
-// WithUserAgent allows setting the userAgent
-func WithUserAgent(userAgent string) ClientOption {
+// WithHTTPClient allows overriding the default Doer, which is
+// automatically created using http.Client. This is useful for tests.
+func WithHTTPClient(doer Doer) ClientOption {
 	return func(c *Client) error {
-		c.userAgent = userAgent
-		return nil
-	}
-}
-
-// WithIdleTimeout overrides the timeout of idle connections.
-func WithIdleTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.idleTimeout = timeout
-		return nil
-	}
-}
-
-// WithRequestTimeout overrides the timeout of individual requests.
-func WithRequestTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.requestTimeout = timeout
-		return nil
-	}
-}
-
-// WithMaxIdleConnections overrides the amount of idle connections of the
-// underlying http-client.
-func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
-	return func(c *Client) error {
-		c.maxIdleConns = int(maxIdleConns)
-		return nil
-	}
-}
-
-// WithHTTPClient allows overriding the default httpClient, which is
-// automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
-	return func(c *Client) error {
-		c.Client = httpClient
+		c.Client = doer
 		return nil
 	}
 }
@@ -429,17 +379,6 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 	return func(c *Client) error {
 		c.RequestEditor = fn
 		return nil
-	}
-}
-
-// newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
-	return &http.Client{
-		Timeout: c.requestTimeout,
-		Transport: &http.Transport{
-			MaxIdleConns:    c.maxIdleConns,
-			IdleConnTimeout: c.idleTimeout,
-		},
 	}
 }
 

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -42,6 +42,11 @@ type PostJsonJSONRequestBody PostJsonJSONBody
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
+// Doer performs HTTP requests
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -49,7 +54,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client Doer
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -42,7 +42,9 @@ type PostJsonJSONRequestBody PostJsonJSONBody
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
-// Doer performs HTTP requests
+// Doer performs HTTP requests.
+//
+// The standard http.Client implements this interface.
 type Doer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -53,7 +55,8 @@ type Client struct {
 	// https://api.deepmap.com for example.
 	Server string
 
-	// HTTP client with any customized settings, such as certificate chains.
+	// Doer for performing requests, typically a *http.Client with any
+	// customized settings, such as certificate chains.
 	Client Doer
 
 	// A callback for modifying requests which are generated before sending over

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -723,6 +723,11 @@ func (a AdditionalPropertiesObject5) MarshalJSON() ([]byte, error) {
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
+// Doer performs HTTP requests
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -730,7 +735,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client Doer
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 )
 
 // AdditionalPropertiesObject1 defines model for AdditionalPropertiesObject1.
@@ -743,18 +742,6 @@ type Client struct {
 	// A callback for modifying requests which are generated before sending over
 	// the network.
 	RequestEditor RequestEditorFn
-
-	// userAgent to use
-	userAgent string
-
-	// timeout of single request
-	requestTimeout time.Duration
-
-	// timeout of idle http connections
-	idleTimeout time.Duration
-
-	// maxium idle connections of the underlying http-client.
-	maxIdleConns int
 }
 
 // ClientOption allows setting custom parameters during construction
@@ -890,11 +877,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 	// create a client with sane default values
 	client := Client{
 		// must have a slash in order to resolve relative paths correctly.
-		Server:         "",
-		userAgent:      "oapi-codegen",
-		maxIdleConns:   10,
-		requestTimeout: 5 * time.Second,
-		idleTimeout:    30 * time.Second,
+		Server: "",
 	}
 	// mutate defaultClient and add all optional params
 	for _, o := range opts {
@@ -905,7 +888,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 
 	// create httpClient, if not already present
 	if client.Client == nil {
-		client.Client = client.newHTTPClient()
+		client.Client = http.DefaultClient
 	}
 
 	return &ClientWithResponses{
@@ -928,44 +911,11 @@ func WithBaseURL(baseURL string) ClientOption {
 	}
 }
 
-// WithUserAgent allows setting the userAgent
-func WithUserAgent(userAgent string) ClientOption {
+// WithHTTPClient allows overriding the default Doer, which is
+// automatically created using http.Client. This is useful for tests.
+func WithHTTPClient(doer Doer) ClientOption {
 	return func(c *Client) error {
-		c.userAgent = userAgent
-		return nil
-	}
-}
-
-// WithIdleTimeout overrides the timeout of idle connections.
-func WithIdleTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.idleTimeout = timeout
-		return nil
-	}
-}
-
-// WithRequestTimeout overrides the timeout of individual requests.
-func WithRequestTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.requestTimeout = timeout
-		return nil
-	}
-}
-
-// WithMaxIdleConnections overrides the amount of idle connections of the
-// underlying http-client.
-func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
-	return func(c *Client) error {
-		c.maxIdleConns = int(maxIdleConns)
-		return nil
-	}
-}
-
-// WithHTTPClient allows overriding the default httpClient, which is
-// automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
-	return func(c *Client) error {
-		c.Client = httpClient
+		c.Client = doer
 		return nil
 	}
 }
@@ -976,17 +926,6 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 	return func(c *Client) error {
 		c.RequestEditor = fn
 		return nil
-	}
-}
-
-// newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
-	return &http.Client{
-		Timeout: c.requestTimeout,
-		Transport: &http.Transport{
-			MaxIdleConns:    c.maxIdleConns,
-			IdleConnTimeout: c.idleTimeout,
-		},
 	}
 }
 

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -723,7 +723,9 @@ func (a AdditionalPropertiesObject5) MarshalJSON() ([]byte, error) {
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
-// Doer performs HTTP requests
+// Doer performs HTTP requests.
+//
+// The standard http.Client implements this interface.
 type Doer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -734,7 +736,8 @@ type Client struct {
 	// https://api.deepmap.com for example.
 	Server string
 
-	// HTTP client with any customized settings, such as certificate chains.
+	// Doer for performing requests, typically a *http.Client with any
+	// customized settings, such as certificate chains.
 	Client Doer
 
 	// A callback for modifying requests which are generated before sending over

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -96,6 +96,11 @@ func (a Document_Fields) MarshalJSON() ([]byte, error) {
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
+// Doer performs HTTP requests
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -103,7 +108,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client Doer
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -96,7 +96,9 @@ func (a Document_Fields) MarshalJSON() ([]byte, error) {
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
-// Doer performs HTTP requests
+// Doer performs HTTP requests.
+//
+// The standard http.Client implements this interface.
 type Doer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -107,7 +109,8 @@ type Client struct {
 	// https://api.deepmap.com for example.
 	Server string
 
-	// HTTP client with any customized settings, such as certificate chains.
+	// Doer for performing requests, typically a *http.Client with any
+	// customized settings, such as certificate chains.
 	Client Doer
 
 	// A callback for modifying requests which are generated before sending over

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 )
 
 // ArrayValue defines model for ArrayValue.
@@ -116,18 +115,6 @@ type Client struct {
 	// A callback for modifying requests which are generated before sending over
 	// the network.
 	RequestEditor RequestEditorFn
-
-	// userAgent to use
-	userAgent string
-
-	// timeout of single request
-	requestTimeout time.Duration
-
-	// timeout of idle http connections
-	idleTimeout time.Duration
-
-	// maxium idle connections of the underlying http-client.
-	maxIdleConns int
 }
 
 // ClientOption allows setting custom parameters during construction
@@ -178,11 +165,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 	// create a client with sane default values
 	client := Client{
 		// must have a slash in order to resolve relative paths correctly.
-		Server:         "",
-		userAgent:      "oapi-codegen",
-		maxIdleConns:   10,
-		requestTimeout: 5 * time.Second,
-		idleTimeout:    30 * time.Second,
+		Server: "",
 	}
 	// mutate defaultClient and add all optional params
 	for _, o := range opts {
@@ -193,7 +176,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 
 	// create httpClient, if not already present
 	if client.Client == nil {
-		client.Client = client.newHTTPClient()
+		client.Client = http.DefaultClient
 	}
 
 	return &ClientWithResponses{
@@ -216,44 +199,11 @@ func WithBaseURL(baseURL string) ClientOption {
 	}
 }
 
-// WithUserAgent allows setting the userAgent
-func WithUserAgent(userAgent string) ClientOption {
+// WithHTTPClient allows overriding the default Doer, which is
+// automatically created using http.Client. This is useful for tests.
+func WithHTTPClient(doer Doer) ClientOption {
 	return func(c *Client) error {
-		c.userAgent = userAgent
-		return nil
-	}
-}
-
-// WithIdleTimeout overrides the timeout of idle connections.
-func WithIdleTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.idleTimeout = timeout
-		return nil
-	}
-}
-
-// WithRequestTimeout overrides the timeout of individual requests.
-func WithRequestTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.requestTimeout = timeout
-		return nil
-	}
-}
-
-// WithMaxIdleConnections overrides the amount of idle connections of the
-// underlying http-client.
-func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
-	return func(c *Client) error {
-		c.maxIdleConns = int(maxIdleConns)
-		return nil
-	}
-}
-
-// WithHTTPClient allows overriding the default httpClient, which is
-// automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
-	return func(c *Client) error {
-		c.Client = httpClient
+		c.Client = doer
 		return nil
 	}
 }
@@ -264,17 +214,6 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 	return func(c *Client) error {
 		c.RequestEditor = fn
 		return nil
-	}
-}
-
-// newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
-	return &http.Client{
-		Timeout: c.requestTimeout,
-		Transport: &http.Transport{
-			MaxIdleConns:    c.maxIdleConns,
-			IdleConnTimeout: c.idleTimeout,
-		},
 	}
 }
 

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -110,6 +110,11 @@ type GetQueryFormParams struct {
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
+// Doer performs HTTP requests
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -117,7 +122,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client Doer
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -17,7 +17,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 )
 
 // ComplexObject defines model for ComplexObject.
@@ -130,18 +129,6 @@ type Client struct {
 	// A callback for modifying requests which are generated before sending over
 	// the network.
 	RequestEditor RequestEditorFn
-
-	// userAgent to use
-	userAgent string
-
-	// timeout of single request
-	requestTimeout time.Duration
-
-	// timeout of idle http connections
-	idleTimeout time.Duration
-
-	// maxium idle connections of the underlying http-client.
-	maxIdleConns int
 }
 
 // ClientOption allows setting custom parameters during construction
@@ -1111,11 +1098,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 	// create a client with sane default values
 	client := Client{
 		// must have a slash in order to resolve relative paths correctly.
-		Server:         "",
-		userAgent:      "oapi-codegen",
-		maxIdleConns:   10,
-		requestTimeout: 5 * time.Second,
-		idleTimeout:    30 * time.Second,
+		Server: "",
 	}
 	// mutate defaultClient and add all optional params
 	for _, o := range opts {
@@ -1126,7 +1109,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 
 	// create httpClient, if not already present
 	if client.Client == nil {
-		client.Client = client.newHTTPClient()
+		client.Client = http.DefaultClient
 	}
 
 	return &ClientWithResponses{
@@ -1149,44 +1132,11 @@ func WithBaseURL(baseURL string) ClientOption {
 	}
 }
 
-// WithUserAgent allows setting the userAgent
-func WithUserAgent(userAgent string) ClientOption {
+// WithHTTPClient allows overriding the default Doer, which is
+// automatically created using http.Client. This is useful for tests.
+func WithHTTPClient(doer Doer) ClientOption {
 	return func(c *Client) error {
-		c.userAgent = userAgent
-		return nil
-	}
-}
-
-// WithIdleTimeout overrides the timeout of idle connections.
-func WithIdleTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.idleTimeout = timeout
-		return nil
-	}
-}
-
-// WithRequestTimeout overrides the timeout of individual requests.
-func WithRequestTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.requestTimeout = timeout
-		return nil
-	}
-}
-
-// WithMaxIdleConnections overrides the amount of idle connections of the
-// underlying http-client.
-func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
-	return func(c *Client) error {
-		c.maxIdleConns = int(maxIdleConns)
-		return nil
-	}
-}
-
-// WithHTTPClient allows overriding the default httpClient, which is
-// automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
-	return func(c *Client) error {
-		c.Client = httpClient
+		c.Client = doer
 		return nil
 	}
 }
@@ -1197,17 +1147,6 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 	return func(c *Client) error {
 		c.RequestEditor = fn
 		return nil
-	}
-}
-
-// newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
-	return &http.Client{
-		Timeout: c.requestTimeout,
-		Transport: &http.Transport{
-			MaxIdleConns:    c.maxIdleConns,
-			IdleConnTimeout: c.idleTimeout,
-		},
 	}
 }
 

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -110,7 +110,9 @@ type GetQueryFormParams struct {
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
-// Doer performs HTTP requests
+// Doer performs HTTP requests.
+//
+// The standard http.Client implements this interface.
 type Doer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -121,7 +123,8 @@ type Client struct {
 	// https://api.deepmap.com for example.
 	Server string
 
-	// HTTP client with any customized settings, such as certificate chains.
+	// Doer for performing requests, typically a *http.Client with any
+	// customized settings, such as certificate chains.
 	Client Doer
 
 	// A callback for modifying requests which are generated before sending over

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 )
 
 // N5StartsWithNumber defines model for 5StartsWithNumber.
@@ -70,18 +69,6 @@ type Client struct {
 	// A callback for modifying requests which are generated before sending over
 	// the network.
 	RequestEditor RequestEditorFn
-
-	// userAgent to use
-	userAgent string
-
-	// timeout of single request
-	requestTimeout time.Duration
-
-	// timeout of idle http connections
-	idleTimeout time.Duration
-
-	// maxium idle connections of the underlying http-client.
-	maxIdleConns int
 }
 
 // ClientOption allows setting custom parameters during construction
@@ -254,11 +241,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 	// create a client with sane default values
 	client := Client{
 		// must have a slash in order to resolve relative paths correctly.
-		Server:         "",
-		userAgent:      "oapi-codegen",
-		maxIdleConns:   10,
-		requestTimeout: 5 * time.Second,
-		idleTimeout:    30 * time.Second,
+		Server: "",
 	}
 	// mutate defaultClient and add all optional params
 	for _, o := range opts {
@@ -269,7 +252,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 
 	// create httpClient, if not already present
 	if client.Client == nil {
-		client.Client = client.newHTTPClient()
+		client.Client = http.DefaultClient
 	}
 
 	return &ClientWithResponses{
@@ -292,44 +275,11 @@ func WithBaseURL(baseURL string) ClientOption {
 	}
 }
 
-// WithUserAgent allows setting the userAgent
-func WithUserAgent(userAgent string) ClientOption {
+// WithHTTPClient allows overriding the default Doer, which is
+// automatically created using http.Client. This is useful for tests.
+func WithHTTPClient(doer Doer) ClientOption {
 	return func(c *Client) error {
-		c.userAgent = userAgent
-		return nil
-	}
-}
-
-// WithIdleTimeout overrides the timeout of idle connections.
-func WithIdleTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.idleTimeout = timeout
-		return nil
-	}
-}
-
-// WithRequestTimeout overrides the timeout of individual requests.
-func WithRequestTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.requestTimeout = timeout
-		return nil
-	}
-}
-
-// WithMaxIdleConnections overrides the amount of idle connections of the
-// underlying http-client.
-func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
-	return func(c *Client) error {
-		c.maxIdleConns = int(maxIdleConns)
-		return nil
-	}
-}
-
-// WithHTTPClient allows overriding the default httpClient, which is
-// automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
-	return func(c *Client) error {
-		c.Client = httpClient
+		c.Client = doer
 		return nil
 	}
 }
@@ -340,17 +290,6 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 	return func(c *Client) error {
 		c.RequestEditor = fn
 		return nil
-	}
-}
-
-// newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
-	return &http.Client{
-		Timeout: c.requestTimeout,
-		Transport: &http.Transport{
-			MaxIdleConns:    c.maxIdleConns,
-			IdleConnTimeout: c.idleTimeout,
-		},
 	}
 }
 

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -50,6 +50,11 @@ type Issue9JSONRequestBody Issue9JSONBody
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
+// Doer performs HTTP requests
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -57,7 +62,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client Doer
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -50,7 +50,9 @@ type Issue9JSONRequestBody Issue9JSONBody
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
-// Doer performs HTTP requests
+// Doer performs HTTP requests.
+//
+// The standard http.Client implements this interface.
 type Doer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -61,7 +63,8 @@ type Client struct {
 	// https://api.deepmap.com for example.
 	Server string
 
-	// HTTP client with any customized settings, such as certificate chains.
+	// Doer for performing requests, typically a *http.Client with any
+	// customized settings, such as certificate chains.
 	Client Doer
 
 	// A callback for modifying requests which are generated before sending over

--- a/pkg/codegen/templates/client-with-responses.tmpl
+++ b/pkg/codegen/templates/client-with-responses.tmpl
@@ -79,11 +79,11 @@ func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
 	}
 }
 
-// WithHTTPClient allows overriding the default httpClient, which is
-// automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
+// WithHTTPClient allows overriding the default Doer, which is
+// automatically created using http.Client. This is useful for tests.
+func WithHTTPClient(doer Doer) ClientOption {
 	return func(c *Client) error {
-		c.Client = httpClient
+		c.Client = doer
 		return nil
 	}
 }

--- a/pkg/codegen/templates/client-with-responses.tmpl
+++ b/pkg/codegen/templates/client-with-responses.tmpl
@@ -9,10 +9,6 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 	client := Client{
 		// must have a slash in order to resolve relative paths correctly.
 		Server:         "",
-		userAgent:      "oapi-codegen",
-		maxIdleConns:   10,
-		requestTimeout: 5 * time.Second,
-		idleTimeout:    30 * time.Second,
 	}
 	// mutate defaultClient and add all optional params
 	for _, o := range opts {
@@ -23,7 +19,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 
 	// create httpClient, if not already present
 	if client.Client == nil {
-		client.Client = client.newHTTPClient()
+		client.Client = http.DefaultClient
 	}
 
 	return &ClientWithResponses{
@@ -46,39 +42,6 @@ func WithBaseURL(baseURL string) ClientOption {
 	}
 }
 
-// WithUserAgent allows setting the userAgent
-func WithUserAgent(userAgent string) ClientOption {
-	return func(c *Client) error {
-		c.userAgent = userAgent
-		return nil
-	}
-}
-
-// WithIdleTimeout overrides the timeout of idle connections.
-func WithIdleTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.idleTimeout = timeout
-		return nil
-	}
-}
-
-// WithRequestTimeout overrides the timeout of individual requests.
-func WithRequestTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.requestTimeout = timeout
-		return nil
-	}
-}
-
-// WithMaxIdleConnections overrides the amount of idle connections of the
-// underlying http-client.
-func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
-	return func(c *Client) error {
-		c.maxIdleConns = int(maxIdleConns)
-		return nil
-	}
-}
-
 // WithHTTPClient allows overriding the default Doer, which is
 // automatically created using http.Client. This is useful for tests.
 func WithHTTPClient(doer Doer) ClientOption {
@@ -94,17 +57,6 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 	return func(c *Client) error {
 		c.RequestEditor = fn
 		return nil
-	}
-}
-
-// newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
-	return &http.Client{
-		Timeout: c.requestTimeout,
-		Transport: &http.Transport{
-			MaxIdleConns:    c.maxIdleConns,
-			IdleConnTimeout: c.idleTimeout,
-		},
 	}
 }
 

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -1,6 +1,11 @@
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
+// Doer performs HTTP requests
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -8,7 +13,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client Doer
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -21,18 +21,6 @@ type Client struct {
 	// A callback for modifying requests which are generated before sending over
 	// the network.
 	RequestEditor RequestEditorFn
-
-	// userAgent to use
-	userAgent string
-
-	// timeout of single request
-	requestTimeout time.Duration
-
-	// timeout of idle http connections
-	idleTimeout time.Duration
-
-	// maxium idle connections of the underlying http-client.
-	maxIdleConns int
 }
 
 // ClientOption allows setting custom parameters during construction

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -1,7 +1,9 @@
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
-// Doer performs HTTP requests
+// Doer performs HTTP requests.
+//
+// The standard http.Client implements this interface.
 type Doer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -12,7 +14,8 @@ type Client struct {
 	// https://api.deepmap.com for example.
 	Server string
 
-	// HTTP client with any customized settings, such as certificate chains.
+	// Doer for performing requests, typically a *http.Client with any
+	// customized settings, such as certificate chains.
 	Client Doer
 
 	// A callback for modifying requests which are generated before sending over

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -473,7 +473,9 @@ func Parse{{genResponseTypeName $opid}}(rsp *http.Response) (*{{genResponseTypeN
 	"client.tmpl": `// RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
-// Doer performs HTTP requests
+// Doer performs HTTP requests.
+//
+// The standard http.Client implements this interface.
 type Doer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -484,7 +486,8 @@ type Client struct {
 	// https://api.deepmap.com for example.
 	Server string
 
-	// HTTP client with any customized settings, such as certificate chains.
+	// Doer for performing requests, typically a *http.Client with any
+	// customized settings, such as certificate chains.
 	Client Doer
 
 	// A callback for modifying requests which are generated before sending over

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -274,10 +274,6 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 	client := Client{
 		// must have a slash in order to resolve relative paths correctly.
 		Server:         "",
-		userAgent:      "oapi-codegen",
-		maxIdleConns:   10,
-		requestTimeout: 5 * time.Second,
-		idleTimeout:    30 * time.Second,
 	}
 	// mutate defaultClient and add all optional params
 	for _, o := range opts {
@@ -288,7 +284,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*ClientWithResponses,
 
 	// create httpClient, if not already present
 	if client.Client == nil {
-		client.Client = client.newHTTPClient()
+		client.Client = http.DefaultClient
 	}
 
 	return &ClientWithResponses{
@@ -311,44 +307,11 @@ func WithBaseURL(baseURL string) ClientOption {
 	}
 }
 
-// WithUserAgent allows setting the userAgent
-func WithUserAgent(userAgent string) ClientOption {
+// WithHTTPClient allows overriding the default Doer, which is
+// automatically created using http.Client. This is useful for tests.
+func WithHTTPClient(doer Doer) ClientOption {
 	return func(c *Client) error {
-		c.userAgent = userAgent
-		return nil
-	}
-}
-
-// WithIdleTimeout overrides the timeout of idle connections.
-func WithIdleTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.idleTimeout = timeout
-		return nil
-	}
-}
-
-// WithRequestTimeout overrides the timeout of individual requests.
-func WithRequestTimeout(timeout time.Duration) ClientOption {
-	return func(c *Client) error {
-		c.requestTimeout = timeout
-		return nil
-	}
-}
-
-// WithMaxIdleConnections overrides the amount of idle connections of the
-// underlying http-client.
-func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
-	return func(c *Client) error {
-		c.maxIdleConns = int(maxIdleConns)
-		return nil
-	}
-}
-
-// WithHTTPClient allows overriding the default httpClient, which is
-// automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
-	return func(c *Client) error {
-		c.Client = httpClient
+		c.Client = doer
 		return nil
 	}
 }
@@ -359,17 +322,6 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 	return func(c *Client) error {
 		c.RequestEditor = fn
 		return nil
-	}
-}
-
-// newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
-	return &http.Client{
-		Timeout: c.requestTimeout,
-		Transport: &http.Transport{
-			MaxIdleConns:    c.maxIdleConns,
-			IdleConnTimeout: c.idleTimeout,
-		},
 	}
 }
 
@@ -493,18 +445,6 @@ type Client struct {
 	// A callback for modifying requests which are generated before sending over
 	// the network.
 	RequestEditor RequestEditorFn
-
-	// userAgent to use
-	userAgent string
-
-	// timeout of single request
-	requestTimeout time.Duration
-
-	// timeout of idle http connections
-	idleTimeout time.Duration
-
-	// maxium idle connections of the underlying http-client.
-	maxIdleConns int
 }
 
 // ClientOption allows setting custom parameters during construction

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -473,6 +473,11 @@ func Parse{{genResponseTypeName $opid}}(rsp *http.Response) (*{{genResponseTypeN
 	"client.tmpl": `// RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
+// Doer performs HTTP requests
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Client which conforms to the OpenAPI3 specification for this service.
 type Client struct {
 	// The endpoint of the server conforming to this interface, with scheme,
@@ -480,7 +485,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client Doer
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.


### PR DESCRIPTION
Depend on an interface, rather than a concrete implementation, so as to
allow for alternate implementations to be used, such as decorated
clients.