### PR TITLE
Switch to HTTP client interface to allow wrapped clients

### DIFF
--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -58,14 +58,12 @@ type AddPetJSONRequestBody addPetJSONBody
 // The interface matches all methods attached to the standard library HTTP Client
 // https://golang.org/pkg/net/http/#Client
 // type Client
-//     func (c *Client) CloseIdleConnections()
 //     func (c *Client) Do(req *Request) (*Response, error)
 //     func (c *Client) Get(url string) (resp *Response, err error)
 //     func (c *Client) Head(url string) (resp *Response, err error)
 //     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
 //     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
 type HTTPClient interface {
-	CloseIdleConnections()
 	Do(req *http.Request) (*http.Response, error)
 	Get(url string) (*http.Response, error)
 	Head(url string) (*http.Response, error)

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -53,6 +53,26 @@ type addPetJSONBody NewPet
 // AddPetRequestBody defines body for AddPet for application/json ContentType.
 type AddPetJSONRequestBody addPetJSONBody
 
+// HTTPClient interface allows the user to use custom wrapped http clients to implement
+// additional features like retries, backoffs
+// The interface matches all methods attached to the standard library HTTP Client
+// https://golang.org/pkg/net/http/#Client
+// type Client
+//     func (c *Client) CloseIdleConnections()
+//     func (c *Client) Do(req *Request) (*Response, error)
+//     func (c *Client) Get(url string) (resp *Response, err error)
+//     func (c *Client) Head(url string) (resp *Response, err error)
+//     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
+//     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
+type HTTPClient interface {
+	CloseIdleConnections()
+	Do(req *http.Request) (*http.Response, error)
+	Get(url string) (*http.Response, error)
+	Head(url string) (*http.Response, error)
+	Post(url, contentType string, body io.Reader) (*http.Response, error)
+	PostForm(url string, data url.Values) (*http.Response, error)
+}
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
@@ -63,7 +83,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client HTTPClient
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
@@ -370,7 +390,7 @@ func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
 
 // WithHTTPClient allows overriding the default httpClient, which is
 // automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
+func WithHTTPClient(httpClient HTTPClient) ClientOption {
 	return func(c *Client) error {
 		c.Client = httpClient
 		return nil
@@ -387,7 +407,7 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 }
 
 // newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
+func (c *Client) newHTTPClient() HTTPClient {
 	return &http.Client{
 		Timeout: c.requestTimeout,
 		Transport: &http.Transport{

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -39,6 +39,26 @@ type PostBothJSONRequestBody PostBothJSONBody
 // PostJsonRequestBody defines body for PostJson for application/json ContentType.
 type PostJsonJSONRequestBody PostJsonJSONBody
 
+// HTTPClient interface allows the user to use custom wrapped http clients to implement
+// additional features like retries, backoffs
+// The interface matches all methods attached to the standard library HTTP Client
+// https://golang.org/pkg/net/http/#Client
+// type Client
+//     func (c *Client) CloseIdleConnections()
+//     func (c *Client) Do(req *Request) (*Response, error)
+//     func (c *Client) Get(url string) (resp *Response, err error)
+//     func (c *Client) Head(url string) (resp *Response, err error)
+//     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
+//     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
+type HTTPClient interface {
+	CloseIdleConnections()
+	Do(req *http.Request) (*http.Response, error)
+	Get(url string) (*http.Response, error)
+	Head(url string) (*http.Response, error)
+	Post(url, contentType string, body io.Reader) (*http.Response, error)
+	PostForm(url string, data url.Values) (*http.Response, error)
+}
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
@@ -49,7 +69,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client HTTPClient
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
@@ -408,7 +428,7 @@ func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
 
 // WithHTTPClient allows overriding the default httpClient, which is
 // automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
+func WithHTTPClient(httpClient HTTPClient) ClientOption {
 	return func(c *Client) error {
 		c.Client = httpClient
 		return nil
@@ -425,7 +445,7 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 }
 
 // newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
+func (c *Client) newHTTPClient() HTTPClient {
 	return &http.Client{
 		Timeout: c.requestTimeout,
 		Transport: &http.Transport{

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -44,14 +44,12 @@ type PostJsonJSONRequestBody PostJsonJSONBody
 // The interface matches all methods attached to the standard library HTTP Client
 // https://golang.org/pkg/net/http/#Client
 // type Client
-//     func (c *Client) CloseIdleConnections()
 //     func (c *Client) Do(req *Request) (*Response, error)
 //     func (c *Client) Get(url string) (resp *Response, err error)
 //     func (c *Client) Head(url string) (resp *Response, err error)
 //     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
 //     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
 type HTTPClient interface {
-	CloseIdleConnections()
 	Do(req *http.Request) (*http.Response, error)
 	Get(url string) (*http.Response, error)
 	Head(url string) (*http.Response, error)

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -720,6 +720,26 @@ func (a AdditionalPropertiesObject5) MarshalJSON() ([]byte, error) {
 	return json.Marshal(object)
 }
 
+// HTTPClient interface allows the user to use custom wrapped http clients to implement
+// additional features like retries, backoffs
+// The interface matches all methods attached to the standard library HTTP Client
+// https://golang.org/pkg/net/http/#Client
+// type Client
+//     func (c *Client) CloseIdleConnections()
+//     func (c *Client) Do(req *Request) (*Response, error)
+//     func (c *Client) Get(url string) (resp *Response, err error)
+//     func (c *Client) Head(url string) (resp *Response, err error)
+//     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
+//     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
+type HTTPClient interface {
+	CloseIdleConnections()
+	Do(req *http.Request) (*http.Response, error)
+	Get(url string) (*http.Response, error)
+	Head(url string) (*http.Response, error)
+	Post(url, contentType string, body io.Reader) (*http.Response, error)
+	PostForm(url string, data url.Values) (*http.Response, error)
+}
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
@@ -730,7 +750,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client HTTPClient
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
@@ -955,7 +975,7 @@ func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
 
 // WithHTTPClient allows overriding the default httpClient, which is
 // automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
+func WithHTTPClient(httpClient HTTPClient) ClientOption {
 	return func(c *Client) error {
 		c.Client = httpClient
 		return nil
@@ -972,7 +992,7 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 }
 
 // newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
+func (c *Client) newHTTPClient() HTTPClient {
 	return &http.Client{
 		Timeout: c.requestTimeout,
 		Transport: &http.Transport{

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -725,14 +725,12 @@ func (a AdditionalPropertiesObject5) MarshalJSON() ([]byte, error) {
 // The interface matches all methods attached to the standard library HTTP Client
 // https://golang.org/pkg/net/http/#Client
 // type Client
-//     func (c *Client) CloseIdleConnections()
 //     func (c *Client) Do(req *Request) (*Response, error)
 //     func (c *Client) Get(url string) (resp *Response, err error)
 //     func (c *Client) Head(url string) (resp *Response, err error)
 //     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
 //     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
 type HTTPClient interface {
-	CloseIdleConnections()
 	Do(req *http.Request) (*http.Response, error)
 	Get(url string) (*http.Response, error)
 	Head(url string) (*http.Response, error)

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -93,6 +94,26 @@ func (a Document_Fields) MarshalJSON() ([]byte, error) {
 	return json.Marshal(object)
 }
 
+// HTTPClient interface allows the user to use custom wrapped http clients to implement
+// additional features like retries, backoffs
+// The interface matches all methods attached to the standard library HTTP Client
+// https://golang.org/pkg/net/http/#Client
+// type Client
+//     func (c *Client) CloseIdleConnections()
+//     func (c *Client) Do(req *Request) (*Response, error)
+//     func (c *Client) Get(url string) (resp *Response, err error)
+//     func (c *Client) Head(url string) (resp *Response, err error)
+//     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
+//     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
+type HTTPClient interface {
+	CloseIdleConnections()
+	Do(req *http.Request) (*http.Response, error)
+	Get(url string) (*http.Response, error)
+	Head(url string) (*http.Response, error)
+	Post(url, contentType string, body io.Reader) (*http.Response, error)
+	PostForm(url string, data url.Values) (*http.Response, error)
+}
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
@@ -103,7 +124,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client HTTPClient
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
@@ -243,7 +264,7 @@ func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
 
 // WithHTTPClient allows overriding the default httpClient, which is
 // automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
+func WithHTTPClient(httpClient HTTPClient) ClientOption {
 	return func(c *Client) error {
 		c.Client = httpClient
 		return nil
@@ -260,7 +281,7 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 }
 
 // newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
+func (c *Client) newHTTPClient() HTTPClient {
 	return &http.Client{
 		Timeout: c.requestTimeout,
 		Transport: &http.Transport{

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -99,14 +99,12 @@ func (a Document_Fields) MarshalJSON() ([]byte, error) {
 // The interface matches all methods attached to the standard library HTTP Client
 // https://golang.org/pkg/net/http/#Client
 // type Client
-//     func (c *Client) CloseIdleConnections()
 //     func (c *Client) Do(req *Request) (*Response, error)
 //     func (c *Client) Get(url string) (resp *Response, err error)
 //     func (c *Client) Head(url string) (resp *Response, err error)
 //     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
 //     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
 type HTTPClient interface {
-	CloseIdleConnections()
 	Do(req *http.Request) (*http.Response, error)
 	Get(url string) (*http.Response, error)
 	Head(url string) (*http.Response, error)

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -13,6 +13,7 @@ import (
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/labstack/echo/v4"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -107,6 +108,26 @@ type GetQueryFormParams struct {
 	Co *ComplexObject `json:"co,omitempty"`
 }
 
+// HTTPClient interface allows the user to use custom wrapped http clients to implement
+// additional features like retries, backoffs
+// The interface matches all methods attached to the standard library HTTP Client
+// https://golang.org/pkg/net/http/#Client
+// type Client
+//     func (c *Client) CloseIdleConnections()
+//     func (c *Client) Do(req *Request) (*Response, error)
+//     func (c *Client) Get(url string) (resp *Response, err error)
+//     func (c *Client) Head(url string) (resp *Response, err error)
+//     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
+//     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
+type HTTPClient interface {
+	CloseIdleConnections()
+	Do(req *http.Request) (*http.Response, error)
+	Get(url string) (*http.Response, error)
+	Head(url string) (*http.Response, error)
+	Post(url, contentType string, body io.Reader) (*http.Response, error)
+	PostForm(url string, data url.Values) (*http.Response, error)
+}
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
@@ -117,7 +138,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client HTTPClient
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
@@ -1176,7 +1197,7 @@ func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
 
 // WithHTTPClient allows overriding the default httpClient, which is
 // automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
+func WithHTTPClient(httpClient HTTPClient) ClientOption {
 	return func(c *Client) error {
 		c.Client = httpClient
 		return nil
@@ -1193,7 +1214,7 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 }
 
 // newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
+func (c *Client) newHTTPClient() HTTPClient {
 	return &http.Client{
 		Timeout: c.requestTimeout,
 		Transport: &http.Transport{

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -113,14 +113,12 @@ type GetQueryFormParams struct {
 // The interface matches all methods attached to the standard library HTTP Client
 // https://golang.org/pkg/net/http/#Client
 // type Client
-//     func (c *Client) CloseIdleConnections()
 //     func (c *Client) Do(req *Request) (*Response, error)
 //     func (c *Client) Get(url string) (resp *Response, err error)
 //     func (c *Client) Head(url string) (resp *Response, err error)
 //     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
 //     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
 type HTTPClient interface {
-	CloseIdleConnections()
 	Do(req *http.Request) (*http.Response, error)
 	Get(url string) (*http.Response, error)
 	Head(url string) (*http.Response, error)

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -52,14 +52,12 @@ type Issue9JSONRequestBody Issue9JSONBody
 // The interface matches all methods attached to the standard library HTTP Client
 // https://golang.org/pkg/net/http/#Client
 // type Client
-//     func (c *Client) CloseIdleConnections()
 //     func (c *Client) Do(req *Request) (*Response, error)
 //     func (c *Client) Get(url string) (resp *Response, err error)
 //     func (c *Client) Head(url string) (resp *Response, err error)
 //     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
 //     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
 type HTTPClient interface {
-	CloseIdleConnections()
 	Do(req *http.Request) (*http.Response, error)
 	Get(url string) (*http.Response, error)
 	Head(url string) (*http.Response, error)

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -47,6 +47,26 @@ type Issue9Params struct {
 // Issue9RequestBody defines body for Issue9 for application/json ContentType.
 type Issue9JSONRequestBody Issue9JSONBody
 
+// HTTPClient interface allows the user to use custom wrapped http clients to implement
+// additional features like retries, backoffs
+// The interface matches all methods attached to the standard library HTTP Client
+// https://golang.org/pkg/net/http/#Client
+// type Client
+//     func (c *Client) CloseIdleConnections()
+//     func (c *Client) Do(req *Request) (*Response, error)
+//     func (c *Client) Get(url string) (resp *Response, err error)
+//     func (c *Client) Head(url string) (resp *Response, err error)
+//     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
+//     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
+type HTTPClient interface {
+	CloseIdleConnections()
+	Do(req *http.Request) (*http.Response, error)
+	Get(url string) (*http.Response, error)
+	Head(url string) (*http.Response, error)
+	Post(url, contentType string, body io.Reader) (*http.Response, error)
+	PostForm(url string, data url.Values) (*http.Response, error)
+}
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
@@ -57,7 +77,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client HTTPClient
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.
@@ -319,7 +339,7 @@ func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
 
 // WithHTTPClient allows overriding the default httpClient, which is
 // automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
+func WithHTTPClient(httpClient HTTPClient) ClientOption {
 	return func(c *Client) error {
 		c.Client = httpClient
 		return nil
@@ -336,7 +356,7 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 }
 
 // newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
+func (c *Client) newHTTPClient() HTTPClient {
 	return &http.Client{
 		Timeout: c.requestTimeout,
 		Transport: &http.Transport{

--- a/pkg/codegen/templates/client-with-responses.tmpl
+++ b/pkg/codegen/templates/client-with-responses.tmpl
@@ -81,7 +81,7 @@ func WithMaxIdleConnections(maxIdleConns uint) ClientOption {
 
 // WithHTTPClient allows overriding the default httpClient, which is
 // automatically created. This is useful for tests.
-func WithHTTPClient(httpClient *http.Client) ClientOption {
+func WithHTTPClient(httpClient HTTPClient) ClientOption {
 	return func(c *Client) error {
 		c.Client = httpClient
 		return nil
@@ -98,7 +98,7 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 }
 
 // newHTTPClient creates a httpClient for the current connection options.
-func (c *Client) newHTTPClient() *http.Client {
+func (c *Client) newHTTPClient() HTTPClient {
 	return &http.Client{
 		Timeout: c.requestTimeout,
 		Transport: &http.Transport{

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -3,14 +3,12 @@
 // The interface matches all methods attached to the standard library HTTP Client
 // https://golang.org/pkg/net/http/#Client
 // type Client
-//     func (c *Client) CloseIdleConnections()
 //     func (c *Client) Do(req *Request) (*Response, error)
 //     func (c *Client) Get(url string) (resp *Response, err error)
 //     func (c *Client) Head(url string) (resp *Response, err error)
 //     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
 //     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
 type HTTPClient interface {
-    CloseIdleConnections()
     Do(req *http.Request) (*http.Response, error)
     Get(url string) (*http.Response, error)
     Head(url string) (*http.Response, error)

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -1,3 +1,23 @@
+// HTTPClient interface allows the user to use custom wrapped http clients to implement
+// additional features like retries, backoffs
+// The interface matches all methods attached to the standard library HTTP Client
+// https://golang.org/pkg/net/http/#Client
+// type Client
+//     func (c *Client) CloseIdleConnections()
+//     func (c *Client) Do(req *Request) (*Response, error)
+//     func (c *Client) Get(url string) (resp *Response, err error)
+//     func (c *Client) Head(url string) (resp *Response, err error)
+//     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
+//     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
+type HTTPClient interface {
+    CloseIdleConnections()
+    Do(req *http.Request) (*http.Response, error)
+    Get(url string) (*http.Response, error)
+    Head(url string) (*http.Response, error)
+    Post(url, contentType string, body io.Reader) (*http.Response, error)
+    PostForm(url string, data url.Values) (*http.Response, error)
+}
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(req *http.Request, ctx context.Context) error
 
@@ -8,7 +28,7 @@ type Client struct {
 	Server string
 
 	// HTTP client with any customized settings, such as certificate chains.
-	Client *http.Client
+	Client HTTPClient
 
 	// A callback for modifying requests which are generated before sending over
 	// the network.

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -475,14 +475,12 @@ func Parse{{genResponseTypeName $opid}}(rsp *http.Response) (*{{genResponseTypeN
 // The interface matches all methods attached to the standard library HTTP Client
 // https://golang.org/pkg/net/http/#Client
 // type Client
-//     func (c *Client) CloseIdleConnections()
 //     func (c *Client) Do(req *Request) (*Response, error)
 //     func (c *Client) Get(url string) (resp *Response, err error)
 //     func (c *Client) Head(url string) (resp *Response, err error)
 //     func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
 //     func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
 type HTTPClient interface {
-    CloseIdleConnections()
     Do(req *http.Request) (*http.Response, error)
     Get(url string) (*http.Response, error)
     Head(url string) (*http.Response, error)


### PR DESCRIPTION
The standard library doesn't support features like Retry of error and different backoff strategies for the same. The recommended approach is to wrap the standard library HTTP client package with any custom handling logic. (See ianlancetaylor's reponse in https://github.com/golang/go/issues/16047)
I propose adding an HTTPClient interface with the same method signatures as the standard library HTTP Client 
```
    type Client
        func (c *Client) CloseIdleConnections()
        func (c *Client) Do(req *Request) (*Response, error)
        func (c *Client) Get(url string) (resp *Response, err error)
        func (c *Client) Head(url string) (resp *Response, err error)
        func (c *Client) Post(url, contentType string, body io.Reader) (resp *Response, err error)
        func (c *Client) PostForm(url string, data url.Values) (resp *Response, err error)
```