### PR TITLE
flag.Int returns a pointer

### DIFF
--- a/examples/petstore-expanded/chi/petstore.go
+++ b/examples/petstore-expanded/chi/petstore.go
@@ -25,7 +25,7 @@ func main() {
 
 	s := &http.Server{
 		Handler: h,
-		Addr:    fmt.Sprintf("0.0.0.0:%d", port),
+		Addr:    fmt.Sprintf("0.0.0.0:%d", *port),
 	}
 
 	// And we serve HTTP until the world ends.


### PR DESCRIPTION
## This PR

Fixes a typo where a pointer is used, instead of an int.
See https://golang.org/pkg/flag/