### PR TITLE
fix typo

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -38,7 +38,7 @@ func main() {
 	)
 	flag.StringVar(&packageName, "package", "", "The package name for generated code")
 	flag.StringVar(&generate, "generate", "types,client,server,spec",
-		`Comma-separated list of code to generate; valid options: "types", client", "chi-server", "server", "skip-fmt", '"spec"  (default types,client,server,"spec")`)
+		`Comma-separated list of code to generate; valid options: "types", "client", "chi-server", "server", "skip-fmt", "spec"`)
 	flag.StringVar(&outputFile, "o", "", "Where to output generated code, stdout is default")
 	flag.Parse()
 


### PR DESCRIPTION
```
 » oapi-codegen --help
Usage of oapi-codegen:
  -generate string
        Comma-separated list of code to generate; valid options: "types", client", "chi-server", "server", "skip-fmt", '"spec"  (default types,client,server,"spec") (default "types,client,server,spec")
```
to

```
 » oapi-codegen  --help
Usage of oapi-codegen:
  -generate string
        Comma-separated list of code to generate; valid options: "types", "client", "chi-server", "server", "skip-fmt", "spec" (default "types,client,server,spec")
```