### PR TITLE
Fixing query parsing of date parameters

### DIFF
--- a/pkg/runtime/bindparam.go
+++ b/pkg/runtime/bindparam.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/labstack/echo/v4"
 )
 
@@ -299,6 +300,7 @@ func BindQueryParameter(style string, explode bool, required bool, paramName str
 			// different things based on destination type.
 			values, found := queryParams[paramName]
 			var err error
+
 			switch k {
 			case reflect.Slice:
 				// In the slice case, we simply use the arguments provided by
@@ -430,6 +432,12 @@ func BindQueryParameter(style string, explode bool, required bool, paramName str
 // We don't try to be smart here, if the field exists as a query argument,
 // set its value.
 func bindParamsToExplodedObject(paramName string, values url.Values, dest interface{}) error {
+	// special handling for custom types
+	switch dest.(type) {
+	case *types.Date:
+		return BindStringToObject(values.Get(paramName), dest)
+	}
+
 	v := reflect.Indirect(reflect.ValueOf(dest))
 	if v.Type().Kind() != reflect.Struct {
 		return echo.NewHTTPError(http.StatusInternalServerError,

--- a/pkg/runtime/bindstring.go
+++ b/pkg/runtime/bindstring.go
@@ -19,6 +19,8 @@ import (
 	"reflect"
 	"strconv"
 	"time"
+
+	"github.com/deepmap/oapi-codegen/pkg/types"
 )
 
 // This function takes a string, and attempts to assign it to the destination
@@ -68,13 +70,21 @@ func BindStringToObject(src string, dst interface{}) error {
 			v.SetBool(val)
 		}
 	case reflect.Struct:
-		// Time is a special case of a struct that we handle
-		if dstTime, ok := dst.(*time.Time); ok {
+		switch dstType := dst.(type) {
+		case *time.Time:
+			// Time is a special case of a struct that we handle
 			parsedTime, err := time.Parse(time.RFC3339Nano, src)
 			if err != nil {
 				return fmt.Errorf("error parsing '%s' as RFC3339 time: %s", src, err)
 			}
-			*dstTime = parsedTime
+			*dstType = parsedTime
+			return nil
+		case *types.Date:
+			parsedTime, err := time.Parse(types.DateFormat, src)
+			if err != nil {
+				return fmt.Errorf("error parsing '%s' as date: %s", src, err)
+			}
+			dstType.Time = parsedTime
 			return nil
 		}
 		fallthrough

--- a/pkg/types/date.go
+++ b/pkg/types/date.go
@@ -5,14 +5,14 @@ import (
 	"time"
 )
 
-const dateFormat = "2006-01-02"
+const DateFormat = "2006-01-02"
 
 type Date struct {
 	time.Time
 }
 
 func (d Date) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.Time.Format(dateFormat))
+	return json.Marshal(d.Time.Format(DateFormat))
 }
 
 func (d *Date) UnmarshalJSON(data []byte) error {
@@ -21,7 +21,7 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	parsed, err := time.Parse(dateFormat, dateStr)
+	parsed, err := time.Parse(DateFormat, dateStr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Looking at [this issue](https://github.com/deepmap/oapi-codegen/issues/104), I neglected to handle query parsing on the server side when implementing the custom Date type.

This attempts to rectify that, with the caveat that this could probably stand a more elegant solution if additional custom types are added.