### PR TITLE
Allow filtering by tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,14 @@ So, for example, if you would like to produce only the server code, you could
 run `oapi-generate --generate types,server`. You could generate `types` and `server`
 into separate files, but both are required for the server code.  
 
+`oapi-codegen` can filter paths base on their tags in the openapi definition.
+Use either `--include-tags` or `--exclude-tags` followed by a comma-separated
+list of tags. For instance, to generate a server that serves all paths except
+those tagged with `auth` or `admin`, use the argument,
+`--exclude-tags="auth,admin"`. To generate a server that only handles `admin`
+paths, use the argument `include-tags="admin"`. When neither of these arguments
+is present, all paths are generated.
+
 ## What's missing or incomplete
 
 This code is still young, and not complete, since we're filling it in as we

--- a/README.md
+++ b/README.md
@@ -400,16 +400,16 @@ you can specify any combination of those.
  the generated file in case the spec contains weird strings.
 
 So, for example, if you would like to produce only the server code, you could
-run `oapi-generate --generate types,server`. You could generate `types` and `server`
-into separate files, but both are required for the server code.  
+run `oapi-generate -generate types,server`. You could generate `types` and
+`server` into separate files, but both are required for the server code.
 
 `oapi-codegen` can filter paths base on their tags in the openapi definition.
-Use either `--include-tags` or `--exclude-tags` followed by a comma-separated
-list of tags. For instance, to generate a server that serves all paths except
-those tagged with `auth` or `admin`, use the argument,
-`--exclude-tags="auth,admin"`. To generate a server that only handles `admin`
-paths, use the argument `include-tags="admin"`. When neither of these arguments
-is present, all paths are generated.
+Use either `-include-tags` or `-exclude-tags` followed by a comma-separated list
+of tags. For instance, to generate a server that serves all paths except those
+tagged with `auth` or `admin`, use the argument, `-exclude-tags="auth,admin"`.
+To generate a server that only handles `admin` paths, use the argument
+`-include-tags="admin"`. When neither of these arguments is present, all paths
+are generated.
 
 ## What's missing or incomplete
 

--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -62,7 +62,7 @@ func main() {
 	}
 
 	opts := codegen.Options{}
-	for _, g := range strings.Split(generate, ",") {
+	for _, g := range splitCSVArg(generate) {
 		switch g {
 		case "client":
 			opts.GenerateClient = true
@@ -83,8 +83,8 @@ func main() {
 		}
 	}
 
-	opts.IncludeTags = strings.Split(includeTags, ",")
-	opts.ExcludeTags = strings.Split(excludeTags, ",")
+	opts.IncludeTags = splitCSVArg(includeTags)
+	opts.ExcludeTags = splitCSVArg(excludeTags)
 
 	if opts.GenerateEchoServer && opts.GenerateChiServer {
 		errExit("can not specify both server and chi-server targets simultaneously")
@@ -108,4 +108,20 @@ func main() {
 	} else {
 		fmt.Println(code)
 	}
+}
+
+func splitCSVArg(input string) []string {
+	input = strings.TrimSpace(input)
+	if len(input) == 0 {
+		return nil
+	}
+	splitInput := strings.Split(input, ",")
+	args := make([]string, 0, len(splitInput))
+	for _, s := range splitInput {
+		s = strings.TrimSpace(s)
+		if len(s) > 0 {
+			args = append(args, s)
+		}
+	}
+	return args
 }

--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -35,11 +35,15 @@ func main() {
 		packageName string
 		generate    string
 		outputFile  string
+		includeTags string
+		excludeTags string
 	)
 	flag.StringVar(&packageName, "package", "", "The package name for generated code")
 	flag.StringVar(&generate, "generate", "types,client,server,spec",
 		`Comma-separated list of code to generate; valid options: "types", "client", "chi-server", "server", "skip-fmt", "spec"`)
 	flag.StringVar(&outputFile, "o", "", "Where to output generated code, stdout is default")
+	flag.StringVar(&includeTags, "include-tags", "", "Only include operations with the given tags. Comma-separated list of tags.")
+	flag.StringVar(&excludeTags, "exclude-tags", "", "Exclude operations that are tagged with the given tags. Comma-separated list of tags.")
 	flag.Parse()
 
 	if flag.NArg() < 1 {
@@ -78,6 +82,9 @@ func main() {
 			os.Exit(1)
 		}
 	}
+
+	opts.IncludeTags = strings.Split(includeTags, ",")
+	opts.ExcludeTags = strings.Split(excludeTags, ",")
 
 	if opts.GenerateEchoServer && opts.GenerateChiServer {
 		errExit("can not specify both server and chi-server targets simultaneously")

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -31,12 +31,14 @@ import (
 
 // Options defines the optional code to generate.
 type Options struct {
-	GenerateChiServer  bool // GenerateChiServer specifies whether to generate chi server boilerplate
-	GenerateEchoServer bool // GenerateEchoServer specifies whether to generate echo server boilerplate
-	GenerateClient     bool // GenerateClient specifies whether to generate client boilerplate
-	GenerateTypes      bool // GenerateTypes specifies whether to generate type definitions
-	EmbedSpec          bool // Whether to embed the swagger spec in the generated code
-	SkipFmt            bool // Whether to skip go fmt on the generated code
+	GenerateChiServer  bool     // GenerateChiServer specifies whether to generate chi server boilerplate
+	GenerateEchoServer bool     // GenerateEchoServer specifies whether to generate echo server boilerplate
+	GenerateClient     bool     // GenerateClient specifies whether to generate client boilerplate
+	GenerateTypes      bool     // GenerateTypes specifies whether to generate type definitions
+	EmbedSpec          bool     // Whether to embed the swagger spec in the generated code
+	SkipFmt            bool     // Whether to skip go fmt on the generated code
+	IncludeTags        []string // Only include operations that have one of these tags. Ignored when empty.
+	ExcludeTags        []string // Exclude operations that have one of these tags. Ignored when empty.
 }
 
 type goImport struct {
@@ -85,6 +87,8 @@ var (
 // the descriptions we've built up above from the schema objects.
 // opts defines
 func Generate(swagger *openapi3.Swagger, packageName string, opts Options) (string, error) {
+	filterOperationsByTag(swagger, opts)
+
 	// This creates the golang templates text package
 	t := template.New("oapi-codegen").Funcs(TemplateFunctions)
 	// This parses all of our own template files into the template object
@@ -491,4 +495,47 @@ func SanitizeCode(goCode string) string {
 	// remove any byte-order-marks which break Go-Code
 	// See: https://groups.google.com/forum/#!topic/golang-nuts/OToNIPdfkks
 	return strings.Replace(goCode, "\uFEFF", "", -1)
+}
+
+func filterOperationsByTag(swagger *openapi3.Swagger, opts Options) {
+	if len(opts.ExcludeTags) > 0 {
+		excludeOperationsWithTags(swagger.Paths, opts.ExcludeTags)
+	}
+	if len(opts.IncludeTags) > 0 {
+		includeOperationsWithTags(swagger.Paths, opts.IncludeTags, false)
+	}
+}
+
+func excludeOperationsWithTags(paths openapi3.Paths, tags []string) {
+	includeOperationsWithTags(paths, tags, true)
+}
+
+func includeOperationsWithTags(paths openapi3.Paths, tags []string, exclude bool) {
+	for _, pathItem := range paths {
+		ops := pathItem.Operations()
+		names := make([]string, 0, len(ops))
+		for name, op := range ops {
+			if operationHasTag(op, tags) == exclude {
+				names = append(names, name)
+			}
+		}
+		for _, name := range names {
+			pathItem.SetOperation(name, nil)
+		}
+	}
+}
+
+//operationHasTag returns true if the operation is tagged with any of tags
+func operationHasTag(op *openapi3.Operation, tags []string) bool {
+	if op == nil {
+		return false
+	}
+	for _, hasTag := range op.Tags {
+		for _, wantTag := range tags {
+			if hasTag == wantTag {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -9,7 +9,6 @@ import (
 
 	examplePetstoreClient "github.com/deepmap/oapi-codegen/examples/petstore-expanded"
 	examplePetstore "github.com/deepmap/oapi-codegen/examples/petstore-expanded/echo/api"
-
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/golangci/lint-1"
 	"github.com/stretchr/testify/assert"
@@ -70,6 +69,51 @@ func TestExamplePetStoreParseFunction(t *testing.T) {
 	assert.Equal(t, "testpet", findPetByIDResponse.JSON200.Name)
 	assert.NotNil(t, findPetByIDResponse.JSON200.Tag)
 	assert.Equal(t, "cat", *findPetByIDResponse.JSON200.Tag)
+}
+
+func TestFilterOperationsByTag(t *testing.T) {
+	packageName := "testswagger"
+	t.Run("include tags", func(t *testing.T) {
+		opts := Options{
+			GenerateClient:     true,
+			GenerateEchoServer: true,
+			GenerateTypes:      true,
+			EmbedSpec:          true,
+			IncludeTags:        []string{"hippo", "giraffe", "cat"},
+		}
+
+		// Get a spec from the test definition in this file:
+		swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(testOpenAPIDefinition))
+		assert.NoError(t, err)
+
+		// Run our code generation:
+		code, err := Generate(swagger, packageName, opts)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, code)
+		assert.NotContains(t, code, `"/test/:name"`)
+		assert.Contains(t, code, `"/cat"`)
+	})
+
+	t.Run("exclude tags", func(t *testing.T) {
+		opts := Options{
+			GenerateClient:     true,
+			GenerateEchoServer: true,
+			GenerateTypes:      true,
+			EmbedSpec:          true,
+			ExcludeTags:        []string{"hippo", "giraffe", "cat"},
+		}
+
+		// Get a spec from the test definition in this file:
+		swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(testOpenAPIDefinition))
+		assert.NoError(t, err)
+
+		// Run our code generation:
+		code, err := Generate(swagger, packageName, opts)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, code)
+		assert.Contains(t, code, `"/test/:name"`)
+		assert.NotContains(t, code, `"/cat"`)
+	})
 }
 
 func TestExampleOpenAPICodeGeneration(t *testing.T) {


### PR DESCRIPTION
I am working on an api that we want implemented by multiple services. The spec has tags like "auth" and "bot" that correspond to the service that will serve the endpoint.  It is handy to be able to generate a server for just the endpoints that have one of these tags.

This PR adds two fields to Options, `IncludeTags` and `ExcludeTags`.  When running `Generate`, the operations in `swagger` will be filtered based on the tags listed in those options.  When `IncludeTags` is non-empty, all operations that aren't tagged with at least one of the listed tags will be removed.  When `ExcludeTags` is non-empty, all operations that are tagged with at least one of the listed tags will be removed.

This has the side effect of modifying the `swagger` pointer being passed to `Generate`.  I don't think that has any practical consequence. If it does, I can find a way to do a deep copy of swagger before filtering.

The new options are exposed to the cli using the `-include-tags` and `-exclude-tags` arguments.