### PR TITLE
Add securitySchemes scopes to chi middleware

### DIFF
--- a/pkg/codegen/templates/chi-middleware.tmpl
+++ b/pkg/codegen/templates/chi-middleware.tmpl
@@ -40,6 +40,10 @@ func {{$opid}}Ctx(next http.Handler) http.Handler {
     ctx = context.WithValue(ctx, "{{$varName}}", {{$varName}})
     {{end}}
 
+{{range .SecurityDefinitions}}
+    ctx = context.WithValue(ctx, "{{.ProviderName}}.Scopes", {{toStringArray .Scopes}})
+{{end}}
+
     {{if .RequiresParamObject}}
       // Parameter object where we will unmarshal all parameters from the context
       var params {{.OperationId}}Params

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -133,6 +133,10 @@ func {{$opid}}Ctx(next http.Handler) http.Handler {
     ctx = context.WithValue(ctx, "{{$varName}}", {{$varName}})
     {{end}}
 
+{{range .SecurityDefinitions}}
+    ctx = context.WithValue(ctx, "{{.ProviderName}}.Scopes", {{toStringArray .Scopes}})
+{{end}}
+
     {{if .RequiresParamObject}}
       // Parameter object where we will unmarshal all parameters from the context
       var params {{.OperationId}}Params


### PR DESCRIPTION
Currently the chi implementation is not adding the scopes to the
middleware like it's done by the regular server implementation.

For now also within Chi the scopes are getting set correctly.
