### PR TITLE
Pass validator's errors inside of echo.HTTPError

### DIFF
--- a/pkg/middleware/oapi_validate.go
+++ b/pkg/middleware/oapi_validate.go
@@ -120,14 +120,25 @@ func ValidateRequestFromContext(ctx echo.Context, router *openapi3filter.Router,
 			// Split up the verbose error by lines and return the first one
 			// openapi errors seem to be multi-line with a decent message on the first
 			errorLines := strings.Split(e.Error(), "\n")
-			return echo.NewHTTPError(http.StatusBadRequest, errorLines[0])
+			return &echo.HTTPError{
+				Code:     http.StatusBadRequest
+				Message:  errorLines[0],
+				Internal: err,
+			}
 		case *openapi3filter.SecurityRequirementsError:
-			return echo.NewHTTPError(http.StatusForbidden, e.Error())
+			return &echo.HTTPError{
+				Code:     http.StatusForbidden
+				Message:  e.Error(),
+				Internal: err,
+			}
 		default:
 			// This should never happen today, but if our upstream code changes,
 			// we don't want to crash the server, so handle the unexpected error.
-			return echo.NewHTTPError(http.StatusInternalServerError,
-				fmt.Sprintf("error validating request: %s", err))
+			return &echo.HTTPError{
+				Code: http.StatusInternalServerError,
+				Message: fmt.Sprintf("error validating request: %s", err),
+				Internal: err,
+			}
 		}
 	}
 	return nil

--- a/pkg/middleware/oapi_validate.go
+++ b/pkg/middleware/oapi_validate.go
@@ -121,13 +121,13 @@ func ValidateRequestFromContext(ctx echo.Context, router *openapi3filter.Router,
 			// openapi errors seem to be multi-line with a decent message on the first
 			errorLines := strings.Split(e.Error(), "\n")
 			return &echo.HTTPError{
-				Code:     http.StatusBadRequest
+				Code:     http.StatusBadRequest,
 				Message:  errorLines[0],
 				Internal: err,
 			}
 		case *openapi3filter.SecurityRequirementsError:
 			return &echo.HTTPError{
-				Code:     http.StatusForbidden
+				Code:     http.StatusForbidden,
 				Message:  e.Error(),
 				Internal: err,
 			}


### PR DESCRIPTION
Wondering why validator's errors silenced, when they can be very useful within custom echo.HTTPErrorHandler. For example for building custom 400 error responses with error field name, or for more verbose logging on SecurityRequirementsError.

So just add original error into echo.HTTPError{Internal}, make it available at the application's level.