### PR TITLE
chi HandlerFromMux, receive interface to make it more flexible

### DIFF
--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -175,7 +175,7 @@ func Handler(si ServerInterface) http.Handler {
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.
-func HandlerFromMux(si ServerInterface, r *chi.Mux) http.Handler {
+func HandlerFromMux(si ServerInterface, r chi.Router) http.Handler {
 	r.Group(func(r chi.Router) {
 		r.Use(FindPetsCtx)
 		r.Get("/pets", si.FindPets)

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -365,7 +365,7 @@ func Handler(si ServerInterface) http.Handler {
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.
-func HandlerFromMux(si ServerInterface, r *chi.Mux) http.Handler {
+func HandlerFromMux(si ServerInterface, r chi.Router) http.Handler {
 	r.Group(func(r chi.Router) {
 		r.Use(GetSimpleCtx)
 		r.Get("/get-simple", si.GetSimple)

--- a/pkg/codegen/templates/chi-handler.tmpl
+++ b/pkg/codegen/templates/chi-handler.tmpl
@@ -4,7 +4,7 @@ func Handler(si ServerInterface) http.Handler {
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.
-func HandlerFromMux(si ServerInterface, r *chi.Mux) http.Handler {
+func HandlerFromMux(si ServerInterface, r chi.Router) http.Handler {
 {{range .}}r.Group(func(r chi.Router) {
   r.Use({{.OperationId}}Ctx)
   r.{{.Method | lower | title }}("{{.Path | swaggerUriToChiUri}}", si.{{.OperationId}})

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -79,7 +79,7 @@ func Handler(si ServerInterface) http.Handler {
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.
-func HandlerFromMux(si ServerInterface, r *chi.Mux) http.Handler {
+func HandlerFromMux(si ServerInterface, r chi.Router) http.Handler {
 {{range .}}r.Group(func(r chi.Router) {
   r.Use({{.OperationId}}Ctx)
   r.{{.Method | lower | title }}("{{.Path | swaggerUriToChiUri}}", si.{{.OperationId}})


### PR DESCRIPTION
```
	r.Group(func(r chi.Router) {
		r.Use(s.tokenMW())
		r.Handle("/api", HandlerFromMux(s, r))
	})
```
If HandlerFromMux receives interface, it makes it function much more flexible.
For example, we can use it inside r.Group.