### PR TITLE
Fixed a panic when property is nil

### DIFF
--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -182,12 +182,15 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 
 					pSchema.RefType = typeName
 				}
-
+				description := ""
+				if p.Value != nil {
+					description = p.Value.Description
+				}
 				prop := Property{
 					JsonFieldName: pName,
 					Schema:        pSchema,
 					Required:      required,
-					Description:   p.Value.Description,
+					Description:   description,
 				}
 				outSchema.Properties = append(outSchema.Properties, prop)
 			}


### PR DESCRIPTION
Because Value is a pointer, in some cases, it could be nil which causes panics even if the OpenAPI document is valid (I was able to successfully generate code with this added null check).