### PR TITLE
Another attempted fix for date param parsing

### DIFF
--- a/examples/petstore-expanded/chi/petstore_test.go
+++ b/examples/petstore-expanded/chi/petstore_test.go
@@ -71,8 +71,8 @@ func TestPetStore(t *testing.T) {
 
 	t.Run("List all pets", func(t *testing.T) {
 		store.Pets = map[int64]api.Pet{
-			1: api.Pet{},
-			2: api.Pet{},
+			1: {},
+			2: {},
 		}
 
 		// Now, list all pets, we should have two
@@ -89,12 +89,12 @@ func TestPetStore(t *testing.T) {
 		tag := "TagOfFido"
 
 		store.Pets = map[int64]api.Pet{
-			1: api.Pet{
+			1: {
 				NewPet: api.NewPet{
 					Tag: &tag,
 				},
 			},
-			2: api.Pet{},
+			2: {},
 		}
 
 		// Filter pets by tag, we should have 1
@@ -109,8 +109,8 @@ func TestPetStore(t *testing.T) {
 
 	t.Run("Filter pets by tag", func(t *testing.T) {
 		store.Pets = map[int64]api.Pet{
-			1: api.Pet{},
-			2: api.Pet{},
+			1: {},
+			2: {},
 		}
 
 		// Filter pets by non existent tag, we should have 0
@@ -125,8 +125,8 @@ func TestPetStore(t *testing.T) {
 
 	t.Run("Delete pets", func(t *testing.T) {
 		store.Pets = map[int64]api.Pet{
-			1: api.Pet{},
-			2: api.Pet{},
+			1: {},
+			2: {},
 		}
 
 		// Let's delete non-existent pet

--- a/internal/test/client/doc.go
+++ b/internal/test/client/doc.go
@@ -1,4 +1,3 @@
 package client
 
 //go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen --package=client -o client.gen.go client.yaml
-

--- a/pkg/codegen/operations_test.go
+++ b/pkg/codegen/operations_test.go
@@ -20,45 +20,45 @@ import (
 
 func TestGenerateDefaultOperationID(t *testing.T) {
 	type test struct {
-		op string
-		path string
-		want string
+		op      string
+		path    string
+		want    string
 		wantErr bool
 	}
 
-	suite := []test {
+	suite := []test{
 		{
-			op: http.MethodGet,
-			path: "/v1/foo/bar",
-			want: "GetV1FooBar",
+			op:      http.MethodGet,
+			path:    "/v1/foo/bar",
+			want:    "GetV1FooBar",
 			wantErr: false,
 		},
 		{
-			op: http.MethodGet,
-			path: "/v1/foo/bar/",
-			want: "GetV1FooBar",
+			op:      http.MethodGet,
+			path:    "/v1/foo/bar/",
+			want:    "GetV1FooBar",
 			wantErr: false,
 		},
 		{
-			op: http.MethodPost,
-			path: "/v1",
-			want: "PostV1",
+			op:      http.MethodPost,
+			path:    "/v1",
+			want:    "PostV1",
 			wantErr: false,
 		},
 		{
-			op: http.MethodPost,
-			path: "v1",
-			want: "PostV1",
+			op:      http.MethodPost,
+			path:    "v1",
+			want:    "PostV1",
 			wantErr: false,
 		},
 		{
-			path: "v1",
-			want: "",
+			path:    "v1",
+			want:    "",
 			wantErr: true,
 		},
 		{
-			path: "",
-			want: "PostV1",
+			path:    "",
+			want:    "PostV1",
 			wantErr: true,
 		},
 	}
@@ -71,7 +71,7 @@ func TestGenerateDefaultOperationID(t *testing.T) {
 			}
 		}
 
-		if test.wantErr	{
+		if test.wantErr {
 			return
 		}
 		if got != test.want {

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -878,4 +878,3 @@ func Parse(t *template.Template) (*template.Template, error) {
 	}
 	return t, nil
 }
-

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -65,7 +65,7 @@ func ToCamelCase(str string) string {
 		if unicode.IsUpper(v) {
 			n += string(v)
 		}
-			if unicode.IsDigit(v) {
+		if unicode.IsDigit(v) {
 			n += string(v)
 		}
 		if unicode.IsLower(v) {
@@ -76,7 +76,7 @@ func ToCamelCase(str string) string {
 			}
 		}
 
-		 if strings.ContainsRune(separators, v) {
+		if strings.ContainsRune(separators, v) {
 			capNext = true
 		} else {
 			capNext = false

--- a/pkg/middleware/oapi_validate.go
+++ b/pkg/middleware/oapi_validate.go
@@ -135,8 +135,8 @@ func ValidateRequestFromContext(ctx echo.Context, router *openapi3filter.Router,
 			// This should never happen today, but if our upstream code changes,
 			// we don't want to crash the server, so handle the unexpected error.
 			return &echo.HTTPError{
-				Code: http.StatusInternalServerError,
-				Message: fmt.Sprintf("error validating request: %s", err),
+				Code:     http.StatusInternalServerError,
+				Message:  fmt.Sprintf("error validating request: %s", err),
 				Internal: err,
 			}
 		}

--- a/pkg/runtime/bindparam.go
+++ b/pkg/runtime/bindparam.go
@@ -443,7 +443,6 @@ func bindParamsToExplodedObject(paramName string, values url.Values, dest interf
 
 	// special handling for custom types
 	if t.ConvertibleTo(types.BaseDateType) {
-		fmt.Printf("It's convertible! %s", t.Name())
 		return BindStringToObject(values.Get(paramName), dest)
 	}
 

--- a/pkg/runtime/bindparam.go
+++ b/pkg/runtime/bindparam.go
@@ -432,19 +432,20 @@ func BindQueryParameter(style string, explode bool, required bool, paramName str
 // We don't try to be smart here, if the field exists as a query argument,
 // set its value.
 func bindParamsToExplodedObject(paramName string, values url.Values, dest interface{}) error {
-	// special handling for custom types
-	switch dest.(type) {
-	case *types.Date:
-		return BindStringToObject(values.Get(paramName), dest)
-	}
-
 	v := reflect.Indirect(reflect.ValueOf(dest))
+
 	if v.Type().Kind() != reflect.Struct {
 		return echo.NewHTTPError(http.StatusInternalServerError,
 			"unmarshaling query arg '%s' into wrong type", paramName)
 	}
 
 	t := v.Type()
+
+	// special handling for custom types
+	if t.ConvertibleTo(types.BaseDateType) {
+		fmt.Printf("It's convertible! %s", t.Name())
+		return BindStringToObject(values.Get(paramName), dest)
+	}
 
 	for i := 0; i < t.NumField(); i++ {
 		fieldT := t.Field(i)

--- a/pkg/runtime/bindparam_test.go
+++ b/pkg/runtime/bindparam_test.go
@@ -261,7 +261,7 @@ func TestBindQueryParameter(t *testing.T) {
 	})
 
 	t.Run("form", func(t *testing.T) {
-		expected := &types.Date{Time:time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)}
+		expected := &types.Date{Time: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)}
 		birthday := &types.Date{}
 		queryParams := url.Values{
 			"birthday": {"2020-01-01"},

--- a/pkg/runtime/bindparam_test.go
+++ b/pkg/runtime/bindparam_test.go
@@ -243,7 +243,7 @@ func TestBindQueryParameter(t *testing.T) {
 		expectedDeepObject := &ID{
 			FirstName: &expectedName,
 			Role:      "admin",
-			Birthday:  &types.Date{time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)},
+			Birthday:  &types.Date{Time: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)},
 		}
 
 		actual := new(ID)
@@ -261,7 +261,7 @@ func TestBindQueryParameter(t *testing.T) {
 	})
 
 	t.Run("form", func(t *testing.T) {
-		expected := &types.Date{time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)}
+		expected := &types.Date{Time:time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)}
 		birthday := &types.Date{}
 		queryParams := url.Values{
 			"birthday": {"2020-01-01"},

--- a/pkg/runtime/bindstring.go
+++ b/pkg/runtime/bindstring.go
@@ -70,6 +70,17 @@ func BindStringToObject(src string, dst interface{}) error {
 			v.SetBool(val)
 		}
 	case reflect.Struct:
+		// special handling for custom types
+		if t.ConvertibleTo(types.BaseDateType) {
+			parsedTime, err := time.Parse(types.DateFormat, src)
+			if err != nil {
+				return fmt.Errorf("error parsing '%s' as date: %s", src, err)
+			}
+			// set the Time field of the struct
+			v.Field(0).Set(reflect.ValueOf(parsedTime))
+			return nil
+		}
+
 		switch dstType := dst.(type) {
 		case *time.Time:
 			// Time is a special case of a struct that we handle
@@ -78,13 +89,6 @@ func BindStringToObject(src string, dst interface{}) error {
 				return fmt.Errorf("error parsing '%s' as RFC3339 time: %s", src, err)
 			}
 			*dstType = parsedTime
-			return nil
-		case *types.Date:
-			parsedTime, err := time.Parse(types.DateFormat, src)
-			if err != nil {
-				return fmt.Errorf("error parsing '%s' as date: %s", src, err)
-			}
-			dstType.Time = parsedTime
 			return nil
 		}
 		fallthrough

--- a/pkg/runtime/styleparam_test.go
+++ b/pkg/runtime/styleparam_test.go
@@ -15,7 +15,9 @@ package runtime
 
 import (
 	"testing"
+	"time"
 
+	"github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,6 +35,11 @@ func TestStyleParam(t *testing.T) {
 	dict := map[string]interface{}{}
 	dict["firstName"] = "Alex"
 	dict["role"] = "admin"
+
+	type testDateType types.Date
+	testDate := testDateType{
+		Time: time.Date(2020, 2, 7, 0, 0, 0, 0, time.UTC),
+	}
 
 	// ---------------------------- Simple Style -------------------------------
 
@@ -168,6 +175,14 @@ func TestStyleParam(t *testing.T) {
 	result, err = StyleParam("form", true, "id", dict)
 	assert.NoError(t, err)
 	assert.EqualValues(t, "firstName=Alex&role=admin", result)
+
+	result, err = StyleParam("form", true, "dateOfBirth", testDate)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "dateOfBirth=2020-02-07", result)
+
+	result, err = StyleParam("form", false, "dateOfBirth", testDate)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "dateOfBirth=2020-02-07", result)
 
 	// ------------------------  spaceDelimited Style --------------------------
 

--- a/pkg/types/date.go
+++ b/pkg/types/date.go
@@ -2,13 +2,23 @@ package types
 
 import (
 	"encoding/json"
+	"reflect"
 	"time"
 )
 
 const DateFormat = "2006-01-02"
 
+var BaseDateType = reflect.TypeOf(Date{})
+
 type Date struct {
 	time.Time
+
+	// Top level *Params structs may contain types that wrap this type,
+	// and we need a way to identify those types as needing special
+	// handling.  We will use reflect.ConvertibleTo to do this, assuming this
+	// field will make this data structure unlikely to collide with types
+	// accidentally.
+	__oapiBaseDateType__ struct{}
 }
 
 func (d Date) MarshalJSON() ([]byte, error) {

--- a/pkg/types/date_test.go
+++ b/pkg/types/date_test.go
@@ -13,7 +13,7 @@ func TestDate_MarshalJSON(t *testing.T) {
 	b := struct {
 		DateField Date	`json:"date"`
 	}{
-		DateField: Date{testDate},
+		DateField: Date{Time:testDate},
 	}
 	jsonBytes, err := json.Marshal(b)
 	assert.NoError(t, err)

--- a/pkg/types/date_test.go
+++ b/pkg/types/date_test.go
@@ -11,9 +11,9 @@ import (
 func TestDate_MarshalJSON(t *testing.T) {
 	testDate := time.Date(2019, 4, 1, 0, 0, 0, 0, time.UTC)
 	b := struct {
-		DateField Date	`json:"date"`
+		DateField Date `json:"date"`
 	}{
-		DateField: Date{Time:testDate},
+		DateField: Date{Time: testDate},
 	}
 	jsonBytes, err := json.Marshal(b)
 	assert.NoError(t, err)
@@ -24,7 +24,7 @@ func TestDate_UnmarshalJSON(t *testing.T) {
 	testDate := time.Date(2019, 4, 1, 0, 0, 0, 0, time.UTC)
 	jsonStr := `{"date":"2019-04-01"}`
 	b := struct {
-		DateField Date	`json:"date"`
+		DateField Date `json:"date"`
 	}{}
 	err := json.Unmarshal([]byte(jsonStr), &b)
 	assert.NoError(t, err)


### PR DESCRIPTION
This is related to https://github.com/deepmap/oapi-codegen/pull/130, so perhaps @ticruz38 would like to collaborate here.  I've attempted to bring in his changes `pkg/runtime/bindstring.go`.

We have continued to find problems with query string date parameters not being parsed properly, and this was related to the fact that the generator is creating new types for the Params structs, like so:

```go
type At openapi_types.Date
```

This makes it difficult to reason about how to handle these types, since a simple type switch won't work.  I've attempted to create a unique signature for our custom type that will help us reflect on what these new types are and how they should be parsed.

This strategy seems to be working in our manual tests, but I will admit to being a little uneasy about using reflect in this way.  Any input is appreciated.