### PR TITLE
Add support for user-provided templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,4 +454,16 @@ Go file.
 Afterwards you should run `go generate ./...`, and the templates will be updated
  accordingly.
 
+Alternatively, you can provide custom templates to override built-in ones using
+the `-templates` flag specifying a path to a directory containing templates
+files. These files **must** be named identically to built-in template files
+(see `pkg/codegen/templates/*.tmpl` in the source code), and will be interpreted
+on-the-fly at run time. Example:
 
+    $ ls -1 my-templates/
+    client.tmpl
+    typedef.tmpl
+    $ oapi-codegen \
+        -templates my-templates/ \
+        -generate types,client \
+        petstore-expanded.yaml

--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -46,7 +46,7 @@ func main() {
 	flag.StringVar(&outputFile, "o", "", "Where to output generated code, stdout is default")
 	flag.StringVar(&includeTags, "include-tags", "", "Only include operations with the given tags. Comma-separated list of tags.")
 	flag.StringVar(&excludeTags, "exclude-tags", "", "Exclude operations that are tagged with the given tags. Comma-separated list of tags.")
-	flag.StringVar(&templatesDir, "templates", "", "Path to directory containing template overrides")
+	flag.StringVar(&templatesDir, "templates", "", "Path to directory containing user templates")
 	flag.Parse()
 
 	if flag.NArg() < 1 {
@@ -136,25 +136,7 @@ func splitCSVArg(input string) []string {
 }
 
 func loadTemplateOverrides(templatesDir string) (map[string]string, error) {
-	var (
-		knownTemplates = map[string]interface{}{
-			"additional-properties.tmpl": nil,
-			"chi-handler.tmpl":           nil,
-			"chi-interface.tmpl":         nil,
-			"chi-middleware.tmpl":        nil,
-			"client-with-responses.tmpl": nil,
-			"client.tmpl":                nil,
-			"imports.tmpl":               nil,
-			"inline.tmpl":                nil,
-			"param-types.tmpl":           nil,
-			"register.tmpl":              nil,
-			"request-bodies.tmpl":        nil,
-			"server-interface.tmpl":      nil,
-			"typedef.tmpl":               nil,
-			"wrappers.tmpl":              nil,
-		}
-		templates = make(map[string]string)
-	)
+	var templates = make(map[string]string)
 
 	if templatesDir == "" {
 		return templates, nil
@@ -166,13 +148,11 @@ func loadTemplateOverrides(templatesDir string) (map[string]string, error) {
 	}
 
 	for _, f := range files {
-		if _, ok := knownTemplates[f.Name()]; ok {
-			data, err := ioutil.ReadFile(path.Join(templatesDir, f.Name()))
-			if err != nil {
-				return nil, err
-			}
-			templates[f.Name()] = string(data)
+		data, err := ioutil.ReadFile(path.Join(templatesDir, f.Name()))
+		if err != nil {
+			return nil, err
 		}
+		templates[f.Name()] = string(data)
 	}
 
 	return templates, nil

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -32,14 +32,15 @@ import (
 
 // Options defines the optional code to generate.
 type Options struct {
-	GenerateChiServer  bool     // GenerateChiServer specifies whether to generate chi server boilerplate
-	GenerateEchoServer bool     // GenerateEchoServer specifies whether to generate echo server boilerplate
-	GenerateClient     bool     // GenerateClient specifies whether to generate client boilerplate
-	GenerateTypes      bool     // GenerateTypes specifies whether to generate type definitions
-	EmbedSpec          bool     // Whether to embed the swagger spec in the generated code
-	SkipFmt            bool     // Whether to skip go fmt on the generated code
-	IncludeTags        []string // Only include operations that have one of these tags. Ignored when empty.
-	ExcludeTags        []string // Exclude operations that have one of these tags. Ignored when empty.
+	GenerateChiServer  bool              // GenerateChiServer specifies whether to generate chi server boilerplate
+	GenerateEchoServer bool              // GenerateEchoServer specifies whether to generate echo server boilerplate
+	GenerateClient     bool              // GenerateClient specifies whether to generate client boilerplate
+	GenerateTypes      bool              // GenerateTypes specifies whether to generate type definitions
+	EmbedSpec          bool              // Whether to embed the swagger spec in the generated code
+	SkipFmt            bool              // Whether to skip go fmt on the generated code
+	IncludeTags        []string          // Only include operations that have one of these tags. Ignored when empty.
+	ExcludeTags        []string          // Exclude operations that have one of these tags. Ignored when empty.
+	UserTemplates      map[string]string // Override built-in templates from user-provided files
 }
 
 type goImport struct {
@@ -97,6 +98,14 @@ func Generate(swagger *openapi3.Swagger, packageName string, opts Options) (stri
 	t, err := templates.Parse(t)
 	if err != nil {
 		return "", errors.Wrap(err, "error parsing oapi-codegen templates")
+	}
+
+	// Override built-in templates with user-provided versions
+	for tplName, tplContent := range opts.UserTemplates {
+		tpl := t.New(tplName)
+		if _, err := tpl.Parse(tplContent); err != nil {
+			return "", errors.Wrapf(err, "error parsing user-provided template %q", tplName)
+		}
 	}
 
 	ops, err := OperationDefinitions(swagger)

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -101,10 +101,12 @@ func Generate(swagger *openapi3.Swagger, packageName string, opts Options) (stri
 	}
 
 	// Override built-in templates with user-provided versions
-	for tplName, tplContent := range opts.UserTemplates {
-		tpl := t.New(tplName)
-		if _, err := tpl.Parse(tplContent); err != nil {
-			return "", errors.Wrapf(err, "error parsing user-provided template %q", tplName)
+	for _, tpl := range t.Templates() {
+		if _, ok := opts.UserTemplates[tpl.Name()]; ok {
+			utpl := t.New(tpl.Name())
+			if _, err := utpl.Parse(opts.UserTemplates[tpl.Name()]); err != nil {
+				return "", errors.Wrapf(err, "error parsing user-provided template %q", tpl.Name())
+			}
 		}
 	}
 

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -59,6 +59,37 @@ func TestExamplePetStoreCodeGeneration(t *testing.T) {
 	assert.Len(t, problems, 0)
 }
 
+func TestExamplePetStoreCodeGenerationWithUserTemplates(t *testing.T) {
+
+	userTemplates := map[string]string{"typedef.tmpl": "//blah"}
+
+	// Input vars for code generation:
+	packageName := "api"
+	opts := Options{
+		GenerateTypes: true,
+		UserTemplates: userTemplates,
+	}
+
+	// Get a spec from the example PetStore definition:
+	swagger, err := examplePetstore.GetSwagger()
+	assert.NoError(t, err)
+
+	// Run our code generation:
+	code, err := Generate(swagger, packageName, opts)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, code)
+
+	// Check that we have valid (formattable) code:
+	_, err = format.Source([]byte(code))
+	assert.NoError(t, err)
+
+	// Check that we have a package:
+	assert.Contains(t, code, "package api")
+
+	// Check that the built-in template has been overriden
+	assert.Contains(t, code, "//blah")
+}
+
 func TestExamplePetStoreParseFunction(t *testing.T) {
 
 	bodyBytes := []byte(`{"id": 5, "name": "testpet", "tag": "cat"}`)


### PR DESCRIPTION
This change introduces a new `-templates` command flag to enable users
to override code generation templates at runtime instead of having to
recompile the binary after having edited the built-in templates.