### PR TITLE
Add command line option to override types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,3 +467,6 @@ on-the-fly at run time. Example:
         -templates my-templates/ \
         -generate types,client \
         petstore-expanded.yaml
+
+Overriding default type mappings can be accomplished with `-type-mappings`.
+For example use unsigned integers with `-type-mappings integer=uint32`.

--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -39,6 +39,7 @@ func main() {
 		includeTags  string
 		excludeTags  string
 		templatesDir string
+		typeMappings string
 	)
 	flag.StringVar(&packageName, "package", "", "The package name for generated code")
 	flag.StringVar(&generate, "generate", "types,client,server,spec",
@@ -47,6 +48,7 @@ func main() {
 	flag.StringVar(&includeTags, "include-tags", "", "Only include operations with the given tags. Comma-separated list of tags.")
 	flag.StringVar(&excludeTags, "exclude-tags", "", "Exclude operations that are tagged with the given tags. Comma-separated list of tags.")
 	flag.StringVar(&templatesDir, "templates", "", "Path to directory containing user templates")
+	flag.StringVar(&typeMappings, "type-mappings", "", "Comma-separated list of type overrides,  like 'integer=uint64'.")
 	flag.Parse()
 
 	if flag.NArg() < 1 {
@@ -88,6 +90,17 @@ func main() {
 
 	opts.IncludeTags = splitCSVArg(includeTags)
 	opts.ExcludeTags = splitCSVArg(excludeTags)
+
+	// Type mapping overrides
+	for _, g := range splitCSVArg(typeMappings) {
+		parts := strings.Split(g, "=")
+		if len(parts) != 2 {
+			fmt.Printf("Invalid type override, expected <type>=<value>, received '%s'", g)
+			os.Exit(1)
+		}
+
+		codegen.TypeMappings[parts[0]] = parts[1]
+	}
 
 	if opts.GenerateEchoServer && opts.GenerateChiServer {
 		errExit("can not specify both server and chi-server targets simultaneously")

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -165,6 +165,8 @@ func TestExampleOpenAPICodeGeneration(t *testing.T) {
 		GenerateTypes:      true,
 		EmbedSpec:          true,
 	}
+	TypeMappings["integer"] = "uint64"
+	defer delete(TypeMappings, "integer")
 
 	// Get a spec from the test definition in this file:
 	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(testOpenAPIDefinition))
@@ -205,7 +207,7 @@ type getTestByNameResponse struct {
 
 	// Check the client method signatures:
 	assert.Contains(t, code, "type GetTestByNameParams struct {")
-	assert.Contains(t, code, "Top *int `json:\"$top,omitempty\"`")
+	assert.Contains(t, code, "Top *uint64 `json:\"$top,omitempty\"`")
 	assert.Contains(t, code, "func (c *Client) GetTestByName(ctx context.Context, name string, params *GetTestByNameParams) (*http.Response, error) {")
 	assert.Contains(t, code, "func (c *ClientWithResponses) GetTestByNameWithResponse(ctx context.Context, name string, params *GetTestByNameParams) (*getTestByNameResponse, error) {")
 

--- a/pkg/runtime/bindstring.go
+++ b/pkg/runtime/bindstring.go
@@ -54,6 +54,12 @@ func BindStringToObject(src string, dst interface{}) error {
 		if err == nil {
 			v.SetInt(val)
 		}
+	case reflect.Uint, reflect.Uint32, reflect.Uint64:
+		var val uint64
+		val, err = strconv.ParseUint(src, 10, 64)
+		if err == nil {
+			v.SetUint(val)
+		}
 	case reflect.String:
 		v.SetString(src)
 		err = nil

--- a/pkg/runtime/bindstring_test.go
+++ b/pkg/runtime/bindstring_test.go
@@ -36,6 +36,9 @@ func TestBindStringToObject(t *testing.T) {
 	assert.NoError(t, BindStringToObject("124", &i64))
 	assert.Equal(t, int64(124), i64)
 
+	assert.NoError(t, BindStringToObject("-124", &i64))
+	assert.Equal(t, int64(-124), i64)
+
 	assert.Error(t, BindStringToObject("5.7", &i64))
 	assert.Error(t, BindStringToObject("foo", &i64))
 	assert.Error(t, BindStringToObject("1,2,3", &i64))
@@ -44,9 +47,30 @@ func TestBindStringToObject(t *testing.T) {
 	assert.NoError(t, BindStringToObject("12", &i32))
 	assert.Equal(t, int32(12), i32)
 
+	assert.NoError(t, BindStringToObject("-12", &i32))
+	assert.Equal(t, int32(-12), i32)
+
 	assert.Error(t, BindStringToObject("5.7", &i32))
 	assert.Error(t, BindStringToObject("foo", &i32))
 	assert.Error(t, BindStringToObject("1,2,3", &i32))
+
+	var ui64 uint64
+	assert.NoError(t, BindStringToObject("124", &ui64))
+	assert.Equal(t, uint64(124), ui64)
+
+	assert.Error(t, BindStringToObject("-124", &ui64))
+	assert.Error(t, BindStringToObject("5.7", &ui64))
+	assert.Error(t, BindStringToObject("foo", &ui64))
+	assert.Error(t, BindStringToObject("1,2,3", &ui64))
+
+	var ui32 uint32
+	assert.NoError(t, BindStringToObject("12", &ui32))
+	assert.Equal(t, uint32(12), ui32)
+
+	assert.Error(t, BindStringToObject("-12", &ui32))
+	assert.Error(t, BindStringToObject("5.7", &ui32))
+	assert.Error(t, BindStringToObject("foo", &ui32))
+	assert.Error(t, BindStringToObject("1,2,3", &ui32))
 
 	var b bool
 	assert.NoError(t, BindStringToObject("True", &b))


### PR DESCRIPTION
My API uses unsigned integers so I needed a way to override the type mappings. The CLI argument is similar to the one used by `openapi-generator`.

At first I tried adding the new `TypeMappings` variable to the codegen `Options`, rather than making the global configuration I have here. However that required passing a new variable into many functions to get the mappings down to `GenerateGoSchema`. I'm happy to adjust the implementation if you could suggest a better approach.