### PR TITLE
Respect an http error returned by the authentication function

### DIFF
--- a/pkg/middleware/oapi_validate.go
+++ b/pkg/middleware/oapi_validate.go
@@ -126,6 +126,12 @@ func ValidateRequestFromContext(ctx echo.Context, router *openapi3filter.Router,
 				Internal: err,
 			}
 		case *openapi3filter.SecurityRequirementsError:
+			for _, err := range e.Errors {
+				httpErr, ok := err.(*echo.HTTPError)
+				if ok {
+					return httpErr
+				}
+			}
 			return &echo.HTTPError{
 				Code:     http.StatusForbidden,
 				Message:  e.Error(),
@@ -135,8 +141,8 @@ func ValidateRequestFromContext(ctx echo.Context, router *openapi3filter.Router,
 			// This should never happen today, but if our upstream code changes,
 			// we don't want to crash the server, so handle the unexpected error.
 			return &echo.HTTPError{
-				Code: http.StatusInternalServerError,
-				Message: fmt.Sprintf("error validating request: %s", err),
+				Code:     http.StatusInternalServerError,
+				Message:  fmt.Sprintf("error validating request: %s", err),
 				Internal: err,
 			}
 		}


### PR DESCRIPTION
Currently, the `OapiRequestValidator` middleware always responds with a 403 if all authentication functions return an error.  The authentication function should be able to distinguish a 401 (missing credentials) from a 403 (invalid credentials).  The change in this branch makes it so the middleware respects an `echo.HTTPError` if one is returned from an authentication function.  The tests demonstrate how the middleware can be configured to generate a 401 instead of a 403.