### PR TITLE
Fix time serialization panic (reflect.Value.Interface: cannot return value obtained from unexported field or method)

### DIFF
--- a/pkg/runtime/styleparam_test.go
+++ b/pkg/runtime/styleparam_test.go
@@ -15,6 +15,7 @@ package runtime
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -33,6 +34,7 @@ func TestStyleParam(t *testing.T) {
 	dict := map[string]interface{}{}
 	dict["firstName"] = "Alex"
 	dict["role"] = "admin"
+	timestamp, _ := time.Parse(time.RFC3339, "2020-01-01T22:00:00Z")
 
 	// ---------------------------- Simple Style -------------------------------
 
@@ -68,6 +70,22 @@ func TestStyleParam(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, "firstName=Alex,role=admin", result)
 
+	result, err = StyleParam("simple", false, "id", timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "2020-01-01T22:00:00Z", result)
+
+	result, err = StyleParam("simple", true, "id", timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "2020-01-01T22:00:00Z", result)
+
+	result, err = StyleParam("simple", false, "id", &timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "2020-01-01T22:00:00Z", result)
+
+	result, err = StyleParam("simple", true, "id", &timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "2020-01-01T22:00:00Z", result)
+
 	// ----------------------------- Label Style -------------------------------
 
 	result, err = StyleParam("label", false, "id", primitive)
@@ -101,6 +119,22 @@ func TestStyleParam(t *testing.T) {
 	result, err = StyleParam("label", true, "id", dict)
 	assert.NoError(t, err)
 	assert.EqualValues(t, ".firstName=Alex.role=admin", result)
+
+	result, err = StyleParam("label", false, "id", timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, ".2020-01-01T22:00:00Z", result)
+
+	result, err = StyleParam("label", true, "id", timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, ".2020-01-01T22:00:00Z", result)
+
+	result, err = StyleParam("label", false, "id", &timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, ".2020-01-01T22:00:00Z", result)
+
+	result, err = StyleParam("label", true, "id", &timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, ".2020-01-01T22:00:00Z", result)
 
 	// ----------------------------- Matrix Style ------------------------------
 
@@ -136,6 +170,22 @@ func TestStyleParam(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, ";firstName=Alex;role=admin", result)
 
+	result, err = StyleParam("matrix", false, "id", timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, ";id=2020-01-01T22:00:00Z", result)
+
+	result, err = StyleParam("matrix", true, "id", timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, ";id=2020-01-01T22:00:00Z", result)
+
+	result, err = StyleParam("matrix", false, "id", &timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, ";id=2020-01-01T22:00:00Z", result)
+
+	result, err = StyleParam("matrix", true, "id", &timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, ";id=2020-01-01T22:00:00Z", result)
+
 	// ------------------------------ Form Style -------------------------------
 	result, err = StyleParam("form", false, "id", primitive)
 	assert.NoError(t, err)
@@ -169,6 +219,22 @@ func TestStyleParam(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, "firstName=Alex&role=admin", result)
 
+	result, err = StyleParam("form", false, "id", timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "id=2020-01-01T22:00:00Z", result)
+
+	result, err = StyleParam("form", true, "id", timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "id=2020-01-01T22:00:00Z", result)
+
+	result, err = StyleParam("form", false, "id", &timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "id=2020-01-01T22:00:00Z", result)
+
+	result, err = StyleParam("form", true, "id", &timestamp)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "id=2020-01-01T22:00:00Z", result)
+
 	// ------------------------  spaceDelimited Style --------------------------
 
 	result, err = StyleParam("spaceDelimited", false, "id", primitive)
@@ -196,6 +262,19 @@ func TestStyleParam(t *testing.T) {
 
 	result, err = StyleParam("spaceDelimited", true, "id", dict)
 	assert.Error(t, err)
+
+	result, err = StyleParam("spaceDelimited", false, "id", timestamp)
+	assert.Error(t, err)
+
+	result, err = StyleParam("spaceDelimited", true, "id", timestamp)
+	assert.Error(t, err)
+
+	result, err = StyleParam("spaceDelimited", false, "id", &timestamp)
+	assert.Error(t, err)
+
+	result, err = StyleParam("spaceDelimited", true, "id", &timestamp)
+	assert.Error(t, err)
+
 	// -------------------------  pipeDelimited Style --------------------------
 
 	result, err = StyleParam("pipeDelimited", false, "id", primitive)
@@ -224,6 +303,18 @@ func TestStyleParam(t *testing.T) {
 	result, err = StyleParam("pipeDelimited", true, "id", dict)
 	assert.Error(t, err)
 
+	result, err = StyleParam("pipeDelimited", false, "id", timestamp)
+	assert.Error(t, err)
+
+	result, err = StyleParam("pipeDelimited", true, "id", timestamp)
+	assert.Error(t, err)
+
+	result, err = StyleParam("pipeDelimited", false, "id", &timestamp)
+	assert.Error(t, err)
+
+	result, err = StyleParam("pipeDelimited", true, "id", &timestamp)
+	assert.Error(t, err)
+
 	// ---------------------------  deepObject Style ---------------------------
 	result, err = StyleParam("deepObject", false, "id", primitive)
 	assert.Error(t, err)
@@ -248,6 +339,19 @@ func TestStyleParam(t *testing.T) {
 	result, err = StyleParam("deepObject", true, "id", dict)
 	assert.NoError(t, err)
 	assert.EqualValues(t, "id[firstName]=Alex&id[role]=admin", result)
+
+	result, err = StyleParam("deepObject", false, "id", timestamp)
+	assert.Error(t, err)
+
+	result, err = StyleParam("deepObject", true, "id", timestamp)
+	assert.Error(t, err)
+
+	result, err = StyleParam("deepObject", false, "id", &timestamp)
+	assert.Error(t, err)
+
+	result, err = StyleParam("deepObject", true, "id", &timestamp)
+	assert.Error(t, err)
+
 
 	// Misc tests
 	// Test type aliases


### PR DESCRIPTION
Fixes #153 

- Fix time serialization
  * For query parameter, time is stored as a direct reference
    (non-pointer) which was previously not supported and
    caused the panic:
    panic: reflect.Value.Interface: cannot return value obtained from unexported field or method
  * It should not be possible to serialize time alone as a
    deepObject, as it should be handled as primitive.
- Add tests for time serialization

