### PR TITLE
feat: prune unused components by default

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[Makefile]
+indent_size = 8
+indent_style = tab
+
+[{go.mod,go.sum,*.go}]
+indent_size = 4
+indent_style = tab
+
+[{*.yml,*.yaml}]
+indent_size = 2
+indent_style = space

--- a/README.md
+++ b/README.md
@@ -398,6 +398,8 @@ you can specify any combination of those.
 - `spec`: embed the OpenAPI spec into the generated code as a gzipped blob. This
 - `skip-fmt`: skip running `go fmt` on the generated code. This is useful for debugging
  the generated file in case the spec contains weird strings.
+- `skip-prune`: skip pruning unused components from the spec prior to generating
+ the code.
 
 So, for example, if you would like to produce only the server code, you could
 run `oapi-generate -generate types,server`. You could generate `types` and

--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -42,7 +42,7 @@ func main() {
 	)
 	flag.StringVar(&packageName, "package", "", "The package name for generated code")
 	flag.StringVar(&generate, "generate", "types,client,server,spec",
-		`Comma-separated list of code to generate; valid options: "types", "client", "chi-server", "server", "skip-fmt", "spec"`)
+		`Comma-separated list of code to generate; valid options: "types", "client", "chi-server", "server", "spec", "skip-fmt", "skip-prune"`)
 	flag.StringVar(&outputFile, "o", "", "Where to output generated code, stdout is default")
 	flag.StringVar(&includeTags, "include-tags", "", "Only include operations with the given tags. Comma-separated list of tags.")
 	flag.StringVar(&excludeTags, "exclude-tags", "", "Exclude operations that are tagged with the given tags. Comma-separated list of tags.")
@@ -79,6 +79,8 @@ func main() {
 			opts.EmbedSpec = true
 		case "skip-fmt":
 			opts.SkipFmt = true
+		case "skip-prune":
+			opts.SkipPrune = true
 		default:
 			fmt.Printf("unknown generate option %s\n", g)
 			flag.PrintDefaults()

--- a/internal/test/components/components.yaml
+++ b/internal/test/components/components.yaml
@@ -5,6 +5,38 @@ info:
   license:
     name: MIT
 paths:
+  /ensure-everything-is-referenced:
+    get:
+      operationId: ensureEverythingIsReferenced
+      description: |
+        This endpoint exists so that components can be created in this
+        spec and not be pruned
+    # TODO: figure out why uncommenting this causes failures
+    #   parameters:
+    #     - $ref: "#/components/parameters/ParameterObject"
+      requestBody:
+        $ref: "#/components/requestBodies/RequestBody"
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  one:
+                    $ref: "#/components/schemas/AdditionalPropertiesObject1"
+                  two:
+                    $ref: "#/components/schemas/AdditionalPropertiesObject2"
+                  three:
+                    $ref: "#/components/schemas/AdditionalPropertiesObject3"
+                  four:
+                    $ref: "#/components/schemas/AdditionalPropertiesObject4"
+                  five:
+                    $ref: "#/components/schemas/AdditionalPropertiesObject5"
+                  jsonField:
+                    $ref: "#/components/schemas/ObjectWithJsonField"
+        default:
+          $ref: "#/components/responses/ResponseObject"
   /params_with_add_props:
     get:
       operationId: ParamsWithAddProps

--- a/internal/test/components/components.yaml
+++ b/internal/test/components/components.yaml
@@ -173,6 +173,7 @@ components:
             type: string
   parameters:
     ParameterObject:
+      name: ParameterObject
       description: a parameter
       in: query
       content:

--- a/internal/test/schemas/schemas.yaml
+++ b/internal/test/schemas/schemas.yaml
@@ -8,6 +8,25 @@ info:
 servers:
   - url: http://openapitest.deepmap.ai
 paths:
+  /ensure-everything-is-referenced:
+    get:
+      operationId: ensureEverythingIsReferenced
+      description: |
+        This endpoint exists so that components can be created in this
+        spec and not be pruned
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  anyType1:
+                    $ref: "#/components/schemas/AnyType1"
+                  anyType2:
+                    $ref: "#/components/schemas/AnyType2"
+                  customStringType:
+                    $ref: "#/components/schemas/CustomStringType"
   /issues/9:
     get:
       operationId: Issue9

--- a/internal/test/server/server_moq.gen.go
+++ b/internal/test/server/server_moq.gen.go
@@ -9,13 +9,16 @@ import (
 )
 
 var (
-	lockServerInterfaceMockCreateResource     sync.RWMutex
-	lockServerInterfaceMockCreateResource2    sync.RWMutex
-	lockServerInterfaceMockGetSimple          sync.RWMutex
-	lockServerInterfaceMockGetWithArgs        sync.RWMutex
-	lockServerInterfaceMockGetWithContentType sync.RWMutex
-	lockServerInterfaceMockGetWithReferences  sync.RWMutex
-	lockServerInterfaceMockUpdateResource3    sync.RWMutex
+	lockServerInterfaceMockCreateResource           sync.RWMutex
+	lockServerInterfaceMockCreateResource2          sync.RWMutex
+	lockServerInterfaceMockGetEveryTypeOptional     sync.RWMutex
+	lockServerInterfaceMockGetReservedKeyword       sync.RWMutex
+	lockServerInterfaceMockGetResponseWithReference sync.RWMutex
+	lockServerInterfaceMockGetSimple                sync.RWMutex
+	lockServerInterfaceMockGetWithArgs              sync.RWMutex
+	lockServerInterfaceMockGetWithContentType       sync.RWMutex
+	lockServerInterfaceMockGetWithReferences        sync.RWMutex
+	lockServerInterfaceMockUpdateResource3          sync.RWMutex
 )
 
 // Ensure, that ServerInterfaceMock does implement ServerInterface.
@@ -33,6 +36,15 @@ var _ ServerInterface = &ServerInterfaceMock{}
 //             },
 //             CreateResource2Func: func(w http.ResponseWriter, r *http.Request)  {
 // 	               panic("mock out the CreateResource2 method")
+//             },
+//             GetEveryTypeOptionalFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 	               panic("mock out the GetEveryTypeOptional method")
+//             },
+//             GetReservedKeywordFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 	               panic("mock out the GetReservedKeyword method")
+//             },
+//             GetResponseWithReferenceFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 	               panic("mock out the GetResponseWithReference method")
 //             },
 //             GetSimpleFunc: func(w http.ResponseWriter, r *http.Request)  {
 // 	               panic("mock out the GetSimple method")
@@ -62,6 +74,15 @@ type ServerInterfaceMock struct {
 	// CreateResource2Func mocks the CreateResource2 method.
 	CreateResource2Func func(w http.ResponseWriter, r *http.Request)
 
+	// GetEveryTypeOptionalFunc mocks the GetEveryTypeOptional method.
+	GetEveryTypeOptionalFunc func(w http.ResponseWriter, r *http.Request)
+
+	// GetReservedKeywordFunc mocks the GetReservedKeyword method.
+	GetReservedKeywordFunc func(w http.ResponseWriter, r *http.Request)
+
+	// GetResponseWithReferenceFunc mocks the GetResponseWithReference method.
+	GetResponseWithReferenceFunc func(w http.ResponseWriter, r *http.Request)
+
 	// GetSimpleFunc mocks the GetSimple method.
 	GetSimpleFunc func(w http.ResponseWriter, r *http.Request)
 
@@ -88,6 +109,27 @@ type ServerInterfaceMock struct {
 		}
 		// CreateResource2 holds details about calls to the CreateResource2 method.
 		CreateResource2 []struct {
+			// W is the w argument value.
+			W http.ResponseWriter
+			// R is the r argument value.
+			R *http.Request
+		}
+		// GetEveryTypeOptional holds details about calls to the GetEveryTypeOptional method.
+		GetEveryTypeOptional []struct {
+			// W is the w argument value.
+			W http.ResponseWriter
+			// R is the r argument value.
+			R *http.Request
+		}
+		// GetReservedKeyword holds details about calls to the GetReservedKeyword method.
+		GetReservedKeyword []struct {
+			// W is the w argument value.
+			W http.ResponseWriter
+			// R is the r argument value.
+			R *http.Request
+		}
+		// GetResponseWithReference holds details about calls to the GetResponseWithReference method.
+		GetResponseWithReference []struct {
 			// W is the w argument value.
 			W http.ResponseWriter
 			// R is the r argument value.
@@ -198,6 +240,111 @@ func (mock *ServerInterfaceMock) CreateResource2Calls() []struct {
 	lockServerInterfaceMockCreateResource2.RLock()
 	calls = mock.calls.CreateResource2
 	lockServerInterfaceMockCreateResource2.RUnlock()
+	return calls
+}
+
+// GetEveryTypeOptional calls GetEveryTypeOptionalFunc.
+func (mock *ServerInterfaceMock) GetEveryTypeOptional(w http.ResponseWriter, r *http.Request) {
+	if mock.GetEveryTypeOptionalFunc == nil {
+		panic("ServerInterfaceMock.GetEveryTypeOptionalFunc: method is nil but ServerInterface.GetEveryTypeOptional was just called")
+	}
+	callInfo := struct {
+		W http.ResponseWriter
+		R *http.Request
+	}{
+		W: w,
+		R: r,
+	}
+	lockServerInterfaceMockGetEveryTypeOptional.Lock()
+	mock.calls.GetEveryTypeOptional = append(mock.calls.GetEveryTypeOptional, callInfo)
+	lockServerInterfaceMockGetEveryTypeOptional.Unlock()
+	mock.GetEveryTypeOptionalFunc(w, r)
+}
+
+// GetEveryTypeOptionalCalls gets all the calls that were made to GetEveryTypeOptional.
+// Check the length with:
+//     len(mockedServerInterface.GetEveryTypeOptionalCalls())
+func (mock *ServerInterfaceMock) GetEveryTypeOptionalCalls() []struct {
+	W http.ResponseWriter
+	R *http.Request
+} {
+	var calls []struct {
+		W http.ResponseWriter
+		R *http.Request
+	}
+	lockServerInterfaceMockGetEveryTypeOptional.RLock()
+	calls = mock.calls.GetEveryTypeOptional
+	lockServerInterfaceMockGetEveryTypeOptional.RUnlock()
+	return calls
+}
+
+// GetReservedKeyword calls GetReservedKeywordFunc.
+func (mock *ServerInterfaceMock) GetReservedKeyword(w http.ResponseWriter, r *http.Request) {
+	if mock.GetReservedKeywordFunc == nil {
+		panic("ServerInterfaceMock.GetReservedKeywordFunc: method is nil but ServerInterface.GetReservedKeyword was just called")
+	}
+	callInfo := struct {
+		W http.ResponseWriter
+		R *http.Request
+	}{
+		W: w,
+		R: r,
+	}
+	lockServerInterfaceMockGetReservedKeyword.Lock()
+	mock.calls.GetReservedKeyword = append(mock.calls.GetReservedKeyword, callInfo)
+	lockServerInterfaceMockGetReservedKeyword.Unlock()
+	mock.GetReservedKeywordFunc(w, r)
+}
+
+// GetReservedKeywordCalls gets all the calls that were made to GetReservedKeyword.
+// Check the length with:
+//     len(mockedServerInterface.GetReservedKeywordCalls())
+func (mock *ServerInterfaceMock) GetReservedKeywordCalls() []struct {
+	W http.ResponseWriter
+	R *http.Request
+} {
+	var calls []struct {
+		W http.ResponseWriter
+		R *http.Request
+	}
+	lockServerInterfaceMockGetReservedKeyword.RLock()
+	calls = mock.calls.GetReservedKeyword
+	lockServerInterfaceMockGetReservedKeyword.RUnlock()
+	return calls
+}
+
+// GetResponseWithReference calls GetResponseWithReferenceFunc.
+func (mock *ServerInterfaceMock) GetResponseWithReference(w http.ResponseWriter, r *http.Request) {
+	if mock.GetResponseWithReferenceFunc == nil {
+		panic("ServerInterfaceMock.GetResponseWithReferenceFunc: method is nil but ServerInterface.GetResponseWithReference was just called")
+	}
+	callInfo := struct {
+		W http.ResponseWriter
+		R *http.Request
+	}{
+		W: w,
+		R: r,
+	}
+	lockServerInterfaceMockGetResponseWithReference.Lock()
+	mock.calls.GetResponseWithReference = append(mock.calls.GetResponseWithReference, callInfo)
+	lockServerInterfaceMockGetResponseWithReference.Unlock()
+	mock.GetResponseWithReferenceFunc(w, r)
+}
+
+// GetResponseWithReferenceCalls gets all the calls that were made to GetResponseWithReference.
+// Check the length with:
+//     len(mockedServerInterface.GetResponseWithReferenceCalls())
+func (mock *ServerInterfaceMock) GetResponseWithReferenceCalls() []struct {
+	W http.ResponseWriter
+	R *http.Request
+} {
+	var calls []struct {
+		W http.ResponseWriter
+		R *http.Request
+	}
+	lockServerInterfaceMockGetResponseWithReference.RLock()
+	calls = mock.calls.GetResponseWithReference
+	lockServerInterfaceMockGetResponseWithReference.RUnlock()
 	return calls
 }
 

--- a/internal/test/test-schema.yaml
+++ b/internal/test/test-schema.yaml
@@ -7,6 +7,35 @@ info:
 servers:
   - url: http://openapitest.deepmap.ai
 paths:
+  /response-with-reference:
+    get:
+      summary: get response with reference
+      operationId: getResponseWithReference
+      responses:
+        '200':
+          $ref: "#/components/responses/ResponseWithReference"
+  /reserved-keyword:
+    get:
+      summary: get with reserved keyword
+      operationId: getReservedKeyword
+      responses:
+        '200':
+          description: example of a response with a reserved keyword
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReservedKeyword"
+  /every-type-optional:
+    get:
+      summary: get every type optional
+      operationId: getEveryTypeOptional
+      responses:
+        '200':
+          description: a example of every type with an optional value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EveryTypeOptional"
   /get-simple:
     get:
       summary: Get resource via simple path
@@ -176,6 +205,10 @@ components:
       schema:
         type: string
   schemas:
+    ThisShouldBePruned:
+      properties:
+        name:
+          type: string
     # This is intentionally named in snake case
     some_object:
       properties:

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -110,51 +110,6 @@ func TestExamplePetStoreParseFunction(t *testing.T) {
 	assert.Equal(t, "cat", *findPetByIDResponse.JSON200.Tag)
 }
 
-func TestFilterOperationsByTag(t *testing.T) {
-	packageName := "testswagger"
-	t.Run("include tags", func(t *testing.T) {
-		opts := Options{
-			GenerateClient:     true,
-			GenerateEchoServer: true,
-			GenerateTypes:      true,
-			EmbedSpec:          true,
-			IncludeTags:        []string{"hippo", "giraffe", "cat"},
-		}
-
-		// Get a spec from the test definition in this file:
-		swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(testOpenAPIDefinition))
-		assert.NoError(t, err)
-
-		// Run our code generation:
-		code, err := Generate(swagger, packageName, opts)
-		assert.NoError(t, err)
-		assert.NotEmpty(t, code)
-		assert.NotContains(t, code, `"/test/:name"`)
-		assert.Contains(t, code, `"/cat"`)
-	})
-
-	t.Run("exclude tags", func(t *testing.T) {
-		opts := Options{
-			GenerateClient:     true,
-			GenerateEchoServer: true,
-			GenerateTypes:      true,
-			EmbedSpec:          true,
-			ExcludeTags:        []string{"hippo", "giraffe", "cat"},
-		}
-
-		// Get a spec from the test definition in this file:
-		swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(testOpenAPIDefinition))
-		assert.NoError(t, err)
-
-		// Run our code generation:
-		code, err := Generate(swagger, packageName, opts)
-		assert.NoError(t, err)
-		assert.NotEmpty(t, code)
-		assert.Contains(t, code, `"/test/:name"`)
-		assert.NotContains(t, code, `"/cat"`)
-	})
-}
-
 func TestExampleOpenAPICodeGeneration(t *testing.T) {
 
 	// Input vars for code generation:

--- a/pkg/codegen/filter.go
+++ b/pkg/codegen/filter.go
@@ -1,0 +1,46 @@
+package codegen
+
+import "github.com/getkin/kin-openapi/openapi3"
+
+func filterOperationsByTag(swagger *openapi3.Swagger, opts Options) {
+	if len(opts.ExcludeTags) > 0 {
+		excludeOperationsWithTags(swagger.Paths, opts.ExcludeTags)
+	}
+	if len(opts.IncludeTags) > 0 {
+		includeOperationsWithTags(swagger.Paths, opts.IncludeTags, false)
+	}
+}
+
+func excludeOperationsWithTags(paths openapi3.Paths, tags []string) {
+	includeOperationsWithTags(paths, tags, true)
+}
+
+func includeOperationsWithTags(paths openapi3.Paths, tags []string, exclude bool) {
+	for _, pathItem := range paths {
+		ops := pathItem.Operations()
+		names := make([]string, 0, len(ops))
+		for name, op := range ops {
+			if operationHasTag(op, tags) == exclude {
+				names = append(names, name)
+			}
+		}
+		for _, name := range names {
+			pathItem.SetOperation(name, nil)
+		}
+	}
+}
+
+//operationHasTag returns true if the operation is tagged with any of tags
+func operationHasTag(op *openapi3.Operation, tags []string) bool {
+	if op == nil {
+		return false
+	}
+	for _, hasTag := range op.Tags {
+		for _, wantTag := range tags {
+			if hasTag == wantTag {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/codegen/filter_test.go
+++ b/pkg/codegen/filter_test.go
@@ -1,0 +1,53 @@
+package codegen
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterOperationsByTag(t *testing.T) {
+	packageName := "testswagger"
+	t.Run("include tags", func(t *testing.T) {
+		opts := Options{
+			GenerateClient:     true,
+			GenerateEchoServer: true,
+			GenerateTypes:      true,
+			EmbedSpec:          true,
+			IncludeTags:        []string{"hippo", "giraffe", "cat"},
+		}
+
+		// Get a spec from the test definition in this file:
+		swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(testOpenAPIDefinition))
+		assert.NoError(t, err)
+
+		// Run our code generation:
+		code, err := Generate(swagger, packageName, opts)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, code)
+		assert.NotContains(t, code, `"/test/:name"`)
+		assert.Contains(t, code, `"/cat"`)
+	})
+
+	t.Run("exclude tags", func(t *testing.T) {
+		opts := Options{
+			GenerateClient:     true,
+			GenerateEchoServer: true,
+			GenerateTypes:      true,
+			EmbedSpec:          true,
+			ExcludeTags:        []string{"hippo", "giraffe", "cat"},
+		}
+
+		// Get a spec from the test definition in this file:
+		swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(testOpenAPIDefinition))
+		assert.NoError(t, err)
+
+		// Run our code generation:
+		code, err := Generate(swagger, packageName, opts)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, code)
+		assert.Contains(t, code, `"/test/:name"`)
+		assert.NotContains(t, code, `"/cat"`)
+	})
+}

--- a/pkg/codegen/prune.go
+++ b/pkg/codegen/prune.go
@@ -1,0 +1,487 @@
+package codegen
+
+import (
+	"fmt"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+type RefWrapper struct {
+	Ref       string
+	HasValue  bool
+	SourceRef interface{}
+}
+
+func walkSwagger(swagger *openapi3.Swagger, doFn func(RefWrapper) (bool, error)) error {
+	if swagger == nil {
+		return nil
+	}
+
+	for _, p := range swagger.Paths {
+		for _, op := range p.Operations() {
+			walkOperation(op, doFn)
+		}
+	}
+
+	walkComponents(&swagger.Components, doFn)
+
+	return nil
+}
+
+func walkOperation(op *openapi3.Operation, doFn func(RefWrapper) (bool, error)) error {
+	// Not a valid ref, ignore it and continue
+	if op == nil {
+		return nil
+	}
+
+	for _, param := range op.Parameters {
+		_ = walkParameterRef(param, doFn)
+	}
+
+	_ = walkRequestBodyRef(op.RequestBody, doFn)
+
+	for _, response := range op.Responses {
+		walkResponseRef(response, doFn)
+	}
+
+	for _, callback := range op.Callbacks {
+		walkCallbackRef(callback, doFn)
+	}
+
+	return nil
+}
+
+func walkComponents(components *openapi3.Components, doFn func(RefWrapper) (bool, error)) error {
+	// Not a valid ref, ignore it and continue
+	if components == nil {
+		return nil
+	}
+
+	for _, schema := range components.Schemas {
+		_ = walkSchemaRef(schema, doFn)
+	}
+
+	for _, param := range components.Parameters {
+		_ = walkParameterRef(param, doFn)
+	}
+
+	for _, header := range components.Headers {
+		_ = walkHeaderRef(header, doFn)
+	}
+
+	for _, requestBody := range components.RequestBodies {
+		_ = walkRequestBodyRef(requestBody, doFn)
+	}
+
+	for _, response := range components.Responses {
+		_ = walkResponseRef(response, doFn)
+	}
+
+	for _, securityScheme := range components.SecuritySchemes {
+		_ = walkSecuritySchemeRef(securityScheme, doFn)
+	}
+
+	for _, example := range components.Examples {
+		_ = walkExampleRef(example, doFn)
+	}
+
+	for _, link := range components.Links {
+		_ = walkLinkRef(link, doFn)
+	}
+
+	for _, callback := range components.Callbacks {
+		_ = walkCallbackRef(callback, doFn)
+	}
+
+	return nil
+}
+
+func walkSchemaRef(ref *openapi3.SchemaRef, doFn func(RefWrapper) (bool, error)) error {
+	// Not a valid ref, ignore it and continue
+	if ref == nil {
+		return nil
+	}
+	refWrapper := RefWrapper{Ref: ref.Ref, HasValue: ref.Value != nil, SourceRef: ref}
+	shouldContinue, err := doFn(refWrapper)
+	if err != nil {
+		return err
+	}
+	if !shouldContinue {
+		return nil
+	}
+	if ref.Value == nil {
+		return nil
+	}
+
+	for _, ref := range ref.Value.OneOf {
+		walkSchemaRef(ref, doFn)
+	}
+
+	for _, ref := range ref.Value.AnyOf {
+		walkSchemaRef(ref, doFn)
+	}
+
+	for _, ref := range ref.Value.AllOf {
+		walkSchemaRef(ref, doFn)
+	}
+
+	walkSchemaRef(ref.Value.Not, doFn)
+	walkSchemaRef(ref.Value.Items, doFn)
+
+	for _, ref := range ref.Value.Properties {
+		walkSchemaRef(ref, doFn)
+	}
+
+	walkSchemaRef(ref.Value.AdditionalProperties, doFn)
+
+	return nil
+}
+
+func walkParameterRef(ref *openapi3.ParameterRef, doFn func(RefWrapper) (bool, error)) error {
+	// Not a valid ref, ignore it and continue
+	if ref == nil {
+		return nil
+	}
+	refWrapper := RefWrapper{Ref: ref.Ref, HasValue: ref.Value != nil, SourceRef: ref}
+	shouldContinue, err := doFn(refWrapper)
+	if err != nil {
+		return err
+	}
+	if !shouldContinue {
+		return nil
+	}
+	if ref.Value == nil {
+		return nil
+	}
+
+	walkSchemaRef(ref.Value.Schema, doFn)
+
+	for _, example := range ref.Value.Examples {
+		walkExampleRef(example, doFn)
+	}
+
+	for _, mediaType := range ref.Value.Content {
+		if mediaType == nil {
+			continue
+		}
+		walkSchemaRef(mediaType.Schema, doFn)
+
+		for _, example := range mediaType.Examples {
+			walkExampleRef(example, doFn)
+		}
+	}
+
+	return nil
+}
+
+func walkRequestBodyRef(ref *openapi3.RequestBodyRef, doFn func(RefWrapper) (bool, error)) error {
+	// Not a valid ref, ignore it and continue
+	if ref == nil {
+		return nil
+	}
+	refWrapper := RefWrapper{Ref: ref.Ref, HasValue: ref.Value != nil, SourceRef: ref}
+	shouldContinue, err := doFn(refWrapper)
+	if err != nil {
+		return err
+	}
+	if !shouldContinue {
+		return nil
+	}
+	if ref.Value == nil {
+		return nil
+	}
+
+	for _, mediaType := range ref.Value.Content {
+		if mediaType == nil {
+			continue
+		}
+		walkSchemaRef(mediaType.Schema, doFn)
+
+		for _, example := range mediaType.Examples {
+			walkExampleRef(example, doFn)
+		}
+	}
+
+	return nil
+}
+
+func walkResponseRef(ref *openapi3.ResponseRef, doFn func(RefWrapper) (bool, error)) error {
+	// Not a valid ref, ignore it and continue
+	if ref == nil {
+		return nil
+	}
+	refWrapper := RefWrapper{Ref: ref.Ref, HasValue: ref.Value != nil, SourceRef: ref}
+	shouldContinue, err := doFn(refWrapper)
+	if err != nil {
+		return err
+	}
+	if !shouldContinue {
+		return nil
+	}
+	if ref.Value == nil {
+		return nil
+	}
+
+	for _, header := range ref.Value.Headers {
+		walkHeaderRef(header, doFn)
+	}
+
+	for _, mediaType := range ref.Value.Content {
+		if mediaType == nil {
+			continue
+		}
+		walkSchemaRef(mediaType.Schema, doFn)
+
+		for _, example := range mediaType.Examples {
+			walkExampleRef(example, doFn)
+		}
+	}
+
+	for _, link := range ref.Value.Links {
+		walkLinkRef(link, doFn)
+	}
+
+	return nil
+}
+
+func walkCallbackRef(ref *openapi3.CallbackRef, doFn func(RefWrapper) (bool, error)) error {
+	// Not a valid ref, ignore it and continue
+	if ref == nil {
+		return nil
+	}
+	refWrapper := RefWrapper{Ref: ref.Ref, HasValue: ref.Value != nil, SourceRef: ref}
+	shouldContinue, err := doFn(refWrapper)
+	if err != nil {
+		return err
+	}
+	if !shouldContinue {
+		return nil
+	}
+	if ref.Value == nil {
+		return nil
+	}
+
+	for _, pathItem := range *ref.Value {
+		for _, parameter := range pathItem.Parameters {
+			walkParameterRef(parameter, doFn)
+		}
+		walkOperation(pathItem.Connect, doFn)
+		walkOperation(pathItem.Delete, doFn)
+		walkOperation(pathItem.Get, doFn)
+		walkOperation(pathItem.Head, doFn)
+		walkOperation(pathItem.Options, doFn)
+		walkOperation(pathItem.Patch, doFn)
+		walkOperation(pathItem.Post, doFn)
+		walkOperation(pathItem.Put, doFn)
+		walkOperation(pathItem.Trace, doFn)
+	}
+
+	return nil
+}
+
+func walkHeaderRef(ref *openapi3.HeaderRef, doFn func(RefWrapper) (bool, error)) error {
+	// Not a valid ref, ignore it and continue
+	if ref == nil {
+		return nil
+	}
+	refWrapper := RefWrapper{Ref: ref.Ref, HasValue: ref.Value != nil, SourceRef: ref}
+	shouldContinue, err := doFn(refWrapper)
+	if err != nil {
+		return err
+	}
+	if !shouldContinue {
+		return nil
+	}
+	if ref.Value == nil {
+		return nil
+	}
+
+	walkSchemaRef(ref.Value.Schema, doFn)
+
+	return nil
+}
+
+func walkSecuritySchemeRef(ref *openapi3.SecuritySchemeRef, doFn func(RefWrapper) (bool, error)) error {
+	// Not a valid ref, ignore it and continue
+	if ref == nil {
+		return nil
+	}
+	refWrapper := RefWrapper{Ref: ref.Ref, HasValue: ref.Value != nil, SourceRef: ref}
+	shouldContinue, err := doFn(refWrapper)
+	if err != nil {
+		return err
+	}
+	if !shouldContinue {
+		return nil
+	}
+	if ref.Value == nil {
+		return nil
+	}
+
+	// NOTE: `SecuritySchemeRef`s don't contain any children that can contain refs
+
+	return nil
+}
+
+func walkLinkRef(ref *openapi3.LinkRef, doFn func(RefWrapper) (bool, error)) error {
+	// Not a valid ref, ignore it and continue
+	if ref == nil {
+		return nil
+	}
+	refWrapper := RefWrapper{Ref: ref.Ref, HasValue: ref.Value != nil, SourceRef: ref}
+	shouldContinue, err := doFn(refWrapper)
+	if err != nil {
+		return err
+	}
+	if !shouldContinue {
+		return nil
+	}
+	if ref.Value == nil {
+		return nil
+	}
+
+	// TODO: for some reason linkRef.Value.Headers is a `map[string]*Schema` instead of a `map[string]*SchemaRef`
+	// so we can't walk it like all the other SchemaRef's we find.
+
+	// for _, schema := range ref.Value.Headers {
+	// 	walkSchemaRef(schema, doFn)
+	// }
+
+	return nil
+}
+
+func walkExampleRef(ref *openapi3.ExampleRef, doFn func(RefWrapper) (bool, error)) error {
+	// Not a valid ref, ignore it and continue
+	if ref == nil {
+		return nil
+	}
+	refWrapper := RefWrapper{Ref: ref.Ref, HasValue: ref.Value != nil, SourceRef: ref}
+	shouldContinue, err := doFn(refWrapper)
+	if err != nil {
+		return err
+	}
+	if !shouldContinue {
+		return nil
+	}
+	if ref.Value == nil {
+		return nil
+	}
+
+	// NOTE: `ExampleRef`s don't contain any children that can contain refs
+
+	return nil
+}
+
+func findComponentRefs(swagger *openapi3.Swagger) []string {
+	refs := []string{}
+
+	walkSwagger(swagger, func(ref RefWrapper) (bool, error) {
+		if ref.Ref != "" {
+			refs = append(refs, ref.Ref)
+			return false, nil
+		}
+		return true, nil
+	})
+
+	return refs
+}
+
+func removeOrphanedComponents(swagger *openapi3.Swagger, refs []string) int {
+	countRemoved := 0
+
+	for key, _ := range swagger.Components.Schemas {
+		ref := fmt.Sprintf("#/components/schemas/%s", key)
+		if !stringInSlice(ref, refs) {
+			countRemoved++
+			delete(swagger.Components.Schemas, key)
+		}
+	}
+
+	for key, _ := range swagger.Components.Parameters {
+		ref := fmt.Sprintf("#/components/parameters/%s", key)
+		if !stringInSlice(ref, refs) {
+			countRemoved++
+			delete(swagger.Components.Parameters, key)
+		}
+	}
+
+	// securitySchemes are an exception. definitions in securitySchemes
+	// are referenced directly by name. and not by $ref
+
+	// for key, _ := range swagger.Components.SecuritySchemes {
+	// 	ref := fmt.Sprintf("#/components/securitySchemes/%s", key)
+	// 	if !stringInSlice(ref, refs) {
+	// 		countRemoved++
+	// 		delete(swagger.Components.SecuritySchemes, key)
+	// 	}
+	// }
+
+	for key, _ := range swagger.Components.RequestBodies {
+		ref := fmt.Sprintf("#/components/requestBodies/%s", key)
+		if !stringInSlice(ref, refs) {
+			countRemoved++
+			delete(swagger.Components.RequestBodies, key)
+		}
+	}
+
+	for key, _ := range swagger.Components.Responses {
+		ref := fmt.Sprintf("#/components/responses/%s", key)
+		if !stringInSlice(ref, refs) {
+			countRemoved++
+			delete(swagger.Components.Responses, key)
+		}
+	}
+
+	for key, _ := range swagger.Components.Headers {
+		ref := fmt.Sprintf("#/components/headers/%s", key)
+		if !stringInSlice(ref, refs) {
+			countRemoved++
+			delete(swagger.Components.Headers, key)
+		}
+	}
+
+	for key, _ := range swagger.Components.Examples {
+		ref := fmt.Sprintf("#/components/examples/%s", key)
+		if !stringInSlice(ref, refs) {
+			countRemoved++
+			delete(swagger.Components.Examples, key)
+		}
+	}
+
+	for key, _ := range swagger.Components.Links {
+		ref := fmt.Sprintf("#/components/links/%s", key)
+		if !stringInSlice(ref, refs) {
+			countRemoved++
+			delete(swagger.Components.Links, key)
+		}
+	}
+
+	for key, _ := range swagger.Components.Callbacks {
+		ref := fmt.Sprintf("#/components/callbacks/%s", key)
+		if !stringInSlice(ref, refs) {
+			countRemoved++
+			delete(swagger.Components.Callbacks, key)
+		}
+	}
+
+	return countRemoved
+}
+
+func pruneUnusedComponents(swagger *openapi3.Swagger) {
+	for {
+		refs := findComponentRefs(swagger)
+		countRemoved := removeOrphanedComponents(swagger, refs)
+		if countRemoved < 1 {
+			break
+		}
+	}
+}

--- a/pkg/codegen/prune.go
+++ b/pkg/codegen/prune.go
@@ -350,10 +350,10 @@ func walkLinkRef(ref *openapi3.LinkRef, doFn func(RefWrapper) (bool, error)) err
 	}
 
 	// TODO: for some reason linkRef.Value.Headers is a `map[string]*Schema` instead of a `map[string]*SchemaRef`
-	// so we can't walk it like all the other SchemaRef's we find.
+	// so we can't walk it like all the other refs.
 
-	// for _, schema := range ref.Value.Headers {
-	// 	walkSchemaRef(schema, doFn)
+	// for _, header := range ref.Value.Headers {
+	// 	walkHeaderRef(header, doFn)
 	// }
 
 	return nil

--- a/pkg/codegen/prune.go
+++ b/pkg/codegen/prune.go
@@ -349,13 +349,6 @@ func walkLinkRef(ref *openapi3.LinkRef, doFn func(RefWrapper) (bool, error)) err
 		return nil
 	}
 
-	// TODO: for some reason linkRef.Value.Headers is a `map[string]*Schema` instead of a `map[string]*SchemaRef`
-	// so we can't walk it like all the other refs.
-
-	// for _, header := range ref.Value.Headers {
-	// 	walkHeaderRef(header, doFn)
-	// }
-
 	return nil
 }
 

--- a/pkg/codegen/prune_test.go
+++ b/pkg/codegen/prune_test.go
@@ -1,0 +1,424 @@
+package codegen
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindReferences(t *testing.T) {
+	t.Run("unfiltered", func(t *testing.T) {
+		swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(pruneSpecTestFixture))
+		assert.NoError(t, err)
+
+		refs := findComponentRefs(swagger)
+		assert.Len(t, refs, 14)
+	})
+	t.Run("only cat", func(t *testing.T) {
+		swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(pruneSpecTestFixture))
+		assert.NoError(t, err)
+		opts := Options{
+			IncludeTags: []string{"cat"},
+		}
+
+		filterOperationsByTag(swagger, opts)
+
+		refs := findComponentRefs(swagger)
+		assert.Len(t, refs, 7)
+	})
+	t.Run("only dog", func(t *testing.T) {
+		swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(pruneSpecTestFixture))
+		assert.NoError(t, err)
+
+		opts := Options{
+			IncludeTags: []string{"dog"},
+		}
+
+		filterOperationsByTag(swagger, opts)
+
+		refs := findComponentRefs(swagger)
+		assert.Len(t, refs, 7)
+	})
+}
+
+func TestFilterOnlyCat(t *testing.T) {
+	// Get a spec from the test definition in this file:
+	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(pruneSpecTestFixture))
+	assert.NoError(t, err)
+
+	opts := Options{
+		IncludeTags: []string{"cat"},
+	}
+
+	refs := findComponentRefs(swagger)
+	assert.Len(t, refs, 14)
+
+	assert.Len(t, swagger.Components.Schemas, 5)
+
+	filterOperationsByTag(swagger, opts)
+
+	refs = findComponentRefs(swagger)
+	assert.Len(t, refs, 7)
+
+	assert.NotEmpty(t, swagger.Paths["/cat"], "/cat path should still be in spec")
+	assert.NotEmpty(t, swagger.Paths["/cat"].Get, "GET /cat operation should still be in spec")
+	assert.Empty(t, swagger.Paths["/dog"].Get, "GET /dog should have been removed from spec")
+
+	pruneUnusedComponents(swagger)
+
+	assert.Len(t, swagger.Components.Schemas, 3)
+}
+
+func TestFilterOnlyDog(t *testing.T) {
+	// Get a spec from the test definition in this file:
+	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(pruneSpecTestFixture))
+	assert.NoError(t, err)
+
+	opts := Options{
+		IncludeTags: []string{"dog"},
+	}
+
+	refs := findComponentRefs(swagger)
+	assert.Len(t, refs, 14)
+
+	filterOperationsByTag(swagger, opts)
+
+	refs = findComponentRefs(swagger)
+	assert.Len(t, refs, 7)
+
+	assert.Len(t, swagger.Components.Schemas, 5)
+
+	assert.NotEmpty(t, swagger.Paths["/dog"])
+	assert.NotEmpty(t, swagger.Paths["/dog"].Get)
+	assert.Empty(t, swagger.Paths["/cat"].Get)
+
+	pruneUnusedComponents(swagger)
+
+	assert.Len(t, swagger.Components.Schemas, 3)
+}
+
+func TestPruningUnusedComponents(t *testing.T) {
+	// Get a spec from the test definition in this file:
+	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(pruneComprehensiveTestFixture))
+	assert.NoError(t, err)
+
+	assert.Len(t, swagger.Components.Schemas, 8)
+	assert.Len(t, swagger.Components.Parameters, 1)
+	assert.Len(t, swagger.Components.SecuritySchemes, 2)
+	assert.Len(t, swagger.Components.RequestBodies, 1)
+	assert.Len(t, swagger.Components.Responses, 2)
+	assert.Len(t, swagger.Components.Headers, 3)
+	assert.Len(t, swagger.Components.Examples, 1)
+	assert.Len(t, swagger.Components.Links, 1)
+	assert.Len(t, swagger.Components.Callbacks, 1)
+
+	pruneUnusedComponents(swagger)
+
+	assert.Len(t, swagger.Components.Schemas, 0)
+	assert.Len(t, swagger.Components.Parameters, 0)
+	// securitySchemes are an exception. definitions in securitySchemes
+	// are referenced directly by name. and not by $ref
+	assert.Len(t, swagger.Components.SecuritySchemes, 2)
+	assert.Len(t, swagger.Components.RequestBodies, 0)
+	assert.Len(t, swagger.Components.Responses, 0)
+	assert.Len(t, swagger.Components.Headers, 0)
+	assert.Len(t, swagger.Components.Examples, 0)
+	assert.Len(t, swagger.Components.Links, 0)
+	assert.Len(t, swagger.Components.Callbacks, 0)
+}
+
+const pruneComprehensiveTestFixture = `
+openapi: 3.0.1
+
+info:
+  title: OpenAPI-CodeGen Test
+  description: 'This is a test OpenAPI Spec'
+  version: 1.0.0
+
+servers:
+- url: https://test.oapi-codegen.com/v2
+- url: http://test.oapi-codegen.com/v2
+
+paths:
+  /test:
+    get:
+      operationId: doesNothing
+      summary: does nothing
+      tags: [nothing]
+      responses:
+        default:
+          description: returns nothing
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  schemas:
+    Object1:
+      type: object
+      properties:
+        object:
+          $ref: "#/components/schemas/Object2"
+    Object2:
+      type: object
+      properties:
+        object:
+          $ref: "#/components/schemas/Object3"
+    Object3:
+      type: object
+      properties:
+        object:
+          $ref: "#/components/schemas/Object4"
+    Object4:
+      type: object
+      properties:
+        object:
+          $ref: "#/components/schemas/Object5"
+    Object5:
+      type: object
+      properties:
+        object:
+          $ref: "#/components/schemas/Object6"
+    Object6:
+      type: object
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+          description: Error code
+        message:
+          type: string
+          description: Error message
+  parameters:
+    offsetParam:
+      name: offset
+      in: query
+      description: Number of items to skip before returning the results.
+      required: false
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+        default: 0
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    BearerAuth:
+      type: http
+      scheme: bearer
+  requestBodies:
+    PetBody:
+      description: A JSON object containing pet information
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+  responses:
+    NotFound:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+  headers:
+    X-RateLimit-Limit:
+      schema:
+        type: integer
+      description: Request limit per hour.
+    X-RateLimit-Remaining:
+      schema:
+        type: integer
+      description: The number of requests left for the time window.
+    X-RateLimit-Reset:
+      schema:
+        type: string
+        format: date-time
+      description: The UTC date/time at which the current rate limit window resets
+  examples:
+    objectExample:
+      value:
+        id: 1
+        name: new object
+      summary: A sample object
+  links:
+    GetUserByUserId:
+      description: >
+        The id value returned in the response can be used as
+        the userId parameter in GET /users/{userId}.
+      operationId: getUser
+      parameters:
+        userId: '$response.body#/id'
+  callbacks:
+    MyCallback:
+      '{$request.body#/callbackUrl}':
+        post:
+          requestBody:
+            required: true
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    message:
+                      type: string
+                      example: Some event happened
+                  required:
+                    - message
+          responses:
+            '200':
+              description: Your server returns this code if it accepts the callback
+`
+
+const pruneSpecTestFixture = `
+openapi: 3.0.1
+
+info:
+  title: OpenAPI-CodeGen Test
+  description: 'This is a test OpenAPI Spec'
+  version: 1.0.0
+
+servers:
+- url: https://test.oapi-codegen.com/v2
+- url: http://test.oapi-codegen.com/v2
+
+paths:
+  /cat:
+    get:
+      tags:
+        - cat
+      summary: Get cat status
+      operationId: getCatStatus
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/CatAlive'
+                  - $ref: '#/components/schemas/CatDead'
+            application/xml:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/CatAlive'
+                  - $ref: '#/components/schemas/CatDead'
+            application/yaml:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/CatAlive'
+                  - $ref: '#/components/schemas/CatDead'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /dog:
+    get:
+      tags:
+        - dog
+      summary: Get dog status
+      operationId: getDogStatus
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/DogAlive'
+                  - $ref: '#/components/schemas/DogDead'
+            application/xml:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/DogAlive'
+                  - $ref: '#/components/schemas/DogDead'
+            application/yaml:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/DogAlive'
+                  - $ref: '#/components/schemas/DogDead'
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+components:
+  schemas:
+
+    Error:
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+
+    CatAlive:
+      properties:
+        name:
+          type: string
+        alive_since:
+          type: string
+          format: date-time
+
+    CatDead:
+      properties:
+        name:
+          type: string
+        dead_since:
+          type: string
+          format: date-time
+        cause:
+          type: string
+          enum: [car, dog, oldage]
+
+    DogAlive:
+      properties:
+        name:
+          type: string
+        alive_since:
+          type: string
+          format: date-time
+
+    DogDead:
+      properties:
+        name:
+          type: string
+        dead_since:
+          type: string
+          format: date-time
+        cause:
+          type: string
+          enum: [car, cat, oldage]
+
+`


### PR DESCRIPTION
## Changes

- Added [`.editorconfig`](https://editorconfig.org/) file (can remove this if you want but IMO it's handy to have and helped fix my whitespace formatting).
- Added a `skip-prune` flag that is similar to `skip-fmt` in that it can be used to prevent running the pruning logic when generating code.
- Rather than making the test code generation use the `skip-prune` flag (which would be a quick way to make the tests pass without updating the specs) I thought it was better to update them and make sure than any components that would have been pruned are referred to in at least one operation (so they don't get pruned). This means that `test/components/components.yaml`, `test/schemas/schemas.yaml` and `test/test-schema.yaml` have a number of additions to the generated code but they're not **missing** anything apart from this https://github.com/deepmap/oapi-codegen/pull/154/files#r392671169
- I moved the filtering logic of the `openapi3.Swagger` from `codegen.go` into `filter.go` (can move these back if it's preferred).
- I have two main types of test in `prune_test.go`
  - `pruneComprehensiveTestFixture` has a fixture where with every type of component and none of them are referred to by an operation. This is to test that it's correctly removing all types of components if they're not referenced.
  - `pruneSpecTestFixture` has a `GET /cat` operation tagged with `cat` and a `GET /dog` operation tagged with `dog`. Both operations share a reference to `#/components/schemas/Error`. The test ensures that when you filter by one tag you don't get models that are only used in the other.

## Notes

Fixes https://github.com/deepmap/oapi-codegen/issues/151