### PR TITLE
fix: operations not appending to server url

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ which help you to use the various OpenAPI 3 Authentication mechanism.
         //
         // WithHTTPClient(httpClient *http.Client)
         //
-        client, clientErr := NewClient(context.Background(), []ClientOption{
+        client, clientErr := NewClient("https://api.deepmap.com", []ClientOption{
             WithBaseURL("https://api.deepmap.com"),
             WithRequestEditorFn(apiKeyProvider.Edit),
         }...,

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -102,6 +102,10 @@ func NewClient(server string, opts ...ClientOption) (*Client, error) {
 			return nil, err
 		}
 	}
+	// ensure the server URL always has a trailing slash
+	if !strings.HasSuffix(client.Server, "/") {
+		client.Server += "/"
+	}
 	// create httpClient, if not already present
 	if client.Client == nil {
 		client.Client = http.DefaultClient
@@ -407,9 +411,6 @@ func NewClientWithResponses(server string, opts ...ClientOption) (*ClientWithRes
 // WithBaseURL overrides the baseURL.
 func WithBaseURL(baseURL string) ClientOption {
 	return func(c *Client) error {
-		if !strings.HasSuffix(baseURL, "/") {
-			baseURL += "/"
-		}
 		newBaseURL, err := url.Parse(baseURL)
 		if err != nil {
 			return err

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -77,6 +77,10 @@ func NewClient(server string, opts ...ClientOption) (*Client, error) {
 			return nil, err
 		}
 	}
+	// ensure the server URL always has a trailing slash
+	if !strings.HasSuffix(client.Server, "/") {
+		client.Server += "/"
+	}
 	// create httpClient, if not already present
 	if client.Client == nil {
 		client.Client = http.DefaultClient
@@ -497,9 +501,6 @@ func NewClientWithResponses(server string, opts ...ClientOption) (*ClientWithRes
 // WithBaseURL overrides the baseURL.
 func WithBaseURL(baseURL string) ClientOption {
 	return func(c *Client) error {
-		if !strings.HasSuffix(baseURL, "/") {
-			baseURL += "/"
-		}
 		newBaseURL, err := url.Parse(baseURL)
 		if err != nil {
 			return err

--- a/internal/test/client/client_test.go
+++ b/internal/test/client/client_test.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemp(t *testing.T) {
+
+	var (
+		withTrailingSlash    string = "https://my-api.com/some-base-url/v1/"
+		withoutTrailingSlash string = "https://my-api.com/some-base-url/v1"
+	)
+
+	client1, err := NewClient(
+		withTrailingSlash,
+	)
+	assert.NoError(t, err)
+
+	client2, err := NewClient(
+		withoutTrailingSlash,
+	)
+	assert.NoError(t, err)
+
+	client3, err := NewClient(
+		"",
+		WithBaseURL(withTrailingSlash),
+	)
+	assert.NoError(t, err)
+
+	client4, err := NewClient(
+		"",
+		WithBaseURL(withoutTrailingSlash),
+	)
+	assert.NoError(t, err)
+
+	expectedURL := withTrailingSlash
+
+	assert.Equal(t, expectedURL, client1.Server)
+	assert.Equal(t, expectedURL, client2.Server)
+	assert.Equal(t, expectedURL, client3.Server)
+	assert.Equal(t, expectedURL, client4.Server)
+}

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -759,6 +759,10 @@ func NewClient(server string, opts ...ClientOption) (*Client, error) {
 			return nil, err
 		}
 	}
+	// ensure the server URL always has a trailing slash
+	if !strings.HasSuffix(client.Server, "/") {
+		client.Server += "/"
+	}
 	// create httpClient, if not already present
 	if client.Client == nil {
 		client.Client = http.DefaultClient
@@ -952,9 +956,6 @@ func NewClientWithResponses(server string, opts ...ClientOption) (*ClientWithRes
 // WithBaseURL overrides the baseURL.
 func WithBaseURL(baseURL string) ClientOption {
 	return func(c *Client) error {
-		if !strings.HasSuffix(baseURL, "/") {
-			baseURL += "/"
-		}
 		newBaseURL, err := url.Parse(baseURL)
 		if err != nil {
 			return err

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -131,6 +131,10 @@ func NewClient(server string, opts ...ClientOption) (*Client, error) {
 			return nil, err
 		}
 	}
+	// ensure the server URL always has a trailing slash
+	if !strings.HasSuffix(client.Server, "/") {
+		client.Server += "/"
+	}
 	// create httpClient, if not already present
 	if client.Client == nil {
 		client.Client = http.DefaultClient
@@ -222,9 +226,6 @@ func NewClientWithResponses(server string, opts ...ClientOption) (*ClientWithRes
 // WithBaseURL overrides the baseURL.
 func WithBaseURL(baseURL string) ClientOption {
 	return func(c *Client) error {
-		if !strings.HasSuffix(baseURL, "/") {
-			baseURL += "/"
-		}
 		newBaseURL, err := url.Parse(baseURL)
 		if err != nil {
 			return err

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -154,6 +154,10 @@ func NewClient(server string, opts ...ClientOption) (*Client, error) {
 			return nil, err
 		}
 	}
+	// ensure the server URL always has a trailing slash
+	if !strings.HasSuffix(client.Server, "/") {
+		client.Server += "/"
+	}
 	// create httpClient, if not already present
 	if client.Client == nil {
 		client.Client = http.DefaultClient
@@ -1471,9 +1475,6 @@ func NewClientWithResponses(server string, opts ...ClientOption) (*ClientWithRes
 // WithBaseURL overrides the baseURL.
 func WithBaseURL(baseURL string) ClientOption {
 	return func(c *Client) error {
-		if !strings.HasSuffix(baseURL, "/") {
-			baseURL += "/"
-		}
 		newBaseURL, err := url.Parse(baseURL)
 		if err != nil {
 			return err

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -88,6 +88,10 @@ func NewClient(server string, opts ...ClientOption) (*Client, error) {
 			return nil, err
 		}
 	}
+	// ensure the server URL always has a trailing slash
+	if !strings.HasSuffix(client.Server, "/") {
+		client.Server += "/"
+	}
 	// create httpClient, if not already present
 	if client.Client == nil {
 		client.Client = http.DefaultClient
@@ -373,9 +377,6 @@ func NewClientWithResponses(server string, opts ...ClientOption) (*ClientWithRes
 // WithBaseURL overrides the baseURL.
 func WithBaseURL(baseURL string) ClientOption {
 	return func(c *Client) error {
-		if !strings.HasSuffix(baseURL, "/") {
-			baseURL += "/"
-		}
 		newBaseURL, err := url.Parse(baseURL)
 		if err != nil {
 			return err

--- a/pkg/codegen/templates/client-with-responses.tmpl
+++ b/pkg/codegen/templates/client-with-responses.tmpl
@@ -16,9 +16,6 @@ func NewClientWithResponses(server string, opts ...ClientOption) (*ClientWithRes
 // WithBaseURL overrides the baseURL.
 func WithBaseURL(baseURL string) ClientOption {
 	return func(c *Client) error {
-		if !strings.HasSuffix(baseURL, "/") {
-			baseURL += "/"
-		}
 		newBaseURL, err := url.Parse(baseURL)
 		if err != nil {
 			return err

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -38,6 +38,10 @@ func NewClient(server string, opts ...ClientOption) (*Client, error) {
             return nil, err
         }
     }
+    // ensure the server URL always has a trailing slash
+    if !strings.HasSuffix(client.Server, "/") {
+        client.Server += "/"
+    }
     // create httpClient, if not already present
     if client.Client == nil {
         client.Client = http.DefaultClient

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -288,9 +288,6 @@ func NewClientWithResponses(server string, opts ...ClientOption) (*ClientWithRes
 // WithBaseURL overrides the baseURL.
 func WithBaseURL(baseURL string) ClientOption {
 	return func(c *Client) error {
-		if !strings.HasSuffix(baseURL, "/") {
-			baseURL += "/"
-		}
 		newBaseURL, err := url.Parse(baseURL)
 		if err != nil {
 			return err
@@ -414,6 +411,10 @@ func NewClient(server string, opts ...ClientOption) (*Client, error) {
         if err := o(&client); err != nil {
             return nil, err
         }
+    }
+    // ensure the server URL always has a trailing slash
+    if !strings.HasSuffix(client.Server, "/") {
+        client.Server += "/"
     }
     // create httpClient, if not already present
     if client.Client == nil {


### PR DESCRIPTION
If you provide a server of `https://my-url.com/path/v1` and you have a `GET /things` operation the correct full path for the operation is `https://my-url.com/path/v1/things`.

Current behavior is that if you don't append a trailing slash to your server string before you pass it to `NewClient(server string, opts ...ClientOption)` then for the above case you will end up with `https://my-url.com/path/things` because that's how go's `url.Parse` treats relative URLs.

## Notes

Fixes https://github.com/deepmap/oapi-codegen/issues/126

## Other

Somewhat related but the more I look into this the more I think that the `WithBaseURL` option doesn't actually make much sense and should probably be discouraged.

I have two main problems with it:

- Ultimately all it's actually doing is setting the  `client.Server` string, but that's already handled by passing it in as a string to `NewClient` so I don't understand why it's even needed.
- The name `WithBaseURL` doesn't align to the OpenAPI spec terminology, if an option like this had to exist I think it'd make more sense for it to be called `WithServer(serverURL string)`.
- I think [this](https://github.com/deepmap/oapi-codegen/pull/155/files#diff-04c6e90faac2675aa89e2176d2eec7d8) fix to the `README.md` docs shows how it's a bit clunky
