### PR TITLE
Generate array properties

### DIFF
--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -222,6 +222,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 				return Schema{}, errors.Wrap(err, "error generating type for array")
 			}
 			outSchema.GoType = "[]" + arrayType.TypeDecl()
+			outSchema.Properties = arrayType.Properties
 		case "integer":
 			// We default to int if format doesn't ask for something else.
 			if f == "int64" {


### PR DESCRIPTION
So, without this update, if we have additional properties in object which in an array, lib generates following code:
```
// Package main provides primitives to interact the openapi HTTP API.
//
// Code generated by github.com/deepmap/oapi-codegen DO NOT EDIT.
package main

// Test defines model for Test.
type Test []struct {
	Test *Test_Test `json:"test,omitempty"`
}
```
And `Test_Test` is undefined.
But with this update lib generates also `Test_Test` struct:
```
// Test_Test defines model for Test.Test.
type Test_Test struct {
	AdditionalProperties map[string]string `json:"-"`
}
...
```

Swagger file example:
```
openapi: 3.0.0
info:
  title: Test
  version: 0.0.0
paths:
  /test:
    get:
      summary: Test
      responses:
        200:
          description: OK
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Test'
components:
  schemas:
    Test:
      type: array
      items:
        type: object
        properties:
          test:
            type: object
            additionalProperties:
              type: string
```