### PR TITLE
generate enum constants

### DIFF
--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -13,6 +13,8 @@ type Schema struct {
 	GoType  string // The Go type needed to represent the schema
 	RefType string // If the type has a type name, this is set
 
+	EnumValues []string // Enum values
+
 	Properties               []Property       // For an object, the fields with names
 	HasAdditionalProperties  bool             // Whether we support additional properties
 	AdditionalPropertiesType *Schema          // And if we do, their type
@@ -248,6 +250,9 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 			}
 			outSchema.GoType = "bool"
 		case "string":
+			for _, enumValue := range schema.Enum {
+				outSchema.EnumValues = append(outSchema.EnumValues, enumValue.(string))
+			}
 			// Special case string formats here.
 			switch f {
 			case "byte":

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -754,6 +754,15 @@ type ServerInterface interface {
 	"typedef.tmpl": `{{range .Types}}
 // {{.TypeName}} defines model for {{.JsonName}}.
 type {{.TypeName}} {{.Schema.TypeDecl}}
+{{- if gt (len .Schema.EnumValues) 0 }}
+// List of {{ .TypeName }}
+const (
+	{{- $typeName := .TypeName }}
+    {{- range .Schema.EnumValues }}
+    {{ $typeName }}_{{ . }} {{ $typeName }} = "{{ . }}"
+    {{- end }}
+)
+{{- end }}
 {{end}}
 `,
 	"wrappers.tmpl": `// ServerInterfaceWrapper converts echo contexts to parameters.

--- a/pkg/codegen/templates/typedef.tmpl
+++ b/pkg/codegen/templates/typedef.tmpl
@@ -1,4 +1,13 @@
 {{range .Types}}
 // {{.TypeName}} defines model for {{.JsonName}}.
 type {{.TypeName}} {{.Schema.TypeDecl}}
+{{- if gt (len .Schema.EnumValues) 0 }}
+// List of {{ .TypeName }}
+const (
+	{{- $typeName := .TypeName }}
+    {{- range .Schema.EnumValues }}
+    {{ $typeName }}_{{ . }} {{ $typeName }} = "{{ . }}"
+    {{- end }}
+)
+{{- end }}
 {{end}}


### PR DESCRIPTION
Added enum generation by producing constants for each enum value.
It only works if enum is the independent schema.
```
components:
  schemas:
    MyEnums:
      type: string
      enum:
        - PHONE
        - EMAIL
```
```
// MyEnums defines model for MyEnums.
type MyEnums string

// List of MyEnums
const (
        MyEnums_PHONE MyEnums = "PHONE"
        MyEnums_EMAIL MyEnums = "EMAIL"
)
```

It **does not work** if the attribute of a schema has the enum type.
Fixes #54