### PR TITLE
Add email format type

### DIFF
--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -37,14 +37,15 @@ type EveryTypeOptional struct {
 
 // EveryTypeRequired defines model for EveryTypeRequired.
 type EveryTypeRequired struct {
-	ArrayInlineField     []int              `json:"array_inline_field"`
-	ArrayReferencedField []SomeObject       `json:"array_referenced_field"`
-	BoolField            bool               `json:"bool_field"`
-	ByteField            []byte             `json:"byte_field"`
-	DateField            openapi_types.Date `json:"date_field"`
-	DateTimeField        time.Time          `json:"date_time_field"`
-	DoubleField          float64            `json:"double_field"`
-	FloatField           float32            `json:"float_field"`
+	ArrayInlineField     []int                `json:"array_inline_field"`
+	ArrayReferencedField []SomeObject         `json:"array_referenced_field"`
+	BoolField            bool                 `json:"bool_field"`
+	ByteField            []byte               `json:"byte_field"`
+	DateField            openapi_types.Date   `json:"date_field"`
+	DateTimeField        time.Time            `json:"date_time_field"`
+	DoubleField          float64              `json:"double_field"`
+	EmailField           *openapi_types.Email `json:"email_field,omitempty"`
+	FloatField           float32              `json:"float_field"`
 	InlineObjectField    struct {
 		Name   string `json:"name"`
 		Number int    `json:"number"`

--- a/internal/test/test-schema.yaml
+++ b/internal/test/test-schema.yaml
@@ -248,6 +248,9 @@ components:
           type: boolean
         string_field:
           type: string
+        email_field:
+          type: string
+          format: email
         date_field:
           type: string
           format: date

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -255,6 +255,8 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 			switch f {
 			case "byte":
 				outSchema.GoType = "[]byte"
+			case "email":
+				outSchema.GoType = "openapi_types.Email"
 			case "date":
 				outSchema.GoType = "openapi_types.Date"
 			case "date-time":

--- a/pkg/types/email.go
+++ b/pkg/types/email.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type Email string
+
+func (e Email) MarshalJSON() ([]byte, error) {
+	if !emailRegex.MatchString(string(e)) {
+		return nil, errors.New("email: failed to pass regex validation")
+	}
+	return json.Marshal(string(e))
+}
+
+func (e *Email) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if !emailRegex.MatchString(s) {
+		return errors.New("email: failed to pass regex validation")
+	}
+	*e = Email(s)
+	return nil
+}

--- a/pkg/types/email_test.go
+++ b/pkg/types/email_test.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmail_MarshalJSON(t *testing.T) {
+	testEmail := "gaben@valvesoftware.com"
+	b := struct {
+		EmailField Email `json:"email"`
+	}{
+		EmailField: Email(testEmail),
+	}
+	jsonBytes, err := json.Marshal(b)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"email":"gaben@valvesoftware.com"}`, string(jsonBytes))
+}
+
+func TestEmail_UnmarshalJSON(t *testing.T) {
+	testEmail := Email("gaben@valvesoftware.com")
+	jsonStr := `{"email":"gaben@valvesoftware.com"}`
+	b := struct {
+		EmailField Email `json:"email"`
+	}{}
+	err := json.Unmarshal([]byte(jsonStr), &b)
+	assert.NoError(t, err)
+	assert.Equal(t, testEmail, b.EmailField)
+}

--- a/pkg/types/regexes.go
+++ b/pkg/types/regexes.go
@@ -1,0 +1,11 @@
+package types
+
+import "regexp"
+
+const (
+	emailRegexString = "^(?:(?:(?:(?:[a-zA-Z]|\\d|[!#\\$%&'\\*\\+\\-\\/=\\?\\^_`{\\|}~]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])+(?:\\.([a-zA-Z]|\\d|[!#\\$%&'\\*\\+\\-\\/=\\?\\^_`{\\|}~]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])+)*)|(?:(?:\\x22)(?:(?:(?:(?:\\x20|\\x09)*(?:\\x0d\\x0a))?(?:\\x20|\\x09)+)?(?:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]|\\x21|[\\x23-\\x5b]|[\\x5d-\\x7e]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(?:(?:[\\x01-\\x09\\x0b\\x0c\\x0d-\\x7f]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}]))))*(?:(?:(?:\\x20|\\x09)*(?:\\x0d\\x0a))?(\\x20|\\x09)+)?(?:\\x22))))@(?:(?:(?:[a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(?:(?:[a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])(?:[a-zA-Z]|\\d|-|\\.|~|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])*(?:[a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])))\\.)+(?:(?:[a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(?:(?:[a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])(?:[a-zA-Z]|\\d|-|\\.|~|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])*(?:[a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])))\\.?$"
+)
+
+var (
+	emailRegex = regexp.MustCompile(emailRegexString)
+)


### PR DESCRIPTION
Add format value called `email` for string type. Use regex expression matched in very popular validation library [go-playground/validator](https://github.com/go-playground/validator).

- Added marshal / unmarshal unit test to `email` type
- Added `email` type to internal test schema