### PR TITLE
:pencil: Added missing feature to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,8 @@ need it. We've not yet implemented several things:
  knows how to parse them, but they're not part of OpenAPI 3.0, so we've left
  them out, as support is very complicated.
 
+- Defining parameters in global `#/components/parameters` section like described in Swagger-UI's section _Common Parameters for Various Paths_ [here](https://swagger.io/docs/specification/describing-parameters/) doesn't work, so far.
+
 
 ## Making changes to code generation
 


### PR DESCRIPTION
First of all, great work, I really appreciate people working together and sharing open source solutions!

Correct me if I am wrong, but:
Seems like defining parameters in global `#/components/parameters` section leads to a struct assumed for named global param, but struct itself (DocTypePathParam in example below) is not generated. Generated code doesn't compile.

openapi-yaml:
```
paths
  /document/{documentType}/{docTxid}:
      parameters:
        - $ref: "#/components/parameters/docTypePathParam"

<...>

components:
  parameters:
    docTypePathParam:
      in: path
      name: documentType
      <...>  
```
Generated go code:
```
type ServerInterface interface {
	RetrieveDocuments(ctx echo.Context, documentType DocTypePathParam) error
}
```