### PR TITLE
Generate plain slice members for structs instead slice references

### DIFF
--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -169,6 +169,9 @@ type GetTestByNameResponse struct {
 	problems, err := linter.Lint("test.gen.go", []byte(code))
 	assert.NoError(t, err)
 	assert.Len(t, problems, 0)
+
+	// Make sure that slices are generated without references
+	assert.Contains(t, code, "Cases []TestCase")
 }
 
 const testOpenAPIDefinition = `

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -227,6 +227,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 			}
 			outSchema.GoType = "[]" + arrayType.TypeDecl()
 			outSchema.Properties = arrayType.Properties
+			outSchema.SkipOptionalPointer = true
 		case "integer":
 			// We default to int if format doesn't ask for something else.
 			if f == "int64" {


### PR DESCRIPTION
Breaking change: generate struct members of slice type as `m []Type` instead of `m *[]Type`. Having pointer-to-slice is near-pointless when slice is a member of a struct.

This suggested behaviour is consistent with how e.g. GRPC generator behaves.