### PR TITLE
feature: --exclude-schemas option for excluding schemas from type generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,12 @@ To generate a server that only handles `admin` paths, use the argument
 `-include-tags="admin"`. When neither of these arguments is present, all paths
 are generated.
 
+`oapi-codegen` can filter schemas based on the option `--exclude-schemas`, which is
+a comma separated list of schema names. For instance, `--exclude-tags=Pet,NewPet`
+will exclude from generation schemas `Pet` and `NewPet`. This allow to have a
+in the same package a manually defined structure or interface and refer to it 
+in the openapi spec. 
+
 ### Import Mappings
 
 OpenAPI specifications may contain references to other OpenAPI specifications,

--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -33,13 +33,14 @@ func errExit(format string, args ...interface{}) {
 
 func main() {
 	var (
-		packageName   string
-		generate      string
-		outputFile    string
-		includeTags   string
-		excludeTags   string
-		templatesDir  string
-		importMapping string
+		packageName    string
+		generate       string
+		outputFile     string
+		includeTags    string
+		excludeTags    string
+		templatesDir   string
+		importMapping  string
+		excludeSchemas string
 	)
 	flag.StringVar(&packageName, "package", "", "The package name for generated code")
 	flag.StringVar(&generate, "generate", "types,client,server,spec",
@@ -49,6 +50,7 @@ func main() {
 	flag.StringVar(&excludeTags, "exclude-tags", "", "Exclude operations that are tagged with the given tags. Comma-separated list of tags.")
 	flag.StringVar(&templatesDir, "templates", "", "Path to directory containing user templates")
 	flag.StringVar(&importMapping, "import-mapping", "", "A dict from the external reference to golang package path")
+	flag.StringVar(&excludeSchemas, "exclude-schemas", "", "A comma separated list of schemas which must be excluded from generation")
 	flag.Parse()
 
 	if flag.NArg() < 1 {
@@ -92,6 +94,7 @@ func main() {
 
 	opts.IncludeTags = splitCSVArg(includeTags)
 	opts.ExcludeTags = splitCSVArg(excludeTags)
+	opts.ExcludeSchemas = splitCSVArg(excludeSchemas)
 
 	if opts.GenerateEchoServer && opts.GenerateChiServer {
 		errExit("can not specify both server and chi-server targets simultaneously")
@@ -168,4 +171,3 @@ func loadTemplateOverrides(templatesDir string) (map[string]string, error) {
 
 	return templates, nil
 }
-


### PR DESCRIPTION
### New feature:

introduce `--exclude-schemas` option to specify the list of schemas that need to be excluded from type generation. 

This will allow to have both generated and hand-written types or interfaces in the same package, and have valid references in both source code, generated code and the openapi spec. 
