### PR TITLE
docs: ✏️ Add the description for "x-go-type" into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,10 +421,12 @@ which help you to use the various OpenAPI 3 Authentication mechanism.
 
 ## Extensions
 
-`oapi-codegen` supports the following properties to extend the behavior.
+`oapi-codegen` supports the following extended properties:
 
-- `x-go-type`: specifies Go type name. It allows you to use type what you want in the generated code.
-See [PR](https://github.com/deepmap/oapi-codegen/pull/212) for details.
+- `x-go-type`: specifies Go type name. It allows you to specify the type name for a schema, and
+ will override any default value. This extended property isn't supported in all parts of
+ OpenAPI, so please refer to the spec as to where it's allowed. Swagger validation tools will
+ flag incorrect usage of this property.
 
 ## Using `oapi-codegen`
 

--- a/README.md
+++ b/README.md
@@ -419,6 +419,13 @@ which help you to use the various OpenAPI 3 Authentication mechanism.
     }
 ```
 
+## Extensions
+
+`oapi-codegen` supports the following properties to extend the behavior.
+
+- `x-go-type`: specifies Go type name. It allows you to use type what you want in the generated code.
+See [PR](https://github.com/deepmap/oapi-codegen/pull/212) for details.
+
 ## Using `oapi-codegen`
 
 The default options for `oapi-codegen` will generate everything; client, server,


### PR DESCRIPTION
I would like to add a description for "x-go-type" into README.md.
The property was merged by #212.

The description to be added is as follows.
![image](https://user-images.githubusercontent.com/2452581/90326562-b450ce00-dfc4-11ea-9e56-4302cb850525.png)
