### PR TITLE
Fix generic status code responses

### DIFF
--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -593,7 +593,7 @@ func ParseFindPetsResponse(rsp *http.Response) (*FindPetsResponse, error) {
 		}
 		response.JSON200 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest Error
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -626,7 +626,7 @@ func ParseAddPetResponse(rsp *http.Response) (*AddPetResponse, error) {
 		}
 		response.JSON200 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest Error
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -652,7 +652,7 @@ func ParseDeletePetResponse(rsp *http.Response) (*DeletePetResponse, error) {
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest Error
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -685,7 +685,7 @@ func ParseFindPetByIdResponse(rsp *http.Response) (*FindPetByIdResponse, error) 
 		}
 		response.JSON200 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest Error
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -1220,7 +1220,7 @@ func ParseEnsureEverythingIsReferencedResponse(rsp *http.Response) (*EnsureEvery
 		}
 		response.JSON200 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest struct {
 			Field SchemaObject `json:"Field"`
 		}
@@ -1229,7 +1229,7 @@ func ParseEnsureEverythingIsReferencedResponse(rsp *http.Response) (*EnsureEvery
 		}
 		response.JSONDefault = &dest
 
-	default:
+	case true:
 		// Content-type (text/plain) unsupported
 
 	}

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -892,7 +892,7 @@ func ParseIssue127Response(rsp *http.Response) (*Issue127Response, error) {
 		}
 		response.YAML200 = &dest
 
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json"):
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest GenericObject
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -916,7 +916,7 @@ func ParseIssue127Response(rsp *http.Response) (*Issue127Response, error) {
 	case rsp.StatusCode == 200:
 	// Content-type (text/markdown) unsupported
 
-	default:
+	case true:
 		// Content-type (text/markdown) unsupported
 
 	}

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -128,13 +128,8 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 		// If there is no content-type then we have no unmarshaling to do:
 		if len(responseRef.Value.Content) == 0 {
 			caseAction := "break // No content-type"
-			if typeDefinition.ResponseName == "default" {
-				caseClauseKey := "default:"
-				unhandledCaseClauses[prefixLeastSpecific+caseClauseKey] = fmt.Sprintf("%s\n%s\n", caseClauseKey, caseAction)
-			} else {
-				caseClauseKey := fmt.Sprintf("case rsp.StatusCode == %s:", typeDefinition.ResponseName)
-				unhandledCaseClauses[prefixLessSpecific+caseClauseKey] = fmt.Sprintf("%s\n%s\n", caseClauseKey, caseAction)
-			}
+			caseClauseKey := "case " + getConditionOfResponseName("rsp.StatusCode", typeDefinition.ResponseName) + ":"
+			unhandledCaseClauses[prefixLeastSpecific+caseClauseKey] = fmt.Sprintf("%s\n%s\n", caseClauseKey, caseAction)
 			continue
 		}
 
@@ -195,13 +190,8 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 			// Everything else:
 			default:
 				caseAction := fmt.Sprintf("// Content-type (%s) unsupported", contentTypeName)
-				if typeDefinition.ResponseName == "default" {
-					caseClauseKey := "default:"
-					unhandledCaseClauses[prefixLeastSpecific+caseClauseKey] = fmt.Sprintf("%s\n%s\n", caseClauseKey, caseAction)
-				} else {
-					caseClauseKey := fmt.Sprintf("case rsp.StatusCode == %s:", typeDefinition.ResponseName)
-					unhandledCaseClauses[prefixLessSpecific+caseClauseKey] = fmt.Sprintf("%s\n%s\n", caseClauseKey, caseAction)
-				}
+				caseClauseKey := "case " + getConditionOfResponseName("rsp.StatusCode", typeDefinition.ResponseName) + ":"
+				unhandledCaseClauses[prefixLeastSpecific+caseClauseKey] = fmt.Sprintf("%s\n%s\n", caseClauseKey, caseAction)
 			}
 		}
 	}
@@ -226,11 +216,8 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 // buildUnmarshalCase builds an unmarshalling case clause for different content-types:
 func buildUnmarshalCase(typeDefinition TypeDefinition, caseAction string, contentType string) (caseKey string, caseClause string) {
 	caseKey = fmt.Sprintf("%s.%s.%s", prefixLeastSpecific, contentType, typeDefinition.ResponseName)
-	if typeDefinition.ResponseName == "default" {
-		caseClause = fmt.Sprintf("case strings.Contains(rsp.Header.Get(\"%s\"), \"%s\"):\n%s\n", echo.HeaderContentType, contentType, caseAction)
-	} else {
-		caseClause = fmt.Sprintf("case strings.Contains(rsp.Header.Get(\"%s\"), \"%s\") && rsp.StatusCode == %s:\n%s\n", echo.HeaderContentType, contentType, typeDefinition.ResponseName, caseAction)
-	}
+	caseClauseKey := getConditionOfResponseName("rsp.StatusCode", typeDefinition.ResponseName)
+	caseClause = fmt.Sprintf("case strings.Contains(rsp.Header.Get(\"%s\"), \"%s\") && %s:\n%s\n", echo.HeaderContentType, contentType, caseClauseKey, caseAction)
 	return caseKey, caseClause
 }
 
@@ -245,6 +232,18 @@ func getResponseTypeDefinitions(op *OperationDefinition) []TypeDefinition {
 		panic(err)
 	}
 	return td
+}
+
+// Return the statusCode comparison clause from the response name.
+func getConditionOfResponseName(statusCodeVar, responseName string) string {
+	switch responseName {
+	case "default":
+		return "true"
+	case "1XX", "2XX", "3XX", "4XX", "5XX":
+		return fmt.Sprintf("%s / 100 == %s", statusCodeVar, responseName[:1])
+	default:
+		return fmt.Sprintf("%s == %s", statusCodeVar, responseName)
+	}
 }
 
 // This outputs a string array


### PR DESCRIPTION
Before, generic responses (like `4XX`) generate un-compilable code.

This fixes the generated code so that it handles generic responses more gracefully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/deepmap/oapi-codegen/224)
<!-- Reviewable:end -->
