### PR TITLE
Type aliasing

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -43,6 +43,7 @@ var (
 	flagImportMapping  string
 	flagExcludeSchemas string
 	flagConfigFile     string
+	flagAliasTypes     bool
 )
 
 type configuration struct {
@@ -68,6 +69,7 @@ func main() {
 	flag.StringVar(&flagImportMapping, "import-mapping", "", "A dict from the external reference to golang package path")
 	flag.StringVar(&flagExcludeSchemas, "exclude-schemas", "", "A comma separated list of schemas which must be excluded from generation")
 	flag.StringVar(&flagConfigFile, "config", "", "a YAML config file that controls oapi-codegen behavior")
+	flag.BoolVar(&flagAliasTypes, "alias-types", false, "Alias type declarations of possible")
 	flag.Parse()
 
 	if flag.NArg() < 1 {
@@ -87,7 +89,9 @@ func main() {
 		cfg.PackageName = codegen.ToCamelCase(nameParts[0])
 	}
 
-	opts := codegen.Options{}
+	opts := codegen.Options{
+		AliasTypes: flagAliasTypes,
+	}
 	for _, g := range cfg.GenerateTargets {
 		switch g {
 		case "client":

--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -59,7 +59,7 @@ type FindPetsParams struct {
 // AddPetJSONBody defines parameters for AddPet.
 type AddPetJSONBody NewPet
 
-// AddPetRequestBody defines body for AddPet for application/json ContentType.
+// AddPetJSONRequestBody defines body for AddPet for application/json ContentType.
 type AddPetJSONRequestBody AddPetJSONBody
 
 // ServerInterface represents all server handlers.

--- a/examples/petstore-expanded/echo/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/echo/api/petstore-types.gen.go
@@ -46,5 +46,5 @@ type FindPetsParams struct {
 // AddPetJSONBody defines parameters for AddPet.
 type AddPetJSONBody NewPet
 
-// AddPetRequestBody defines body for AddPet for application/json ContentType.
+// AddPetJSONRequestBody defines body for AddPet for application/json ContentType.
 type AddPetJSONRequestBody AddPetJSONBody

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -60,7 +60,7 @@ type FindPetsParams struct {
 // AddPetJSONBody defines parameters for AddPet.
 type AddPetJSONBody NewPet
 
-// AddPetRequestBody defines body for AddPet for application/json ContentType.
+// AddPetJSONRequestBody defines body for AddPet for application/json ContentType.
 type AddPetJSONRequestBody AddPetJSONBody
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -32,10 +32,10 @@ type PostBothJSONBody SchemaObject
 // PostJsonJSONBody defines parameters for PostJson.
 type PostJsonJSONBody SchemaObject
 
-// PostBothRequestBody defines body for PostBoth for application/json ContentType.
+// PostBothJSONRequestBody defines body for PostBoth for application/json ContentType.
 type PostBothJSONRequestBody PostBothJSONBody
 
-// PostJsonRequestBody defines body for PostJson for application/json ContentType.
+// PostJsonJSONRequestBody defines body for PostJson for application/json ContentType.
 type PostJsonJSONRequestBody PostJsonJSONBody
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -118,10 +118,10 @@ type BodyWithAddPropsJSONBody_Inner struct {
 	AdditionalProperties map[string]int `json:"-"`
 }
 
-// EnsureEverythingIsReferencedRequestBody defines body for EnsureEverythingIsReferenced for application/json ContentType.
+// EnsureEverythingIsReferencedJSONRequestBody defines body for EnsureEverythingIsReferenced for application/json ContentType.
 type EnsureEverythingIsReferencedJSONRequestBody RequestBody
 
-// BodyWithAddPropsRequestBody defines body for BodyWithAddProps for application/json ContentType.
+// BodyWithAddPropsJSONRequestBody defines body for BodyWithAddProps for application/json ContentType.
 type BodyWithAddPropsJSONRequestBody BodyWithAddPropsJSONBody
 
 // Getter for additional properties for ParamsWithAddPropsParams_P1. Returns the specified

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -61,10 +61,10 @@ type Issue9Params struct {
 	Foo string `json:"foo"`
 }
 
-// Issue185RequestBody defines body for Issue185 for application/json ContentType.
+// Issue185JSONRequestBody defines body for Issue185 for application/json ContentType.
 type Issue185JSONRequestBody Issue185JSONBody
 
-// Issue9RequestBody defines body for Issue9 for application/json ContentType.
+// Issue9JSONRequestBody defines body for Issue9 for application/json ContentType.
 type Issue9JSONRequestBody Issue9JSONBody
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -117,13 +117,13 @@ type UpdateResource3JSONBody struct {
 	Name *string `json:"name,omitempty"`
 }
 
-// CreateResourceRequestBody defines body for CreateResource for application/json ContentType.
+// CreateResourceJSONRequestBody defines body for CreateResource for application/json ContentType.
 type CreateResourceJSONRequestBody CreateResourceJSONBody
 
-// CreateResource2RequestBody defines body for CreateResource2 for application/json ContentType.
+// CreateResource2JSONRequestBody defines body for CreateResource2 for application/json ContentType.
 type CreateResource2JSONRequestBody CreateResource2JSONBody
 
-// UpdateResource3RequestBody defines body for UpdateResource3 for application/json ContentType.
+// UpdateResource3JSONRequestBody defines body for UpdateResource3 for application/json ContentType.
 type UpdateResource3JSONRequestBody UpdateResource3JSONBody
 
 // ServerInterface represents all server handlers.

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -38,6 +38,7 @@ type Options struct {
 	EmbedSpec          bool              // Whether to embed the swagger spec in the generated code
 	SkipFmt            bool              // Whether to skip go imports on the generated code
 	SkipPrune          bool              // Whether to skip pruning unused components on the generated code
+	AliasTypes         bool              // Whether to alias types if possible
 	IncludeTags        []string          // Only include operations that have one of these tags. Ignored when empty.
 	ExcludeTags        []string          // Exclude operations that have one of these tags. Ignored when empty.
 	UserTemplates      map[string]string // Override built-in templates from user-provided files
@@ -110,6 +111,7 @@ func Generate(swagger *openapi3.Swagger, packageName string, opts Options) (stri
 	}
 
 	// This creates the golang templates text package
+	TemplateFunctions["opts"] = func() Options { return opts }
 	t := template.New("oapi-codegen").Funcs(TemplateFunctions)
 	// This parses all of our own template files into the template object
 	// above

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -333,8 +333,11 @@ type RequestBodyDefinition struct {
 }
 
 // Returns the Go type definition for a request body
-func (r RequestBodyDefinition) TypeDef() string {
-	return r.Schema.TypeDecl()
+func (r RequestBodyDefinition) TypeDef(opID string) *TypeDefinition {
+	return &TypeDefinition{
+		TypeName: fmt.Sprintf("%s%sRequestBody", opID, r.NameTag),
+		Schema:   r.Schema,
+	}
 }
 
 // Returns whether the body is a custom inline type, or pre-defined. This is

--- a/pkg/codegen/templates/param-types.tmpl
+++ b/pkg/codegen/templates/param-types.tmpl
@@ -1,6 +1,6 @@
 {{range .}}{{$opid := .OperationId}}
 {{range .TypeDefinitions}}
 // {{.TypeName}} defines parameters for {{$opid}}.
-type {{.TypeName}} {{.Schema.TypeDecl}}
+type {{.TypeName}} {{if and (opts.AliasTypes) (.CanAlias)}}={{end}} {{.Schema.TypeDecl}}
 {{end}}
 {{end}}

--- a/pkg/codegen/templates/request-bodies.tmpl
+++ b/pkg/codegen/templates/request-bodies.tmpl
@@ -1,6 +1,8 @@
 {{range .}}{{$opid := .OperationId}}
 {{range .Bodies}}
-// {{$opid}}RequestBody defines body for {{$opid}} for application/json ContentType.
-type {{$opid}}{{.NameTag}}RequestBody {{.TypeDef}}
+{{with .TypeDef $opid}}
+// {{.TypeName}} defines body for {{$opid}} for application/json ContentType.
+type {{.TypeName}} {{if and (opts.AliasTypes) (.CanAlias)}}={{end}} {{.Schema.TypeDecl}}
+{{end}}
 {{end}}
 {{end}}

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -765,7 +765,7 @@ func GetSwagger() (*openapi3.Swagger, error) {
 	"param-types.tmpl": `{{range .}}{{$opid := .OperationId}}
 {{range .TypeDefinitions}}
 // {{.TypeName}} defines parameters for {{$opid}}.
-type {{.TypeName}} {{.Schema.TypeDecl}}
+type {{.TypeName}} {{if and (opts.AliasTypes) (.CanAlias)}}={{end}} {{.Schema.TypeDecl}}
 {{end}}
 {{end}}
 `,
@@ -805,8 +805,10 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 `,
 	"request-bodies.tmpl": `{{range .}}{{$opid := .OperationId}}
 {{range .Bodies}}
-// {{$opid}}RequestBody defines body for {{$opid}} for application/json ContentType.
-type {{$opid}}{{.NameTag}}RequestBody {{.TypeDef}}
+{{with .TypeDef $opid}}
+// {{.TypeName}} defines body for {{$opid}} for application/json ContentType.
+type {{.TypeName}} {{if and (opts.AliasTypes) (.CanAlias)}}={{end}} {{.Schema.TypeDecl}}
+{{end}}
 {{end}}
 {{end}}
 `,
@@ -820,7 +822,7 @@ type ServerInterface interface {
 `,
 	"typedef.tmpl": `{{range .Types}}
 // {{.TypeName}} defines model for {{.JsonName}}.
-type {{.TypeName}} {{.Schema.TypeDecl}}
+type {{.TypeName}} {{if and (opts.AliasTypes) (.CanAlias)}}={{end}} {{.Schema.TypeDecl}}
 {{- if gt (len .Schema.EnumValues) 0 }}
 // List of {{ .TypeName }}
 const (

--- a/pkg/codegen/templates/typedef.tmpl
+++ b/pkg/codegen/templates/typedef.tmpl
@@ -1,6 +1,6 @@
 {{range .Types}}
 // {{.TypeName}} defines model for {{.JsonName}}.
-type {{.TypeName}} {{.Schema.TypeDecl}}
+type {{.TypeName}} {{if and (opts.AliasTypes) (.CanAlias)}}={{end}} {{.Schema.TypeDecl}}
 {{- if gt (len .Schema.EnumValues) 0 }}
 // List of {{ .TypeName }}
 const (


### PR DESCRIPTION
Some types are unnecessary wrapped, for example 
```go
type AddPetJSONRequestBody Pet
```
which lengthens the code needed to create and handle such types.

I added an option, called `-alias-types`, that changes all types satisfying:
```go
type A struct { /* ... */ } // unchanged
type B string // native type wrappers are unchanged, they are useful for e.g. enums
type C = A  // Direct wrappers of another defined type is aliased
type D = []A // Array of referenced types are aliased
type E []int // Array of non-referenced types are not aliased
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/deepmap/oapi-codegen/232)
<!-- Reviewable:end -->
