### PR TITLE
fix: fixing time styling

### DIFF
--- a/pkg/runtime/styleparam.go
+++ b/pkg/runtime/styleparam.go
@@ -16,11 +16,14 @@ package runtime
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	errorsw "github.com/pkg/errors"
 )
 
 // Given an input value, such as a primitive type, array or object, turn it
@@ -132,7 +135,6 @@ func sortedKeys(strMap map[string]string) []string {
 	return keys
 }
 
-
 // This is a special case. The struct may be a time, in which case, marshal
 // it in RFC3339 format.
 func marshalTimeValue(value interface{}) (string, bool) {
@@ -149,7 +151,11 @@ func marshalTimeValue(value interface{}) (string, bool) {
 
 func styleStruct(style string, explode bool, paramName string, value interface{}) (string, error) {
 	if timeVal, ok := marshalTimeValue(value); ok {
-		return stylePrimitive(style, explode, paramName, timeVal)
+		styledVal, err := stylePrimitive(style, explode, paramName, url.QueryEscape(timeVal))
+		if err != nil {
+			return "", errorsw.Wrap(err, "failed to style time")
+		}
+		return styledVal, nil
 	}
 
 	if style == "deepObject" {

--- a/pkg/runtime/styleparam_test.go
+++ b/pkg/runtime/styleparam_test.go
@@ -34,7 +34,7 @@ func TestStyleParam(t *testing.T) {
 	dict := map[string]interface{}{}
 	dict["firstName"] = "Alex"
 	dict["role"] = "admin"
-	timestamp, _ := time.Parse(time.RFC3339, "2020-01-01T22:00:00Z")
+	timestamp, _ := time.Parse(time.RFC3339, "2020-01-01T22:00:00+02:00")
 
 	// ---------------------------- Simple Style -------------------------------
 
@@ -72,19 +72,19 @@ func TestStyleParam(t *testing.T) {
 
 	result, err = StyleParam("simple", false, "id", timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, "2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, "2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	result, err = StyleParam("simple", true, "id", timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, "2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, "2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	result, err = StyleParam("simple", false, "id", &timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, "2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, "2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	result, err = StyleParam("simple", true, "id", &timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, "2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, "2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	// ----------------------------- Label Style -------------------------------
 
@@ -122,19 +122,19 @@ func TestStyleParam(t *testing.T) {
 
 	result, err = StyleParam("label", false, "id", timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, ".2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, ".2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	result, err = StyleParam("label", true, "id", timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, ".2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, ".2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	result, err = StyleParam("label", false, "id", &timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, ".2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, ".2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	result, err = StyleParam("label", true, "id", &timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, ".2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, ".2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	// ----------------------------- Matrix Style ------------------------------
 
@@ -172,19 +172,19 @@ func TestStyleParam(t *testing.T) {
 
 	result, err = StyleParam("matrix", false, "id", timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, ";id=2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, ";id=2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	result, err = StyleParam("matrix", true, "id", timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, ";id=2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, ";id=2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	result, err = StyleParam("matrix", false, "id", &timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, ";id=2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, ";id=2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	result, err = StyleParam("matrix", true, "id", &timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, ";id=2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, ";id=2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	// ------------------------------ Form Style -------------------------------
 	result, err = StyleParam("form", false, "id", primitive)
@@ -221,19 +221,19 @@ func TestStyleParam(t *testing.T) {
 
 	result, err = StyleParam("form", false, "id", timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, "id=2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, "id=2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	result, err = StyleParam("form", true, "id", timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, "id=2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, "id=2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	result, err = StyleParam("form", false, "id", &timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, "id=2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, "id=2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	result, err = StyleParam("form", true, "id", &timestamp)
 	assert.NoError(t, err)
-	assert.EqualValues(t, "id=2020-01-01T22:00:00Z", result)
+	assert.EqualValues(t, "id=2020-01-01T22%3A00%3A00%2B02%3A00", result)
 
 	// ------------------------  spaceDelimited Style --------------------------
 
@@ -351,7 +351,6 @@ func TestStyleParam(t *testing.T) {
 
 	result, err = StyleParam("deepObject", true, "id", &timestamp)
 	assert.Error(t, err)
-
 
 	// Misc tests
 	// Test type aliases


### PR DESCRIPTION
This fixes the serialization of time values. 

If a  param with type _time_ has a value with positive timezone, e.g.  `2020-01-01T22:00:00+02:00`, it is unescaped by `url.ParseQuery` in the generated code into the `2020-01-01T22:00:00 02:00` string (missing the + char) and then wrongly escaped with %20 at that place later by `queryValues.Encode() `.
