### PR TITLE
make task for release assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .DS_Store
 .vscode/
+.bin

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,10 @@ generate:
 
 test:
 	go test -cover ./...
+
+build_release_assets: generate test
+	mkdir -p ./bin
+	GOOS=darwin GOARCH=amd64 go build -o ./.bin/oapi-codegen_darwin_amd64 ./cmd/oapi-codegen/oapi-codegen.go
+	GOOS=windows GOARCH=amd64 go build -o ./.bin/oapi-codegen_windows_amd64 ./cmd/oapi-codegen/oapi-codegen.go
+	GOOS=linux GOARCH=amd64 go build -o ./.bin/oapi-codegen_linux_amd64 ./cmd/oapi-codegen/oapi-codegen.go
+	GOOS=freebsd GOARCH=amd64 go build -o ./.bin/oapi-codegen_freebsd_amd64 ./cmd/oapi-codegen/oapi-codegen.go


### PR DESCRIPTION
Hi

Great work, I got up and running this AM in minutes, thank you!

A pattern I like to follow is to add binaries to GitHub releases (e.g. https://github.com/myles-mcdonnell/oapi-codegen/releases/tag/v1.4.0), I can then pin my toolchain (docker builds etc) to specific versions that I pull from the GH release.  You probably don't want to do this or you would have already but wanted to share what I did this morning on the off chance that you find it useful.

Thanks
Myles