### PR TITLE
Feature: Middlewares per handler in chi-server

### DIFF
--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -81,10 +81,10 @@ type ServerInterface interface {
 // ServerInterfaceWrapper converts contexts to parameters.
 type ServerInterfaceWrapper struct {
 	Handler            ServerInterface
-	HandlerMiddlewares []middlewareFunc
+	HandlerMiddlewares []MiddlewareFunc
 }
 
-type middlewareFunc func(http.HandlerFunc) http.HandlerFunc
+type MiddlewareFunc func(http.HandlerFunc) http.HandlerFunc
 
 // FindPets operation middleware
 func (siw *ServerInterfaceWrapper) FindPets(w http.ResponseWriter, r *http.Request) {

--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -80,8 +80,11 @@ type ServerInterface interface {
 
 // ServerInterfaceWrapper converts contexts to parameters.
 type ServerInterfaceWrapper struct {
-	Handler ServerInterface
+	Handler            ServerInterface
+	HandlerMiddlewares []middlewareFunc
 }
+
+type middlewareFunc func(http.HandlerFunc) http.HandlerFunc
 
 // FindPets operation middleware
 func (siw *ServerInterfaceWrapper) FindPets(w http.ResponseWriter, r *http.Request) {
@@ -114,14 +117,30 @@ func (siw *ServerInterfaceWrapper) FindPets(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	siw.Handler.FindPets(w, r.WithContext(ctx), params)
+	var handler = func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.FindPets(w, r, params)
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler(w, r.WithContext(ctx))
 }
 
 // AddPet operation middleware
 func (siw *ServerInterfaceWrapper) AddPet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	siw.Handler.AddPet(w, r.WithContext(ctx))
+	var handler = func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.AddPet(w, r)
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler(w, r.WithContext(ctx))
 }
 
 // DeletePet operation middleware
@@ -139,7 +158,15 @@ func (siw *ServerInterfaceWrapper) DeletePet(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	siw.Handler.DeletePet(w, r.WithContext(ctx), id)
+	var handler = func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeletePet(w, r, id)
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler(w, r.WithContext(ctx))
 }
 
 // FindPetById operation middleware
@@ -157,35 +184,65 @@ func (siw *ServerInterfaceWrapper) FindPetById(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	siw.Handler.FindPetById(w, r.WithContext(ctx), id)
+	var handler = func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.FindPetById(w, r, id)
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler(w, r.WithContext(ctx))
 }
 
 // Handler creates http.Handler with routing matching OpenAPI spec.
 func Handler(si ServerInterface) http.Handler {
-	return HandlerFromMux(si, chi.NewRouter())
+	return HandlerWithOptions(si, ChiServerOptions{})
+}
+
+type ChiServerOptions struct {
+	BaseURL     string
+	BaseRouter  chi.Router
+	Middlewares []middlewareFunc
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.
 func HandlerFromMux(si ServerInterface, r chi.Router) http.Handler {
-	return HandlerFromMuxWithBaseURL(si, r, "")
+	return HandlerWithOptions(si, ChiServerOptions{
+		BaseRouter: r,
+	})
 }
 
 func HandlerFromMuxWithBaseURL(si ServerInterface, r chi.Router, baseURL string) http.Handler {
+	return HandlerWithOptions(si, ChiServerOptions{
+		BaseURL:    baseURL,
+		BaseRouter: r,
+	})
+}
+
+// HandlerWithOptions creates http.Handler with additional options
+func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handler {
+	r := options.BaseRouter
+
+	if r == nil {
+		r = chi.NewRouter()
+	}
 	wrapper := ServerInterfaceWrapper{
-		Handler: si,
+		Handler:            si,
+		HandlerMiddlewares: options.Middlewares,
 	}
 
 	r.Group(func(r chi.Router) {
-		r.Get(baseURL+"/pets", wrapper.FindPets)
+		r.Get(options.BaseURL+"/pets", wrapper.FindPets)
 	})
 	r.Group(func(r chi.Router) {
-		r.Post(baseURL+"/pets", wrapper.AddPet)
+		r.Post(options.BaseURL+"/pets", wrapper.AddPet)
 	})
 	r.Group(func(r chi.Router) {
-		r.Delete(baseURL+"/pets/{id}", wrapper.DeletePet)
+		r.Delete(options.BaseURL+"/pets/{id}", wrapper.DeletePet)
 	})
 	r.Group(func(r chi.Router) {
-		r.Get(baseURL+"/pets/{id}", wrapper.FindPetById)
+		r.Get(options.BaseURL+"/pets/{id}", wrapper.FindPetById)
 	})
 
 	return r

--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -203,7 +203,7 @@ func Handler(si ServerInterface) http.Handler {
 type ChiServerOptions struct {
 	BaseURL     string
 	BaseRouter  chi.Router
-	Middlewares []middlewareFunc
+	Middlewares []MiddlewareFunc
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -164,10 +164,10 @@ type ServerInterface interface {
 // ServerInterfaceWrapper converts contexts to parameters.
 type ServerInterfaceWrapper struct {
 	Handler            ServerInterface
-	HandlerMiddlewares []middlewareFunc
+	HandlerMiddlewares []MiddlewareFunc
 }
 
-type middlewareFunc func(http.HandlerFunc) http.HandlerFunc
+type MiddlewareFunc func(http.HandlerFunc) http.HandlerFunc
 
 // GetEveryTypeOptional operation middleware
 func (siw *ServerInterfaceWrapper) GetEveryTypeOptional(w http.ResponseWriter, r *http.Request) {

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -163,21 +163,40 @@ type ServerInterface interface {
 
 // ServerInterfaceWrapper converts contexts to parameters.
 type ServerInterfaceWrapper struct {
-	Handler ServerInterface
+	Handler            ServerInterface
+	HandlerMiddlewares []middlewareFunc
 }
+
+type middlewareFunc func(http.HandlerFunc) http.HandlerFunc
 
 // GetEveryTypeOptional operation middleware
 func (siw *ServerInterfaceWrapper) GetEveryTypeOptional(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	siw.Handler.GetEveryTypeOptional(w, r.WithContext(ctx))
+	var handler = func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetEveryTypeOptional(w, r)
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler(w, r.WithContext(ctx))
 }
 
 // GetSimple operation middleware
 func (siw *ServerInterfaceWrapper) GetSimple(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	siw.Handler.GetSimple(w, r.WithContext(ctx))
+	var handler = func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetSimple(w, r)
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler(w, r.WithContext(ctx))
 }
 
 // GetWithArgs operation middleware
@@ -235,7 +254,15 @@ func (siw *ServerInterfaceWrapper) GetWithArgs(w http.ResponseWriter, r *http.Re
 
 	}
 
-	siw.Handler.GetWithArgs(w, r.WithContext(ctx), params)
+	var handler = func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetWithArgs(w, r, params)
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler(w, r.WithContext(ctx))
 }
 
 // GetWithReferences operation middleware
@@ -262,7 +289,15 @@ func (siw *ServerInterfaceWrapper) GetWithReferences(w http.ResponseWriter, r *h
 		return
 	}
 
-	siw.Handler.GetWithReferences(w, r.WithContext(ctx), globalArgument, argument)
+	var handler = func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetWithReferences(w, r, globalArgument, argument)
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler(w, r.WithContext(ctx))
 }
 
 // GetWithContentType operation middleware
@@ -280,14 +315,30 @@ func (siw *ServerInterfaceWrapper) GetWithContentType(w http.ResponseWriter, r *
 		return
 	}
 
-	siw.Handler.GetWithContentType(w, r.WithContext(ctx), contentType)
+	var handler = func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetWithContentType(w, r, contentType)
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler(w, r.WithContext(ctx))
 }
 
 // GetReservedKeyword operation middleware
 func (siw *ServerInterfaceWrapper) GetReservedKeyword(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	siw.Handler.GetReservedKeyword(w, r.WithContext(ctx))
+	var handler = func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetReservedKeyword(w, r)
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler(w, r.WithContext(ctx))
 }
 
 // CreateResource operation middleware
@@ -305,7 +356,15 @@ func (siw *ServerInterfaceWrapper) CreateResource(w http.ResponseWriter, r *http
 		return
 	}
 
-	siw.Handler.CreateResource(w, r.WithContext(ctx), argument)
+	var handler = func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateResource(w, r, argument)
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler(w, r.WithContext(ctx))
 }
 
 // CreateResource2 operation middleware
@@ -337,7 +396,15 @@ func (siw *ServerInterfaceWrapper) CreateResource2(w http.ResponseWriter, r *htt
 		return
 	}
 
-	siw.Handler.CreateResource2(w, r.WithContext(ctx), inlineArgument, params)
+	var handler = func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateResource2(w, r, inlineArgument, params)
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler(w, r.WithContext(ctx))
 }
 
 // UpdateResource3 operation middleware
@@ -355,60 +422,98 @@ func (siw *ServerInterfaceWrapper) UpdateResource3(w http.ResponseWriter, r *htt
 		return
 	}
 
-	siw.Handler.UpdateResource3(w, r.WithContext(ctx), pFallthrough)
+	var handler = func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateResource3(w, r, pFallthrough)
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler(w, r.WithContext(ctx))
 }
 
 // GetResponseWithReference operation middleware
 func (siw *ServerInterfaceWrapper) GetResponseWithReference(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	siw.Handler.GetResponseWithReference(w, r.WithContext(ctx))
+	var handler = func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetResponseWithReference(w, r)
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler(w, r.WithContext(ctx))
 }
 
 // Handler creates http.Handler with routing matching OpenAPI spec.
 func Handler(si ServerInterface) http.Handler {
-	return HandlerFromMux(si, chi.NewRouter())
+	return HandlerWithOptions(si, ChiServerOptions{})
+}
+
+type ChiServerOptions struct {
+	BaseURL     string
+	BaseRouter  chi.Router
+	Middlewares []middlewareFunc
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.
 func HandlerFromMux(si ServerInterface, r chi.Router) http.Handler {
-	return HandlerFromMuxWithBaseURL(si, r, "")
+	return HandlerWithOptions(si, ChiServerOptions{
+		BaseRouter: r,
+	})
 }
 
 func HandlerFromMuxWithBaseURL(si ServerInterface, r chi.Router, baseURL string) http.Handler {
+	return HandlerWithOptions(si, ChiServerOptions{
+		BaseURL:    baseURL,
+		BaseRouter: r,
+	})
+}
+
+// HandlerWithOptions creates http.Handler with additional options
+func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handler {
+	r := options.BaseRouter
+
+	if r == nil {
+		r = chi.NewRouter()
+	}
 	wrapper := ServerInterfaceWrapper{
-		Handler: si,
+		Handler:            si,
+		HandlerMiddlewares: options.Middlewares,
 	}
 
 	r.Group(func(r chi.Router) {
-		r.Get(baseURL+"/every-type-optional", wrapper.GetEveryTypeOptional)
+		r.Get(options.BaseURL+"/every-type-optional", wrapper.GetEveryTypeOptional)
 	})
 	r.Group(func(r chi.Router) {
-		r.Get(baseURL+"/get-simple", wrapper.GetSimple)
+		r.Get(options.BaseURL+"/get-simple", wrapper.GetSimple)
 	})
 	r.Group(func(r chi.Router) {
-		r.Get(baseURL+"/get-with-args", wrapper.GetWithArgs)
+		r.Get(options.BaseURL+"/get-with-args", wrapper.GetWithArgs)
 	})
 	r.Group(func(r chi.Router) {
-		r.Get(baseURL+"/get-with-references/{global_argument}/{argument}", wrapper.GetWithReferences)
+		r.Get(options.BaseURL+"/get-with-references/{global_argument}/{argument}", wrapper.GetWithReferences)
 	})
 	r.Group(func(r chi.Router) {
-		r.Get(baseURL+"/get-with-type/{content_type}", wrapper.GetWithContentType)
+		r.Get(options.BaseURL+"/get-with-type/{content_type}", wrapper.GetWithContentType)
 	})
 	r.Group(func(r chi.Router) {
-		r.Get(baseURL+"/reserved-keyword", wrapper.GetReservedKeyword)
+		r.Get(options.BaseURL+"/reserved-keyword", wrapper.GetReservedKeyword)
 	})
 	r.Group(func(r chi.Router) {
-		r.Post(baseURL+"/resource/{argument}", wrapper.CreateResource)
+		r.Post(options.BaseURL+"/resource/{argument}", wrapper.CreateResource)
 	})
 	r.Group(func(r chi.Router) {
-		r.Post(baseURL+"/resource2/{inline_argument}", wrapper.CreateResource2)
+		r.Post(options.BaseURL+"/resource2/{inline_argument}", wrapper.CreateResource2)
 	})
 	r.Group(func(r chi.Router) {
-		r.Put(baseURL+"/resource3/{fallthrough}", wrapper.UpdateResource3)
+		r.Put(options.BaseURL+"/resource3/{fallthrough}", wrapper.UpdateResource3)
 	})
 	r.Group(func(r chi.Router) {
-		r.Get(baseURL+"/response-with-reference", wrapper.GetResponseWithReference)
+		r.Get(options.BaseURL+"/response-with-reference", wrapper.GetResponseWithReference)
 	})
 
 	return r

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -456,7 +456,7 @@ func Handler(si ServerInterface) http.Handler {
 type ChiServerOptions struct {
 	BaseURL     string
 	BaseRouter  chi.Router
-	Middlewares []middlewareFunc
+	Middlewares []MiddlewareFunc
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.

--- a/pkg/codegen/templates/chi-handler.tmpl
+++ b/pkg/codegen/templates/chi-handler.tmpl
@@ -6,7 +6,7 @@ func Handler(si ServerInterface) http.Handler {
 type ChiServerOptions struct {
     BaseURL string
     BaseRouter chi.Router
-    Middlewares []middlewareFunc
+    Middlewares []MiddlewareFunc
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.

--- a/pkg/codegen/templates/chi-handler.tmpl
+++ b/pkg/codegen/templates/chi-handler.tmpl
@@ -1,21 +1,43 @@
 // Handler creates http.Handler with routing matching OpenAPI spec.
 func Handler(si ServerInterface) http.Handler {
-  return HandlerFromMux(si, chi.NewRouter())
+  return HandlerWithOptions(si, ChiServerOptions{})
+}
+
+type ChiServerOptions struct {
+    BaseURL string
+    BaseRouter chi.Router
+    Middlewares []middlewareFunc
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.
 func HandlerFromMux(si ServerInterface, r chi.Router) http.Handler {
-    return HandlerFromMuxWithBaseURL(si, r, "")
+    return HandlerWithOptions(si, ChiServerOptions {
+        BaseRouter: r,
+    })
 }
 
 func HandlerFromMuxWithBaseURL(si ServerInterface, r chi.Router, baseURL string) http.Handler {
+    return HandlerWithOptions(si, ChiServerOptions {
+        BaseURL: baseURL,
+        BaseRouter: r,
+    })
+}
+
+// HandlerWithOptions creates http.Handler with additional options
+func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handler {
+r := options.BaseRouter
+
+if r == nil {
+r = chi.NewRouter()
+}
 {{if .}}wrapper := ServerInterfaceWrapper{
-        Handler: si,
-    }
+Handler: si,
+HandlerMiddlewares: options.Middlewares,
+}
 {{end}}
 {{range .}}r.Group(func(r chi.Router) {
-  r.{{.Method | lower | title }}(baseURL+"{{.Path | swaggerUriToChiUri}}", wrapper.{{.OperationId}})
+r.{{.Method | lower | title }}(options.BaseURL+"{{.Path | swaggerUriToChiUri}}", wrapper.{{.OperationId}})
 })
 {{end}}
-  return r
+return r
 }

--- a/pkg/codegen/templates/chi-middleware.tmpl
+++ b/pkg/codegen/templates/chi-middleware.tmpl
@@ -1,7 +1,10 @@
 // ServerInterfaceWrapper converts contexts to parameters.
 type ServerInterfaceWrapper struct {
     Handler ServerInterface
+    HandlerMiddlewares []middlewareFunc
 }
+
+type middlewareFunc func(http.HandlerFunc) http.HandlerFunc
 
 {{range .}}{{$opid := .OperationId}}
 
@@ -159,7 +162,16 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
       {{- end}}
     {{end}}
   {{end}}
-  siw.Handler.{{.OperationId}}(w, r.WithContext(ctx){{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
+
+  var handler = func(w http.ResponseWriter, r *http.Request) {
+    siw.Handler.{{.OperationId}}(w, r{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
+}
+
+  for _, middleware := range siw.HandlerMiddlewares {
+    handler = middleware(handler)
+  }
+
+  handler(w, r.WithContext(ctx))
 }
 {{end}}
 

--- a/pkg/codegen/templates/chi-middleware.tmpl
+++ b/pkg/codegen/templates/chi-middleware.tmpl
@@ -1,10 +1,10 @@
 // ServerInterfaceWrapper converts contexts to parameters.
 type ServerInterfaceWrapper struct {
     Handler ServerInterface
-    HandlerMiddlewares []middlewareFunc
+    HandlerMiddlewares []MiddlewareFunc
 }
 
-type middlewareFunc func(http.HandlerFunc) http.HandlerFunc
+type MiddlewareFunc func(http.HandlerFunc) http.HandlerFunc
 
 {{range .}}{{$opid := .OperationId}}
 

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -75,24 +75,46 @@ func (a {{.TypeName}}) MarshalJSON() ([]byte, error) {
 `,
 	"chi-handler.tmpl": `// Handler creates http.Handler with routing matching OpenAPI spec.
 func Handler(si ServerInterface) http.Handler {
-  return HandlerFromMux(si, chi.NewRouter())
+  return HandlerWithOptions(si, ChiServerOptions{})
+}
+
+type ChiServerOptions struct {
+    BaseURL string
+    BaseRouter chi.Router
+    Middlewares []middlewareFunc
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.
 func HandlerFromMux(si ServerInterface, r chi.Router) http.Handler {
-    return HandlerFromMuxWithBaseURL(si, r, "")
+    return HandlerWithOptions(si, ChiServerOptions {
+        BaseRouter: r,
+    })
 }
 
 func HandlerFromMuxWithBaseURL(si ServerInterface, r chi.Router, baseURL string) http.Handler {
+    return HandlerWithOptions(si, ChiServerOptions {
+        BaseURL: baseURL,
+        BaseRouter: r,
+    })
+}
+
+// HandlerWithOptions creates http.Handler with additional options
+func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handler {
+r := options.BaseRouter
+
+if r == nil {
+r = chi.NewRouter()
+}
 {{if .}}wrapper := ServerInterfaceWrapper{
-        Handler: si,
-    }
+Handler: si,
+HandlerMiddlewares: options.Middlewares,
+}
 {{end}}
 {{range .}}r.Group(func(r chi.Router) {
-  r.{{.Method | lower | title }}(baseURL+"{{.Path | swaggerUriToChiUri}}", wrapper.{{.OperationId}})
+r.{{.Method | lower | title }}(options.BaseURL+"{{.Path | swaggerUriToChiUri}}", wrapper.{{.OperationId}})
 })
 {{end}}
-  return r
+return r
 }
 `,
 	"chi-interface.tmpl": `// ServerInterface represents all server handlers.
@@ -106,7 +128,10 @@ type ServerInterface interface {
 	"chi-middleware.tmpl": `// ServerInterfaceWrapper converts contexts to parameters.
 type ServerInterfaceWrapper struct {
     Handler ServerInterface
+    HandlerMiddlewares []middlewareFunc
 }
+
+type middlewareFunc func(http.HandlerFunc) http.HandlerFunc
 
 {{range .}}{{$opid := .OperationId}}
 
@@ -264,7 +289,16 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
       {{- end}}
     {{end}}
   {{end}}
-  siw.Handler.{{.OperationId}}(w, r.WithContext(ctx){{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
+
+  var handler = func(w http.ResponseWriter, r *http.Request) {
+    siw.Handler.{{.OperationId}}(w, r{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
+}
+
+  for _, middleware := range siw.HandlerMiddlewares {
+    handler = middleware(handler)
+  }
+
+  handler(w, r.WithContext(ctx))
 }
 {{end}}
 

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -128,10 +128,10 @@ type ServerInterface interface {
 	"chi-middleware.tmpl": `// ServerInterfaceWrapper converts contexts to parameters.
 type ServerInterfaceWrapper struct {
     Handler ServerInterface
-    HandlerMiddlewares []middlewareFunc
+    HandlerMiddlewares []MiddlewareFunc
 }
 
-type middlewareFunc func(http.HandlerFunc) http.HandlerFunc
+type MiddlewareFunc func(http.HandlerFunc) http.HandlerFunc
 
 {{range .}}{{$opid := .OperationId}}
 

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -81,7 +81,7 @@ func Handler(si ServerInterface) http.Handler {
 type ChiServerOptions struct {
     BaseURL string
     BaseRouter chi.Router
-    Middlewares []middlewareFunc
+    Middlewares []MiddlewareFunc
 }
 
 // HandlerFromMux creates http.Handler with routing matching OpenAPI spec based on the provided mux.


### PR DESCRIPTION
### 1. Add `HandlerMiddlewares` to `ServerInterfaceWrapper`

#### What changed

A `HandlerMiddlewares []middlewareFunc` field was added to `ServerInterfaceWrapper`, storing a slice of middleware functions.

`type middlewareFunc func(http.HandlerFunc) http.HandlerFunc` follows the basic middleware convention used within `chi`.

The middlewares are applied from `0` to `n` before the wrapped handler:

```go
        var handler = func(w http.ResponseWriter, r *http.Request) {
		siw.Handler.DeletePet(w, r, id)
	}

	for _, middleware := range siw.HandlerMiddlewares {
		handler = middleware(handler)
	}

	handler(w, r.WithContext(ctx))
```

The stack receives a `*http.Request` with any context values set for the handler.

#### Rationale

It was previously possible to add middlewares to the auto-generated `chi` server, but it was attained through passing a custom `chi.Router` to `HandlerFromMux` or `HandlerFromMuxWithBaseURL`.

Before, the context values were added to `ctx` **after** all `chi.Middlewares` had already fired, between the auto-generated wrapper and the wrapped handler:

```go
// DeletePet operation middleware
func (siw *ServerInterfaceWrapper) DeletePet(w http.ResponseWriter, r *http.Request) {
	ctx := r.Context()

	var err error

	// ------------- Path parameter "id" -------------
	var id int64

	err = runtime.BindStyledParameter("simple", false, "id", chi.URLParam(r, "id"), &id)
	if err != nil {
		http.Error(w, fmt.Sprintf("Invalid format for parameter id: %s", err), http.StatusBadRequest)
		return
	}

	ctx = context.WithValue(ctx, "bearer.Scopes", []string{"pets:delete"})

	siw.Handler.DeletePet(w, r.WithContext(ctx), id)
}
```
_note: I added a `pets:delete` expected scope to the operation to make my point clearer_

Now, the enriched context will be passed through the stack of middlewares, enabling a permissions middleware that reads the expected scopes from ctx values dictated by the OpenApi definition, and compares them to the scopes that came with the request:

```go
// DeletePet operation middleware
func (siw *ServerInterfaceWrapper) DeletePet(w http.ResponseWriter, r *http.Request) {
	ctx := r.Context()

	var err error

	// ------------- Path parameter "id" -------------
	var id int64

	err = runtime.BindStyledParameter("simple", false, "id", chi.URLParam(r, "id"), &id)
	if err != nil {
		http.Error(w, fmt.Sprintf("Invalid format for parameter id: %s", err), http.StatusBadRequest)
		return
	}

	ctx = context.WithValue(ctx, "bearer.Scopes", []string{"pets:delete"})

	var handler = func(w http.ResponseWriter, r *http.Request) {
		siw.Handler.DeletePet(w, r, id)
	}

	for _, middleware := range siw.HandlerMiddlewares {
		handler = middleware(handler)
	}

	handler(w, r.WithContext(ctx))
}
```

The permissions middleware can read the `bearer.Scopes` context value to find out what scopes are expected for the call and compare with what's presented for the request.
The Openapi def becomes the only source of truth for expected security scopes for every operation, and there's no need to duplicate them in non-auto-generated code.

Because of the middleware pattern, it may pass to lower handler in the stack or cut it short, writing a `401` or `403` status.

### 2. Add a `HandlerWithOptions` auto-generated constructor for the chi Server handler.

#### What changed

A new constructor `HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handler` was added that takes an options struct:

```go
type ChiServerOptions struct {
    BaseURL string
    BaseRouter chi.Router
    Middlewares []middlewareFunc
}
```

Unfortunately, there are 3 different constructors introduced previously, so this is starting to pollute the scope.
However, this newest constructor is extensible, so no new ones will be necessary.

All the previous constructors (`Handler`, `HandlerFromMux`, `HandlerFromMuxWithBaseURL`) have been expressed in terms of the new one, to avoid duplication and to retain previous functionality.

Zero values of `ChiServerOptions` behave in a sane manner.

#### Rationale

I wanted to retain symmetry with the previous approaches that there's a designated `Handler*` function to create a new handler, so that `ServerInterfaceWrapper` doesn't have to be enriched with `Middlewares` manually.

This will improve adding new features in the future, because `ChiServerOptions` is extensible without breaking the API.