### PR TITLE
Mark embedded structs for inlining in yaml

### DIFF
--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -39,7 +39,7 @@ type NewPet struct {
 // Pet defines model for Pet.
 type Pet struct {
 	// Embedded struct due to allOf(#/components/schemas/NewPet)
-	NewPet
+	NewPet `yaml:",inline"`
 	// Embedded fields due to inline allOf schema
 
 	// Unique id of the pet

--- a/examples/petstore-expanded/echo/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/echo/api/petstore-types.gen.go
@@ -26,7 +26,7 @@ type NewPet struct {
 // Pet defines model for Pet.
 type Pet struct {
 	// Embedded struct due to allOf(#/components/schemas/NewPet)
-	NewPet
+	NewPet `yaml:",inline"`
 	// Embedded fields due to inline allOf schema
 
 	// Unique id of the pet

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -40,7 +40,7 @@ type NewPet struct {
 // Pet defines model for Pet.
 type Pet struct {
 	// Embedded struct due to allOf(#/components/schemas/NewPet)
-	NewPet
+	NewPet `yaml:",inline"`
 	// Embedded fields due to inline allOf schema
 
 	// Unique id of the pet

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -430,7 +430,7 @@ func GenStructFromAllOf(allOf []*openapi3.SchemaRef, path []string) (string, err
 			objectParts = append(objectParts,
 				fmt.Sprintf("   // Embedded struct due to allOf(%s)", ref))
 			objectParts = append(objectParts,
-				fmt.Sprintf("   %s", goType))
+				fmt.Sprintf("   %s `yaml:\",inline\"`", goType))
 		} else {
 			// Inline all the fields from the schema into the output struct,
 			// just like in the simple case of generating an object.


### PR DESCRIPTION
Configures yaml to inline the embedded struct, see: https://github.com/go-yaml/yaml/blob/7649d4548cb53a614db133b2a8ac1f31859dda8c/yaml.go#L183-L186