### PR TITLE
New Bind method to allow more custom basic types

### DIFF
--- a/pkg/runtime/bind.go
+++ b/pkg/runtime/bind.go
@@ -1,0 +1,24 @@
+// Copyright 2021 DeepMap, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package runtime
+
+// Binder is the interface implemented by types that can be bound to a query string or a parameter string
+// The input can be assumed to be a valid string.  If you define a Bind method you are responsible for all
+// data being completely bound to the type.
+//
+// By convention, to approximate the behavior of Bind functions themselves,
+// Binder implements Bind("") as a no-op.
+type Binder interface {
+	Bind(src string) error
+}

--- a/pkg/runtime/bindstring.go
+++ b/pkg/runtime/bindstring.go
@@ -76,6 +76,11 @@ func BindStringToObject(src string, dst interface{}) error {
 			v.SetBool(val)
 		}
 	case reflect.Struct:
+		// if this is not of type Time or of type Date look to see if this is of type Binder.
+		if dstType, ok := dst.(Binder); ok {
+			return dstType.Bind(src)
+		}
+
 		if t.ConvertibleTo(reflect.TypeOf(time.Time{})) {
 			// Don't fail on empty string.
 			if src == "" {
@@ -122,10 +127,6 @@ func BindStringToObject(src string, dst interface{}) error {
 			}
 			v.Set(reflect.ValueOf(parsedDate))
 			return nil
-		}
-		// if this is not of type Time or of type Date look to see if this is of type Binder.
-		if dstType, ok := dst.(Binder); ok {
-			return dstType.Bind(src)
 		}
 
 		// We fall through to the error case below if we haven't handled the

--- a/pkg/runtime/bindstring.go
+++ b/pkg/runtime/bindstring.go
@@ -90,7 +90,7 @@ func BindStringToObject(src string, dst interface{}) error {
 				}
 			}
 			// So, assigning this gets a little fun. We have a value to the
-			// dereferenced destination. We can't do a conversion to
+			// dereference destination. We can't do a conversion to
 			// time.Time because the result isn't assignable, so we need to
 			// convert pointers.
 			if t != reflect.TypeOf(time.Time{}) {
@@ -122,6 +122,10 @@ func BindStringToObject(src string, dst interface{}) error {
 			}
 			v.Set(reflect.ValueOf(parsedDate))
 			return nil
+		}
+		// if this is not of type Time or of type Date look to see if this is of type Binder.
+		if dstType, ok := dst.(Binder); ok {
+			return dstType.Bind(src)
 		}
 
 		// We fall through to the error case below if we haven't handled the

--- a/pkg/runtime/bindstring_test.go
+++ b/pkg/runtime/bindstring_test.go
@@ -161,4 +161,12 @@ func TestBindStringToObject(t *testing.T) {
 	type AliasedDate types.Date
 	var dstAliasedDate AliasedDate
 	assert.NoError(t, BindStringToObject(dateString, &dstAliasedDate))
+
+	// Checks whether a mock binder works and embedded types
+	var mockBinder MockBinder
+	assert.NoError(t, BindStringToObject(dateString, &mockBinder))
+	assert.EqualValues(t, dateString, mockBinder.Time.Format("2006-01-02"))
+	var dstEmbeddedMockBinder EmbeddedMockBinder
+	assert.NoError(t, BindStringToObject(dateString, &dstEmbeddedMockBinder))
+	assert.EqualValues(t, dateString, dstEmbeddedMockBinder.Time.Format("2006-01-02"))
 }

--- a/pkg/runtime/deepobject.go
+++ b/pkg/runtime/deepobject.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/deepmap/oapi-codegen/pkg/types"
 	"net/url"
 	"reflect"
 	"sort"
@@ -11,8 +12,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
-	"github.com/deepmap/oapi-codegen/pkg/types"
 )
 
 func marshalDeepObject(in interface{}, path []string) ([]string, error) {
@@ -212,9 +211,9 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 		return nil
 	case reflect.Struct:
 		// Some special types we care about are structs. Handle them
-		// here. They may be aliased, so we need to do some hoop
+		// here. They may be redefined, so we need to do some hoop
 		// jumping. If the types are aliased, we need to type convert
-		// the pointer, then set the value of the dereferenced pointer.
+		// the pointer, then set the value of the dereference pointer.
 		if it.ConvertibleTo(reflect.TypeOf(types.Date{})) {
 			var date types.Date
 			var err error
@@ -231,7 +230,6 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 			}
 			dst.Set(reflect.ValueOf(date))
 		}
-
 		if it.ConvertibleTo(reflect.TypeOf(time.Time{})) {
 			var tm time.Time
 			var err error
@@ -253,7 +251,11 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 			}
 			dst.Set(reflect.ValueOf(tm))
 		}
-
+		// If we don't match those two standard cases we should check the Binder interface.
+		//
+		if dst, isBinder := v.Interface().(Binder); isBinder {
+			return dst.Bind(pathValues.value)
+		}
 		fieldMap, err := fieldIndicesByJsonTag(iv.Interface())
 		if err != nil {
 			return errors.Wrap(err, "failed enumerating fields")

--- a/pkg/runtime/deepobject.go
+++ b/pkg/runtime/deepobject.go
@@ -214,6 +214,12 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 		// here. They may be redefined, so we need to do some hoop
 		// jumping. If the types are aliased, we need to type convert
 		// the pointer, then set the value of the dereference pointer.
+
+		// We check to see if the object implements the Binder interface first.
+		if dst, isBinder := v.Interface().(Binder); isBinder {
+			return dst.Bind(pathValues.value)
+		}
+		// Then check the legacy types
 		if it.ConvertibleTo(reflect.TypeOf(types.Date{})) {
 			var date types.Date
 			var err error
@@ -250,11 +256,6 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 				dst = reflect.Indirect(aPtr)
 			}
 			dst.Set(reflect.ValueOf(tm))
-		}
-		// If we don't match those two standard cases we should check the Binder interface.
-		//
-		if dst, isBinder := v.Interface().(Binder); isBinder {
-			return dst.Bind(pathValues.value)
 		}
 		fieldMap, err := fieldIndicesByJsonTag(iv.Interface())
 		if err != nil {

--- a/pkg/runtime/deepobject_test.go
+++ b/pkg/runtime/deepobject_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,8 @@ type AllFields struct {
 	Oas *[]string    `json:"oas,omitempty"`
 	O   InnerObject  `json:"o"`
 	Oo  *InnerObject `json:"oo,omitempty"`
+	D   MockBinder   `json:"d"`
+	Od  *MockBinder  `json:"od,omitempty"`
 }
 
 func TestDeepObject(t *testing.T) {
@@ -37,6 +40,7 @@ func TestDeepObject(t *testing.T) {
 		Name: "Marcin Romaszewicz",
 		ID:   123,
 	}
+	d := MockBinder{Time: time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC)}
 
 	srcObj := AllFields{
 		I:   12,
@@ -52,6 +56,8 @@ func TestDeepObject(t *testing.T) {
 			ID:   456,
 		},
 		Oo: &oo,
+		D:  d,
+		Od: &d,
 	}
 
 	marshaled, err := MarshalDeepObject(srcObj, "p")


### PR DESCRIPTION
This introduces the Bind Method to allow new custom types to be defined for query parameters without introducing a new dependency between runtime and types.