### PR TITLE
Error Message for Non-String Enum

### DIFF
--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -268,8 +268,12 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 			outSchema.GoType = "bool"
 		case "string":
 			enumValues := make([]string, len(schema.Enum))
+			var ok bool
 			for i, enumValue := range schema.Enum {
-				enumValues[i] = enumValue.(string)
+				enumValues[i], ok = enumValue.(string)
+				if !ok {
+					return Schema{}, fmt.Errorf("expected enum to contain strings, found a %T", enumValue)
+				}
 			}
 
 			outSchema.EnumValues = SanitizeEnumNames(enumValues)


### PR DESCRIPTION
I just ran across a spec that had an enum containing the values `[Y, N]` which were meant as strings but interpreted as boolean, causing a panic during generation with the message `interface conversion: interface {} is bool, not string` at `schema.go:272`.

This tweak adds a helpful error message that lets you locate which part of the spec broke the generation and fix it, such as changing to `['Y', 'N']`.