### PR TITLE
Allow Content-Type override

### DIFF
--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -325,6 +325,7 @@ func NewAddPetRequestWithBody(server string, contentType string, body io.Reader)
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
 	return req, nil
 }
 

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -308,6 +308,7 @@ func NewPostBothRequestWithBody(server string, contentType string, body io.Reade
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
 	return req, nil
 }
 
@@ -374,6 +375,7 @@ func NewPostJsonRequestWithBody(server string, contentType string, body io.Reade
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
 	return req, nil
 }
 
@@ -429,6 +431,7 @@ func NewPostOtherRequestWithBody(server string, contentType string, body io.Read
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
 	return req, nil
 }
 

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -918,6 +918,7 @@ func NewEnsureEverythingIsReferencedRequestWithBody(server string, contentType s
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
 	return req, nil
 }
 
@@ -1012,6 +1013,7 @@ func NewBodyWithAddPropsRequestWithBody(server string, contentType string, body 
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
 	return req, nil
 }
 

--- a/internal/test/issues/issue-grab_import_names/issue.gen.go
+++ b/internal/test/issues/issue-grab_import_names/issue.gen.go
@@ -154,7 +154,7 @@ func NewGetFooRequest(server string, params *GetFooParams) (*http.Request, error
 			return nil, err
 		}
 
-		req.Header.Add("Foo", headerParam0)
+		req.Header.Set("Foo", headerParam0)
 	}
 
 	if params.Bar != nil {
@@ -165,7 +165,7 @@ func NewGetFooRequest(server string, params *GetFooParams) (*http.Request, error
 			return nil, err
 		}
 
-		req.Header.Add("Bar", headerParam1)
+		req.Header.Set("Bar", headerParam1)
 	}
 
 	return req, nil

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -733,7 +733,7 @@ func NewGetHeaderRequest(server string, params *GetHeaderParams) (*http.Request,
 			return nil, err
 		}
 
-		req.Header.Add("X-Primitive", headerParam0)
+		req.Header.Set("X-Primitive", headerParam0)
 	}
 
 	if params.XPrimitiveExploded != nil {
@@ -744,7 +744,7 @@ func NewGetHeaderRequest(server string, params *GetHeaderParams) (*http.Request,
 			return nil, err
 		}
 
-		req.Header.Add("X-Primitive-Exploded", headerParam1)
+		req.Header.Set("X-Primitive-Exploded", headerParam1)
 	}
 
 	if params.XArrayExploded != nil {
@@ -755,7 +755,7 @@ func NewGetHeaderRequest(server string, params *GetHeaderParams) (*http.Request,
 			return nil, err
 		}
 
-		req.Header.Add("X-Array-Exploded", headerParam2)
+		req.Header.Set("X-Array-Exploded", headerParam2)
 	}
 
 	if params.XArray != nil {
@@ -766,7 +766,7 @@ func NewGetHeaderRequest(server string, params *GetHeaderParams) (*http.Request,
 			return nil, err
 		}
 
-		req.Header.Add("X-Array", headerParam3)
+		req.Header.Set("X-Array", headerParam3)
 	}
 
 	if params.XObjectExploded != nil {
@@ -777,7 +777,7 @@ func NewGetHeaderRequest(server string, params *GetHeaderParams) (*http.Request,
 			return nil, err
 		}
 
-		req.Header.Add("X-Object-Exploded", headerParam4)
+		req.Header.Set("X-Object-Exploded", headerParam4)
 	}
 
 	if params.XObject != nil {
@@ -788,7 +788,7 @@ func NewGetHeaderRequest(server string, params *GetHeaderParams) (*http.Request,
 			return nil, err
 		}
 
-		req.Header.Add("X-Object", headerParam5)
+		req.Header.Set("X-Object", headerParam5)
 	}
 
 	if params.XComplexObject != nil {
@@ -801,7 +801,7 @@ func NewGetHeaderRequest(server string, params *GetHeaderParams) (*http.Request,
 		}
 		headerParam6 = string(headerParamBuf6)
 
-		req.Header.Add("X-Complex-Object", headerParam6)
+		req.Header.Set("X-Complex-Object", headerParam6)
 	}
 
 	return req, nil

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -391,6 +391,7 @@ func NewIssue185RequestWithBody(server string, contentType string, body io.Reade
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
 	return req, nil
 }
 
@@ -548,6 +549,7 @@ func NewIssue9RequestWithBody(server string, params *Issue9Params, contentType s
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
 	return req, nil
 }
 

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -217,6 +217,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
         return nil, err
     }
 
+    {{if .HasBody}}req.Header.Add("Content-Type", contentType){{end}}
 {{range $paramIdx, $param := .HeaderParams}}
     {{if not .Required}} if params.{{.GoName}} != nil { {{end}}
     var headerParam{{$paramIdx}} string
@@ -237,7 +238,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
         return nil, err
     }
     {{end}}
-    req.Header.Add("{{.ParamName}}", headerParam{{$paramIdx}})
+    req.Header.Set("{{.ParamName}}", headerParam{{$paramIdx}})
     {{if not .Required}}}{{end}}
 {{end}}
 
@@ -268,7 +269,6 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
     req.AddCookie(cookie{{$paramIdx}})
     {{if not .Required}}}{{end}}
 {{end}}
-    {{if .HasBody}}req.Header.Add("Content-Type", contentType){{end}}
     return req, nil
 }
 

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -642,6 +642,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
         return nil, err
     }
 
+    {{if .HasBody}}req.Header.Add("Content-Type", contentType){{end}}
 {{range $paramIdx, $param := .HeaderParams}}
     {{if not .Required}} if params.{{.GoName}} != nil { {{end}}
     var headerParam{{$paramIdx}} string
@@ -662,7 +663,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
         return nil, err
     }
     {{end}}
-    req.Header.Add("{{.ParamName}}", headerParam{{$paramIdx}})
+    req.Header.Set("{{.ParamName}}", headerParam{{$paramIdx}})
     {{if not .Required}}}{{end}}
 {{end}}
 
@@ -693,7 +694,6 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
     req.AddCookie(cookie{{$paramIdx}})
     {{if not .Required}}}{{end}}
 {{end}}
-    {{if .HasBody}}req.Header.Add("Content-Type", contentType){{end}}
     return req, nil
 }
 


### PR DESCRIPTION
Changes the templates to Add the default Content-Type header, then Set custom headers to allow overwriting.

Fixes #273 