### PR TITLE
Request validation middleware for go-chi server

### DIFF
--- a/examples/petstore-expanded/chi/petstore.go
+++ b/examples/petstore-expanded/chi/petstore.go
@@ -9,22 +9,43 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+
+	"github.com/go-chi/chi"
 
 	api "github.com/deepmap/oapi-codegen/examples/petstore-expanded/chi/api"
+	middleware "github.com/deepmap/oapi-codegen/pkg/chi-middleware"
 )
 
 func main() {
 	var port = flag.Int("port", 8080, "Port for test HTTP server")
 	flag.Parse()
 
+	swagger, err := api.GetSwagger()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading swagger spec\n: %s", err)
+		os.Exit(1)
+	}
+
+	// Clear out the servers array in the swagger spec, that skips validating
+	// that server names match. We don't know how this thing will be run.
+	swagger.Servers = nil
+
 	// Create an instance of our handler which satisfies the generated interface
 	petStore := api.NewPetStore()
 
+	// This is how you set up a basic chi router
+	r := chi.NewRouter()
+
+	// Use our validation middleware to check all requests against the
+	// OpenAPI schema.
+	r.Use(middleware.OapiRequestValidator(swagger))
+
 	// We now register our petStore above as the handler for the interface
-	h := api.Handler(petStore)
+	api.HandlerFromMux(petStore, r)
 
 	s := &http.Server{
-		Handler: h,
+		Handler: r,
 		Addr:    fmt.Sprintf("0.0.0.0:%d", *port),
 	}
 

--- a/examples/petstore-expanded/chi/petstore_test.go
+++ b/examples/petstore-expanded/chi/petstore_test.go
@@ -1,32 +1,46 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/deepmap/oapi-codegen/examples/petstore-expanded/chi/api"
+	middleware "github.com/deepmap/oapi-codegen/pkg/chi-middleware"
+	"github.com/deepmap/oapi-codegen/pkg/testutil"
 )
 
-func DoJson(handler http.Handler, method string, url string, body interface{}) *httptest.ResponseRecorder {
-	rr := httptest.NewRecorder()
-	b, _ := json.Marshal(body)
-	req, _ := http.NewRequest(method, url, bytes.NewBuffer(b))
-	handler.ServeHTTP(rr, req)
-
-	return rr
+func doGet(t *testing.T, mux *chi.Mux, url string) *httptest.ResponseRecorder {
+	response := testutil.NewRequest().Get(url).WithAcceptJson().GoWithHTTPHandler(t, mux)
+	return response.Recorder
 }
 
 func TestPetStore(t *testing.T) {
 	var err error
 
+	// Get the swagger description of our API
+	swagger, err := api.GetSwagger()
+	require.NoError(t, err)
+
+	// Clear out the servers array in the swagger spec, that skips validating
+	// that server names match. We don't know how this thing will be run.
+	swagger.Servers = nil
+
+	// This is how you set up a basic chi router
+	r := chi.NewRouter()
+
+	// Use our validation middleware to check all requests against the
+	// OpenAPI schema.
+	r.Use(middleware.OapiRequestValidator(swagger))
+
 	store := api.NewPetStore()
-	h := api.Handler(store)
+	api.HandlerFromMux(store, r)
 
 	t.Run("Add pet", func(t *testing.T) {
 		tag := "TagOfSpot"
@@ -35,7 +49,7 @@ func TestPetStore(t *testing.T) {
 			Tag:  &tag,
 		}
 
-		rr := DoJson(h, "POST", "/pets", newPet)
+		rr := testutil.NewRequest().Post("/pets").WithJsonBody(newPet).GoWithHTTPHandler(t, r).Recorder
 		assert.Equal(t, http.StatusCreated, rr.Code)
 
 		var resultPet api.Pet
@@ -51,7 +65,7 @@ func TestPetStore(t *testing.T) {
 		}
 
 		store.Pets[pet.Id] = pet
-		rr := DoJson(h, "GET", fmt.Sprintf("/pets/%d", pet.Id), nil)
+		rr := doGet(t, r, fmt.Sprintf("/pets/%d", pet.Id))
 
 		var resultPet api.Pet
 		err = json.NewDecoder(rr.Body).Decode(&resultPet)
@@ -60,7 +74,7 @@ func TestPetStore(t *testing.T) {
 	})
 
 	t.Run("Pet not found", func(t *testing.T) {
-		rr := DoJson(h, "GET", "/pets/27179095781", nil)
+		rr := doGet(t, r, "/pets/27179095781")
 		assert.Equal(t, http.StatusNotFound, rr.Code)
 
 		var petError api.Error
@@ -76,7 +90,7 @@ func TestPetStore(t *testing.T) {
 		}
 
 		// Now, list all pets, we should have two
-		rr := DoJson(h, "GET", "/pets", nil)
+		rr := doGet(t, r, "/pets")
 		assert.Equal(t, http.StatusOK, rr.Code)
 
 		var petList []api.Pet
@@ -98,7 +112,7 @@ func TestPetStore(t *testing.T) {
 		}
 
 		// Filter pets by tag, we should have 1
-		rr := DoJson(h, "GET", "/pets?tags=TagOfFido", nil)
+		rr := doGet(t, r, "/pets?tags=TagOfFido")
 		assert.Equal(t, http.StatusOK, rr.Code)
 
 		var petList []api.Pet
@@ -114,7 +128,7 @@ func TestPetStore(t *testing.T) {
 		}
 
 		// Filter pets by non existent tag, we should have 0
-		rr := DoJson(h, "GET", "/pets?tags=NotExists", nil)
+		rr := doGet(t, r, "/pets?tags=NotExists")
 		assert.Equal(t, http.StatusOK, rr.Code)
 
 		var petList []api.Pet
@@ -130,7 +144,7 @@ func TestPetStore(t *testing.T) {
 		}
 
 		// Let's delete non-existent pet
-		rr := DoJson(h, "DELETE", "/pets/7", nil)
+		rr := testutil.NewRequest().Delete("/pets/7").GoWithHTTPHandler(t, r).Recorder
 		assert.Equal(t, http.StatusNotFound, rr.Code)
 
 		var petError api.Error
@@ -139,15 +153,15 @@ func TestPetStore(t *testing.T) {
 		assert.Equal(t, int32(http.StatusNotFound), petError.Code)
 
 		// Now, delete both real pets
-		rr = DoJson(h, "DELETE", "/pets/1", nil)
+		rr = testutil.NewRequest().Delete("/pets/1").GoWithHTTPHandler(t, r).Recorder
 		assert.Equal(t, http.StatusNoContent, rr.Code)
 
-		rr = DoJson(h, "DELETE", "/pets/2", nil)
+		rr = testutil.NewRequest().Delete("/pets/2").GoWithHTTPHandler(t, r).Recorder
 		assert.Equal(t, http.StatusNoContent, rr.Code)
 
 		// Should have no pets left.
 		var petList []api.Pet
-		rr = DoJson(h, "GET", "/pets", nil)
+		rr = doGet(t, r, "/pets")
 		assert.Equal(t, http.StatusOK, rr.Code)
 		err = json.NewDecoder(rr.Body).Decode(&petList)
 		assert.NoError(t, err, "error getting response", err)

--- a/pkg/chi-middleware/oapi_validate.go
+++ b/pkg/chi-middleware/oapi_validate.go
@@ -1,0 +1,87 @@
+// Package middleware implements middleware function for go-chi or net/http,
+// which validates incoming HTTP requests to make sure that they conform to the given OAPI 3.0 specification.
+// When OAPI validation failes on the request, we return an HTTP/400.
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3filter"
+)
+
+// Options to customize request validation, openapi3filter specified options will be passed through.
+type Options struct {
+	Options openapi3filter.Options
+}
+
+// OapiRequestValidator Creates middleware to validate request by swagger spec.
+// This middleware is good for net/http either since go-chi is 100% compatible with net/http.
+func OapiRequestValidator(swagger *openapi3.Swagger) func(next http.Handler) http.Handler {
+	return OapiRequestValidatorWithOptions(swagger, nil)
+}
+
+// OapiRequestValidatorWithOptions Creates middleware to validate request by swagger spec.
+// This middleware is good for net/http either since go-chi is 100% compatible with net/http.
+func OapiRequestValidatorWithOptions(swagger *openapi3.Swagger, options *Options) func(next http.Handler) http.Handler {
+	router := openapi3filter.NewRouter().WithSwagger(swagger)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+			// validate request
+			if statusCode, err := validateRequest(r, router, options); err != nil {
+				http.Error(w, err.Error(), statusCode)
+				return
+			}
+
+			// serve
+			next.ServeHTTP(w, r)
+		})
+	}
+
+}
+
+// This function is called from the middleware above and actually does the work
+// of validating a request.
+func validateRequest(r *http.Request, router *openapi3filter.Router, options *Options) (int, error) {
+
+	// Find route
+	route, pathParams, err := router.FindRoute(r.Method, r.URL)
+	if err != nil {
+		return http.StatusBadRequest, err // We failed to find a matching route for the request.
+	}
+
+	// Validate request
+	requestValidationInput := &openapi3filter.RequestValidationInput{
+		Request:    r,
+		PathParams: pathParams,
+		Route:      route,
+	}
+
+	if options != nil {
+		requestValidationInput.Options = &options.Options
+	}
+
+	if err := openapi3filter.ValidateRequest(context.Background(), requestValidationInput); err != nil {
+		switch e := err.(type) {
+		case *openapi3filter.RequestError:
+			// We've got a bad request
+			// Split up the verbose error by lines and return the first one
+			// openapi errors seem to be multi-line with a decent message on the first
+			errorLines := strings.Split(e.Error(), "\n")
+			return http.StatusBadRequest, fmt.Errorf(errorLines[0])
+		case *openapi3filter.SecurityRequirementsError:
+			return http.StatusUnauthorized, err
+		default:
+			// This should never happen today, but if our upstream code changes,
+			// we don't want to crash the server, so handle the unexpected error.
+			return http.StatusInternalServerError, fmt.Errorf("error validating route: %s", err.Error())
+		}
+	}
+
+	return http.StatusOK, nil
+}

--- a/pkg/chi-middleware/oapi_validate_test.go
+++ b/pkg/chi-middleware/oapi_validate_test.go
@@ -1,0 +1,260 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/deepmap/oapi-codegen/pkg/testutil"
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/go-chi/chi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testSchema = `openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: TestServer
+servers:
+  - url: http://deepmap.ai
+paths:
+  /resource:
+    get:
+      operationId: getResource
+      parameters:
+        - name: id
+          in: query
+          schema:
+            type: integer
+            minimum: 10
+            maximum: 100
+      responses:
+        '200':
+            description: success
+            content:
+              application/json:
+                schema:
+                  properties:
+                    name:
+                      type: string
+                    id:
+                      type: integer
+    post:
+      operationId: createResource
+      responses:
+        '204':
+          description: No content
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+  /protected_resource:
+    get:
+      operationId: getProtectedResource
+      security:
+        - BearerAuth:
+          - someScope
+      responses:
+        '204':
+          description: no content
+  /protected_resource2:
+    get:
+      operationId: getProtectedResource
+      security:
+        - BearerAuth:
+          - otherScope
+      responses:
+        '204':
+          description: no content
+  /protected_resource_401:
+    get:
+      operationId: getProtectedResource
+      security:
+        - BearerAuth:
+          - unauthorized
+      responses:
+        '401':
+          description: no content
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+`
+
+func doGet(t *testing.T, mux *chi.Mux, url string) *httptest.ResponseRecorder {
+	response := testutil.NewRequest().Get(url).WithAcceptJson().GoWithHTTPHandler(t, mux)
+	return response.Recorder
+}
+
+func doPost(t *testing.T, mux *chi.Mux, url string, jsonBody interface{}) *httptest.ResponseRecorder {
+	response := testutil.NewRequest().Post(url).WithJsonBody(jsonBody).GoWithHTTPHandler(t, mux)
+	return response.Recorder
+}
+
+func TestOapiRequestValidator(t *testing.T) {
+	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(testSchema))
+	require.NoError(t, err, "Error initializing swagger")
+
+	r := chi.NewRouter()
+
+	// register middleware
+	r.Use(OapiRequestValidator(swagger))
+
+	// basic cases
+	testRequestValidatorBasicFunctions(t, r)
+}
+
+func TestOapiRequestValidatorWithOptions(t *testing.T) {
+	swagger, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData([]byte(testSchema))
+	require.NoError(t, err, "Error initializing swagger")
+
+	r := chi.NewRouter()
+
+	// Set up an authenticator to check authenticated function. It will allow
+	// access to "someScope", but disallow others.
+	options := Options{
+		Options: openapi3filter.Options{
+			AuthenticationFunc: func(c context.Context, input *openapi3filter.AuthenticationInput) error {
+
+				for _, s := range input.Scopes {
+					if s == "someScope" {
+						return nil
+					}
+				}
+				return errors.New("unauthorized")
+			},
+		},
+	}
+
+	// register middleware
+	r.Use(OapiRequestValidatorWithOptions(swagger, &options))
+
+	// basic cases
+	testRequestValidatorBasicFunctions(t, r)
+
+	called := false
+
+	r.Get("/protected_resource", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// Call a protected function to which we have access
+	{
+		rec := doGet(t, r, "http://deepmap.ai/protected_resource")
+		assert.Equal(t, http.StatusNoContent, rec.Code)
+		assert.True(t, called, "Handler should have been called")
+		called = false
+	}
+
+	r.Get("/protected_resource2", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	// Call a protected function to which we dont have access
+	{
+		rec := doGet(t, r, "http://deepmap.ai/protected_resource2")
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.False(t, called, "Handler should not have been called")
+		called = false
+	}
+
+	r.Get("/protected_resource_401", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	// Call a protected function without credentials
+	{
+		rec := doGet(t, r, "http://deepmap.ai/protected_resource_401")
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.False(t, called, "Handler should not have been called")
+		called = false
+	}
+
+}
+
+func testRequestValidatorBasicFunctions(t *testing.T, r *chi.Mux) {
+
+	called := false
+
+	// Install a request handler for /resource. We want to make sure it doesn't
+	// get called.
+	r.Get("/resource", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	// Let's send the request to the wrong server, this should fail validation
+	{
+		rec := doGet(t, r, "http://not.deepmap.ai/resource")
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.False(t, called, "Handler should not have been called")
+	}
+
+	// Let's send a good request, it should pass
+	{
+		rec := doGet(t, r, "http://deepmap.ai/resource")
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.True(t, called, "Handler should have been called")
+		called = false
+	}
+
+	// Send an out-of-spec parameter
+	{
+		rec := doGet(t, r, "http://deepmap.ai/resource?id=500")
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.False(t, called, "Handler should not have been called")
+		called = false
+	}
+
+	// Send a bad parameter type
+	{
+		rec := doGet(t, r, "http://deepmap.ai/resource?id=foo")
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.False(t, called, "Handler should not have been called")
+		called = false
+	}
+
+	// Add a handler for the POST message
+	r.Post("/resource", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	called = false
+	// Send a good request body
+	{
+		body := struct {
+			Name string `json:"name"`
+		}{
+			Name: "Marcin",
+		}
+		rec := doPost(t, r, "http://deepmap.ai/resource", body)
+		assert.Equal(t, http.StatusNoContent, rec.Code)
+		assert.True(t, called, "Handler should have been called")
+		called = false
+	}
+
+	// Send a malformed body
+	{
+		body := struct {
+			Name int `json:"name"`
+		}{
+			Name: 7,
+		}
+		rec := doPost(t, r, "http://deepmap.ai/resource", body)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.False(t, called, "Handler should not have been called")
+		called = false
+	}
+
+}

--- a/pkg/testutil/request_helpers.go
+++ b/pkg/testutil/request_helpers.go
@@ -129,9 +129,9 @@ func (r *RequestBuilder) WithCookieNameValue(name, value string) *RequestBuilder
 	return r.WithCookie(&http.Cookie{Name: name, Value: value})
 }
 
-// This function performs the request, it takes a pointer to a testing context
-// to print messages, and a pointer to an echo context for request handling.
-func (r *RequestBuilder) Go(t *testing.T, e *echo.Echo) *CompletedRequest {
+// GoWithHTTPHandler performs the request, it takes a pointer to a testing context
+// to print messages, and a http handler for request handling.
+func (r *RequestBuilder) GoWithHTTPHandler(t *testing.T, handler http.Handler) *CompletedRequest {
 	if r.Error != nil {
 		// Fail the test if we had an error
 		t.Errorf("error constructing request: %s", r.Error)
@@ -151,11 +151,17 @@ func (r *RequestBuilder) Go(t *testing.T, e *echo.Echo) *CompletedRequest {
 	}
 
 	rec := httptest.NewRecorder()
-	e.ServeHTTP(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	return &CompletedRequest{
 		Recorder: rec,
 	}
+}
+
+// Go performs the request, it takes a pointer to a testing context
+// to print messages, and a pointer to an echo context for request handling.
+func (r *RequestBuilder) Go(t *testing.T, e *echo.Echo) *CompletedRequest {
+	return r.GoWithHTTPHandler(t, e)
 }
 
 // This is the result of calling Go() on the request builder. We're wrapping the


### PR DESCRIPTION
### Changes     
- Provides request validation middleware for [go-chi](https://github.com/go-chi/chi) server, which is similar with middleware to validate request for [echo](https://github.com/labstack/echo) server;       
- This middleware is good for `net/http` either since [go-chi](https://github.com/go-chi/chi) is compatible with `net/http`;    

Please help to review. Thanks! 

Closes https://github.com/deepmap/oapi-codegen/issues/271
https://github.com/deepmap/oapi-codegen/issues/2