### PR TITLE
Add resp postfix for responses generated

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -428,7 +428,7 @@ func GenerateTypesForResponses(t *template.Template, responses openapi3.Response
 			typeDef := TypeDefinition{
 				JsonName: responseName,
 				Schema:   goType,
-				TypeName: SchemaNameToTypeName(responseName),
+				TypeName: SchemaNameToTypeName(responseName) + "Resp",
 			}
 
 			if responseOrRef.Ref != "" {


### PR DESCRIPTION
Hi!
I started to generate my openapi3.0 spec and got some troubles.
This part of spec is pretty valid:
`openapi: 3.0.0
info:
  version: 1.24.0
  title: Magnit middle-layer API
  description: A middle-layer API between the Magnit mobile app and the Magnit backends.
paths:

  /v1/register:
    post:
      operationId: register
      summary: Register a new user.
      tags:
        - Users
      requestBody:
        required: true
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/RegistrationRequest'
      responses:
        409:
          $ref: '#/components/responses/UserAlreadyExistsError'
 
components:
  responses:
    UserAlreadyExistsError:
      description: User already exists
      content:
        application/json:
          schema:
            $ref: '#/components/schemas/UserAlreadyExistsError'
  schemas:
    RegistrationRequest:
      type: object
      properties:
        code:
          type: string

    UserAlreadyExistsError:
      type: object
      required:
        - code
        - message
      properties:
        code:
          type: string
          enum:
            - user_already_exists
        message:
          type: string
          enum:
            - The user already exists.`