### PR TITLE
Parameter generated structures has params postfix to avoid names conflicting

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/labstack/echo/v4 v4.1.17 h1:PQIBaRplyRy3OjwILGkPg89JRtH2x5bssi59G2EL3fo=
 github.com/labstack/echo/v4 v4.1.17/go.mod h1:Tn2yRQL/UclUalpb5rPdXDevbkJ+lp/2svdyFBg6CHQ=
 github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
@@ -40,6 +41,7 @@ github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -56,6 +58,7 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1 h1:tY9CJiPnMXf1ERmG2EyK7gNUd+c6RKGD0IfU8WdUSz8=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
+github.com/valyala/fasttemplate v1.2.1 h1:TVEnxayobAdVkhQfrfes2IzOB6o+z4roRkPF52WA1u4=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -84,9 +84,7 @@ type RequestBody struct {
 }
 
 // ParamsWithAddPropsParams_P1 defines parameters for ParamsWithAddProps.
-type ParamsWithAddPropsParams_P1 struct {
-	AdditionalProperties map[string]interface{} `json:"-"`
-}
+type ParamsWithAddPropsParams_P1 ParamsWithAddPropsParams_P1
 
 // ParamsWithAddPropsParams defines parameters for ParamsWithAddProps.
 type ParamsWithAddPropsParams struct {

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -47,8 +47,8 @@ type NullableProperties struct {
 	RequiredAndNullable *string `json:"requiredAndNullable"`
 }
 
-// StringInPath defines model for StringInPath.
-type StringInPath string
+// StringInPathParam defines model for StringInPath.
+type StringInPathParam string
 
 // Issue185JSONBody defines parameters for Issue185.
 type Issue185JSONBody NullableProperties
@@ -152,7 +152,7 @@ type ClientInterface interface {
 	Issue185(ctx context.Context, body Issue185JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// Issue209 request
-	Issue209(ctx context.Context, str StringInPath, reqEditors ...RequestEditorFn) (*http.Response, error)
+	Issue209(ctx context.Context, str StringInPathParam, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// Issue30 request
 	Issue30(ctx context.Context, pFallthrough string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -210,7 +210,7 @@ func (c *Client) Issue185(ctx context.Context, body Issue185JSONRequestBody, req
 	return c.Client.Do(req)
 }
 
-func (c *Client) Issue209(ctx context.Context, str StringInPath, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *Client) Issue209(ctx context.Context, str StringInPathParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewIssue209Request(c.Server, str)
 	if err != nil {
 		return nil, err
@@ -360,7 +360,7 @@ func NewIssue185RequestWithBody(server string, contentType string, body io.Reade
 }
 
 // NewIssue209Request generates requests for Issue209
-func NewIssue209Request(server string, str StringInPath) (*http.Request, error) {
+func NewIssue209Request(server string, str StringInPathParam) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -573,7 +573,7 @@ type ClientWithResponsesInterface interface {
 	Issue185WithResponse(ctx context.Context, body Issue185JSONRequestBody) (*Issue185Response, error)
 
 	// Issue209 request
-	Issue209WithResponse(ctx context.Context, str StringInPath) (*Issue209Response, error)
+	Issue209WithResponse(ctx context.Context, str StringInPathParam) (*Issue209Response, error)
 
 	// Issue30 request
 	Issue30WithResponse(ctx context.Context, pFallthrough string) (*Issue30Response, error)
@@ -781,7 +781,7 @@ func (c *ClientWithResponses) Issue185WithResponse(ctx context.Context, body Iss
 }
 
 // Issue209WithResponse request returning *Issue209Response
-func (c *ClientWithResponses) Issue209WithResponse(ctx context.Context, str StringInPath) (*Issue209Response, error) {
+func (c *ClientWithResponses) Issue209WithResponse(ctx context.Context, str StringInPathParam) (*Issue209Response, error) {
 	rsp, err := c.Issue209(ctx, str)
 	if err != nil {
 		return nil, err
@@ -1017,7 +1017,7 @@ type ServerInterface interface {
 	Issue185(ctx echo.Context) error
 
 	// (GET /issues/209/${str})
-	Issue209(ctx echo.Context, str StringInPath) error
+	Issue209(ctx echo.Context, str StringInPathParam) error
 
 	// (GET /issues/30/{fallthrough})
 	Issue30(ctx echo.Context, pFallthrough string) error
@@ -1065,7 +1065,7 @@ func (w *ServerInterfaceWrapper) Issue185(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) Issue209(ctx echo.Context) error {
 	var err error
 	// ------------- Path parameter "str" -------------
-	var str StringInPath
+	var str StringInPathParam
 
 	err = runtime.BindStyledParameter("simple", false, "str", ctx.Param("str"), &str)
 	if err != nil {

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -74,8 +74,8 @@ type SomeObject struct {
 	Name string `json:"name"`
 }
 
-// Argument defines model for argument.
-type Argument string
+// ArgumentParam defines model for argument.
+type ArgumentParam string
 
 // ResponseWithReference defines model for ResponseWithReference.
 type ResponseWithReference SomeObject
@@ -139,7 +139,7 @@ type ServerInterface interface {
 	GetWithArgs(w http.ResponseWriter, r *http.Request, params GetWithArgsParams)
 	// Getter with referenced parameter and referenced response
 	// (GET /get-with-references/{global_argument}/{argument})
-	GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument)
+	GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument ArgumentParam)
 	// Get an object by ID
 	// (GET /get-with-type/{content_type})
 	GetWithContentType(w http.ResponseWriter, r *http.Request, contentType string)
@@ -148,7 +148,7 @@ type ServerInterface interface {
 	GetReservedKeyword(w http.ResponseWriter, r *http.Request)
 	// Create a resource
 	// (POST /resource/{argument})
-	CreateResource(w http.ResponseWriter, r *http.Request, argument Argument)
+	CreateResource(w http.ResponseWriter, r *http.Request, argument ArgumentParam)
 	// Create a resource with inline parameter
 	// (POST /resource2/{inline_argument})
 	CreateResource2(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params)
@@ -281,7 +281,7 @@ func (siw *ServerInterfaceWrapper) GetWithReferences(w http.ResponseWriter, r *h
 	}
 
 	// ------------- Path parameter "argument" -------------
-	var argument Argument
+	var argument ArgumentParam
 
 	err = runtime.BindStyledParameter("simple", false, "argument", chi.URLParam(r, "argument"), &argument)
 	if err != nil {
@@ -348,7 +348,7 @@ func (siw *ServerInterfaceWrapper) CreateResource(w http.ResponseWriter, r *http
 	var err error
 
 	// ------------- Path parameter "argument" -------------
-	var argument Argument
+	var argument ArgumentParam
 
 	err = runtime.BindStyledParameter("simple", false, "argument", chi.URLParam(r, "argument"), &argument)
 	if err != nil {

--- a/internal/test/server/server_moq.gen.go
+++ b/internal/test/server/server_moq.gen.go
@@ -31,7 +31,7 @@ var _ ServerInterface = &ServerInterfaceMock{}
 //
 //         // make and configure a mocked ServerInterface
 //         mockedServerInterface := &ServerInterfaceMock{
-//             CreateResourceFunc: func(w http.ResponseWriter, r *http.Request, argument Argument)  {
+//             CreateResourceFunc: func(w http.ResponseWriter, r *http.Request, argument ArgumentParam)  {
 // 	               panic("mock out the CreateResource method")
 //             },
 //             CreateResource2Func: func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params)  {
@@ -55,7 +55,7 @@ var _ ServerInterface = &ServerInterfaceMock{}
 //             GetWithContentTypeFunc: func(w http.ResponseWriter, r *http.Request, contentType string)  {
 // 	               panic("mock out the GetWithContentType method")
 //             },
-//             GetWithReferencesFunc: func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument)  {
+//             GetWithReferencesFunc: func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument ArgumentParam)  {
 // 	               panic("mock out the GetWithReferences method")
 //             },
 //             UpdateResource3Func: func(w http.ResponseWriter, r *http.Request, pFallthrough int)  {
@@ -69,7 +69,7 @@ var _ ServerInterface = &ServerInterfaceMock{}
 //     }
 type ServerInterfaceMock struct {
 	// CreateResourceFunc mocks the CreateResource method.
-	CreateResourceFunc func(w http.ResponseWriter, r *http.Request, argument Argument)
+	CreateResourceFunc func(w http.ResponseWriter, r *http.Request, argument ArgumentParam)
 
 	// CreateResource2Func mocks the CreateResource2 method.
 	CreateResource2Func func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params)
@@ -93,7 +93,7 @@ type ServerInterfaceMock struct {
 	GetWithContentTypeFunc func(w http.ResponseWriter, r *http.Request, contentType string)
 
 	// GetWithReferencesFunc mocks the GetWithReferences method.
-	GetWithReferencesFunc func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument)
+	GetWithReferencesFunc func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument ArgumentParam)
 
 	// UpdateResource3Func mocks the UpdateResource3 method.
 	UpdateResource3Func func(w http.ResponseWriter, r *http.Request, pFallthrough int)
@@ -107,7 +107,7 @@ type ServerInterfaceMock struct {
 			// R is the r argument value.
 			R *http.Request
 			// Argument is the argument argument value.
-			Argument Argument
+			Argument ArgumentParam
 		}
 		// CreateResource2 holds details about calls to the CreateResource2 method.
 		CreateResource2 []struct {
@@ -175,7 +175,7 @@ type ServerInterfaceMock struct {
 			// GlobalArgument is the globalArgument argument value.
 			GlobalArgument int64
 			// Argument is the argument argument value.
-			Argument Argument
+			Argument ArgumentParam
 		}
 		// UpdateResource3 holds details about calls to the UpdateResource3 method.
 		UpdateResource3 []struct {
@@ -190,14 +190,14 @@ type ServerInterfaceMock struct {
 }
 
 // CreateResource calls CreateResourceFunc.
-func (mock *ServerInterfaceMock) CreateResource(w http.ResponseWriter, r *http.Request, argument Argument) {
+func (mock *ServerInterfaceMock) CreateResource(w http.ResponseWriter, r *http.Request, argument ArgumentParam) {
 	if mock.CreateResourceFunc == nil {
 		panic("ServerInterfaceMock.CreateResourceFunc: method is nil but ServerInterface.CreateResource was just called")
 	}
 	callInfo := struct {
 		W        http.ResponseWriter
 		R        *http.Request
-		Argument Argument
+		Argument ArgumentParam
 	}{
 		W:        w,
 		R:        r,
@@ -215,12 +215,12 @@ func (mock *ServerInterfaceMock) CreateResource(w http.ResponseWriter, r *http.R
 func (mock *ServerInterfaceMock) CreateResourceCalls() []struct {
 	W        http.ResponseWriter
 	R        *http.Request
-	Argument Argument
+	Argument ArgumentParam
 } {
 	var calls []struct {
 		W        http.ResponseWriter
 		R        *http.Request
-		Argument Argument
+		Argument ArgumentParam
 	}
 	lockServerInterfaceMockCreateResource.RLock()
 	calls = mock.calls.CreateResource
@@ -490,7 +490,7 @@ func (mock *ServerInterfaceMock) GetWithContentTypeCalls() []struct {
 }
 
 // GetWithReferences calls GetWithReferencesFunc.
-func (mock *ServerInterfaceMock) GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument) {
+func (mock *ServerInterfaceMock) GetWithReferences(w http.ResponseWriter, r *http.Request, globalArgument int64, argument ArgumentParam) {
 	if mock.GetWithReferencesFunc == nil {
 		panic("ServerInterfaceMock.GetWithReferencesFunc: method is nil but ServerInterface.GetWithReferences was just called")
 	}
@@ -498,7 +498,7 @@ func (mock *ServerInterfaceMock) GetWithReferences(w http.ResponseWriter, r *htt
 		W              http.ResponseWriter
 		R              *http.Request
 		GlobalArgument int64
-		Argument       Argument
+		Argument       ArgumentParam
 	}{
 		W:              w,
 		R:              r,
@@ -518,13 +518,13 @@ func (mock *ServerInterfaceMock) GetWithReferencesCalls() []struct {
 	W              http.ResponseWriter
 	R              *http.Request
 	GlobalArgument int64
-	Argument       Argument
+	Argument       ArgumentParam
 } {
 	var calls []struct {
 		W              http.ResponseWriter
 		R              *http.Request
 		GlobalArgument int64
-		Argument       Argument
+		Argument       ArgumentParam
 	}
 	lockServerInterfaceMockGetWithReferences.RLock()
 	calls = mock.calls.GetWithReferences

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -385,11 +385,10 @@ func GenerateTypesForParameters(t *template.Template, params map[string]*openapi
 		if err != nil {
 			return nil, errors.Wrap(err, fmt.Sprintf("error generating Go type for schema in parameter %s", paramName))
 		}
-
 		typeDef := TypeDefinition{
 			JsonName: paramName,
 			Schema:   goType,
-			TypeName: SchemaNameToTypeName(paramName),
+			TypeName: SchemaNameToTypeName(paramName) + parameterPostfix,
 		}
 
 		if paramOrRef.Ref != "" {

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -152,6 +152,10 @@ func DescribeParameters(params openapi3.Parameters, path []string) ([]ParameterD
 				param.Name, err)
 		}
 
+		if IsParametersSectionRef(paramOrRef.Ref) {
+			goType.IsParameterSection = true
+		}
+
 		pd := ParameterDefinition{
 			ParamName: param.Name,
 			In:        param.In,
@@ -378,12 +382,12 @@ func OperationDefinitions(swagger *openapi3.Swagger) ([]OperationDefinition, err
 		pathItem := swagger.Paths[requestPath]
 		// These are parameters defined for all methods on a given path. They
 		// are shared by all methods.
+
 		globalParams, err := DescribeParameters(pathItem.Parameters, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error describing global parameters for %s: %s",
 				requestPath, err)
 		}
-
 		// Each path can have a number of operations, POST, GET, OPTIONS, etc.
 		pathOps := pathItem.Operations()
 		for _, opName := range SortedOperationsKeys(pathOps) {
@@ -588,7 +592,7 @@ func GenerateParamsTypes(op OperationDefinition) []TypeDefinition {
 			pSchema.RefType = propRefName
 			typeDefs = append(typeDefs, TypeDefinition{
 				TypeName: propRefName,
-				Schema:   param.Schema,
+				Schema:   pSchema,
 			})
 		}
 		prop := Property{

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -592,7 +592,7 @@ func GenerateParamsTypes(op OperationDefinition) []TypeDefinition {
 			pSchema.RefType = propRefName
 			typeDefs = append(typeDefs, TypeDefinition{
 				TypeName: propRefName,
-				Schema:   pSchema,
+				Schema:   param.Schema,
 			})
 		}
 		prop := Property{

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -8,6 +8,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	parameterPostfix = "Param"
+)
+
 // This describes a Schema, a type definition.
 type Schema struct {
 	GoType  string // The Go type needed to represent the schema
@@ -23,6 +27,8 @@ type Schema struct {
 	AdditionalTypes          []TypeDefinition // We may need to generate auxiliary helper types, stored here
 
 	SkipOptionalPointer bool // Some types don't need a * in front when they're optional
+
+	IsParameterSection bool
 }
 
 func (s Schema) IsRef() bool {
@@ -32,6 +38,9 @@ func (s Schema) IsRef() bool {
 func (s Schema) TypeDecl() string {
 	if s.IsRef() {
 		return s.RefType
+	}
+	if s.IsParameterSection {
+		return s.GoType + parameterPostfix
 	}
 	return s.GoType
 }

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -224,6 +224,10 @@ func RefPathToGoType(refPath string) (string, error) {
 	}
 }
 
+func IsParametersSectionRef(refPath string) bool {
+	return strings.Contains(refPath, "/parameters/")
+}
+
 // This function converts a swagger style path URI with parameters to a
 // Echo compatible path URI. We need to replace all of Swagger parameters with
 // ":param". Valid input parameters are:


### PR DESCRIPTION
Hi!
When 'parameter' has the same naming as 'response' they are conflicting.