### PR TITLE
BUG: converting float32 fixed

### DIFF
--- a/pkg/runtime/styleparam.go
+++ b/pkg/runtime/styleparam.go
@@ -335,8 +335,10 @@ func primitiveToString(value interface{}) (string, error) {
 	switch kind {
 	case reflect.Int8, reflect.Int32, reflect.Int64, reflect.Int:
 		output = strconv.FormatInt(v.Int(), 10)
-	case reflect.Float32, reflect.Float64:
+	case reflect.Float64:
 		output = strconv.FormatFloat(v.Float(), 'f', -1, 64)
+	case reflect.Float32:
+		output = strconv.FormatFloat(v.Float(), 'f', -1, 32)
 	case reflect.Bool:
 		if v.Bool() {
 			output = "true"

--- a/pkg/runtime/styleparam_test.go
+++ b/pkg/runtime/styleparam_test.go
@@ -490,10 +490,15 @@ func TestStyleParam(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, "7", result)
 
-	type FloatType float64
-	result, err = StyleParam("simple", false, "foo", FloatType(7.5))
+	type FloatType64 float64
+	result, err = StyleParam("simple", false, "foo", FloatType64(7.5))
 	assert.NoError(t, err)
 	assert.EqualValues(t, "7.5", result)
+
+	type FloatType32 float32
+	result, err = StyleParam("simple", false, "foo", FloatType32(1.05))
+	assert.NoError(t, err)
+	assert.EqualValues(t, "1.05", result)
 
 	// Test that we handle optional fields
 	type TestObject2 struct {


### PR DESCRIPTION
- `strconv.FormatFloat` was using 64 bitSize for both float32 and float64
- float32 should use 32 bitSize (https://golang.org/src/strconv/ftoa.go?s=1697:1760#L37)
- this conversion caused a bug when you send pointer *float32 e.g. 1.05, you get something like 1.0499999523162842