### PR TITLE
Fix broken build due to kin backwards-incompatible change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/deepmap/oapi-codegen
 
 require (
 	github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c
-	github.com/getkin/kin-openapi v0.50.0
+	github.com/getkin/kin-openapi v0.51.0
 	github.com/go-chi/chi/v5 v5.0.0
 	github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219
 	github.com/labstack/echo/v4 v4.2.1

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/getkin/kin-openapi v0.50.0 h1:oB1zA3meOwIQxk8PixEBVfmWjK8nLK3+3k30FcRZ19I=
-github.com/getkin/kin-openapi v0.50.0/go.mod h1:2A98vcQ5YzTfxP4KRgugPL3i0U1B/IVLT+tN2zotSiQ=
+github.com/getkin/kin-openapi v0.51.0 h1:KwdZxNsT8ano/hV9P9+ys5e2hWc4jQoN7WTbwarqjYk=
+github.com/getkin/kin-openapi v0.51.0/go.mod h1:fRpo2Nw4Czgy0QnrIesRrEXs5+15N1F9mGZLP/aIomE=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-chi/chi/v5 v5.0.0 h1:DBPx88FjZJH3FsICfDAfIfnb7XxKIYVGG6lOPlhENAg=
@@ -17,6 +17,7 @@ github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tF
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219 h1:utua3L2IbQJmauC5IXdEA547bcoU5dozgQAfc8Onsg4=
 github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219/go.mod h1:/X8TswGSh1pIozq4ZwCfxS0WA5JGXguxk94ar/4c87Y=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/pkg/chi-middleware/oapi_validate.go
+++ b/pkg/chi-middleware/oapi_validate.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/getkin/kin-openapi/routers"
+	"github.com/getkin/kin-openapi/routers/legacy"
 )
 
 // Options to customize request validation, openapi3filter specified options will be passed through.
@@ -27,7 +29,10 @@ func OapiRequestValidator(swagger *openapi3.Swagger) func(next http.Handler) htt
 // OapiRequestValidatorWithOptions Creates middleware to validate request by swagger spec.
 // This middleware is good for net/http either since go-chi is 100% compatible with net/http.
 func OapiRequestValidatorWithOptions(swagger *openapi3.Swagger, options *Options) func(next http.Handler) http.Handler {
-	router := openapi3filter.NewRouter().WithSwagger(swagger)
+	router, err := legacy.NewRouter(swagger)
+	if err != nil {
+		panic(err)
+	}
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -47,10 +52,10 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.Swagger, options *Options
 
 // This function is called from the middleware above and actually does the work
 // of validating a request.
-func validateRequest(r *http.Request, router *openapi3filter.Router, options *Options) (int, error) {
+func validateRequest(r *http.Request, router routers.Router, options *Options) (int, error) {
 
 	// Find route
-	route, pathParams, err := router.FindRoute(r.Method, r.URL)
+	route, pathParams, err := router.FindRoute(r)
 	if err != nil {
 		return http.StatusBadRequest, err // We failed to find a matching route for the request.
 	}

--- a/pkg/middleware/oapi_validate.go
+++ b/pkg/middleware/oapi_validate.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/getkin/kin-openapi/routers"
+	"github.com/getkin/kin-openapi/routers/legacy"
 	"github.com/labstack/echo/v4"
 	echomiddleware "github.com/labstack/echo/v4/middleware"
 )
@@ -65,7 +67,11 @@ type Options struct {
 
 // Create a validator from a swagger object, with validation options
 func OapiRequestValidatorWithOptions(swagger *openapi3.Swagger, options *Options) echo.MiddlewareFunc {
-	router := openapi3filter.NewRouter().WithSwagger(swagger)
+	router, err := legacy.NewRouter(swagger)
+	if err != nil {
+		panic(err)
+	}
+
 	skipper := getSkipperFromOptions(options)
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -84,14 +90,14 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.Swagger, options *Options
 
 // This function is called from the middleware above and actually does the work
 // of validating a request.
-func ValidateRequestFromContext(ctx echo.Context, router *openapi3filter.Router, options *Options) error {
+func ValidateRequestFromContext(ctx echo.Context, router routers.Router, options *Options) error {
 	req := ctx.Request()
-	route, pathParams, err := router.FindRoute(req.Method, req.URL)
+	route, pathParams, err := router.FindRoute(req)
 
 	// We failed to find a matching route for the request.
 	if err != nil {
 		switch e := err.(type) {
-		case *openapi3filter.RouteError:
+		case *routers.RouteError:
 			// We've got a bad request, the path requested doesn't match
 			// either server, or path, or something.
 			return echo.NewHTTPError(http.StatusBadRequest, e.Reason)


### PR DESCRIPTION
There was a backwards-incompatible change in `github.com/getkin/kin-openapi` 0.51.0: getkin/kin-openapi#326

This PR fixes the build & hopefully maintains the old behavior. Unfortunately, this means panicking on error, since that's what kin-openapi used to do: https://github.com/getkin/kin-openapi/blob/v0.50.0/openapi3filter/router.go#L87-L94