### PR TITLE
fix when responseBody has multiple content types (fixed for #329)

### DIFF
--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -887,7 +887,7 @@ func ParseIssue127Response(rsp *http.Response) (*Issue127Response, error) {
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.YAML200 = &dest
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest GenericObject
@@ -901,7 +901,7 @@ func ParseIssue127Response(rsp *http.Response) (*Issue127Response, error) {
 		if err := xml.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.YAML200 = &dest
+		response.XML200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "yaml") && rsp.StatusCode == 200:
 		var dest GenericObject

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -294,9 +294,10 @@ func (o *OperationDefinition) GetResponseTypeDefinitions() ([]TypeDefinition, er
 					}
 
 					td := TypeDefinition{
-						TypeName:     typeName,
-						Schema:       responseSchema,
-						ResponseName: responseName,
+						TypeName:        typeName,
+						Schema:          responseSchema,
+						ResponseName:    responseName,
+						ContentTypeName: contentTypeName,
 					}
 					if IsGoTypeReference(contentType.Schema.Ref) {
 						refType, err := RefPathToGoType(contentType.Schema.Ref)

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -82,10 +82,11 @@ type Constants struct {
 }
 
 type TypeDefinition struct {
-	TypeName     string
-	JsonName     string
-	ResponseName string
-	Schema       Schema
+	TypeName        string
+	JsonName        string
+	ResponseName    string
+	Schema          Schema
+	ContentTypeName string
 }
 
 func (t *TypeDefinition) CanAlias() bool {

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -130,65 +130,63 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 		}
 
 		// If we made it this far then we need to handle unmarshaling for each content-type:
-		sortedContentKeys := SortedContentKeys(responseRef.Value.Content)
-		for _, contentTypeName := range sortedContentKeys {
+		contentTypeName := typeDefinition.ContentTypeName
 
-			// We get "interface{}" when using "anyOf" or "oneOf" (which doesn't work with Go types):
-			if typeDefinition.TypeName == "interface{}" {
-				// Unable to unmarshal this, so we leave it out:
-				continue
-			}
+		// We get "interface{}" when using "anyOf" or "oneOf" (which doesn't work with Go types):
+		if typeDefinition.TypeName == "interface{}" {
+			// Unable to unmarshal this, so we leave it out:
+			continue
+		}
 
-			// Add content-types here (json / yaml / xml etc):
-			switch {
+		// Add content-types here (json / yaml / xml etc):
+		switch {
 
-			// JSON:
-			case StringInArray(contentTypeName, contentTypesJSON):
-				var caseAction string
+		// JSON:
+		case StringInArray(contentTypeName, contentTypesJSON):
+			var caseAction string
 
-				caseAction = fmt.Sprintf("var dest %s\n"+
-					"if err := json.Unmarshal(bodyBytes, &dest); err != nil { \n"+
-					" return nil, err \n"+
-					"}\n"+
-					"response.%s = &dest",
-					typeDefinition.Schema.TypeDecl(),
-					typeDefinition.TypeName)
+			caseAction = fmt.Sprintf("var dest %s\n"+
+				"if err := json.Unmarshal(bodyBytes, &dest); err != nil { \n"+
+				" return nil, err \n"+
+				"}\n"+
+				"response.%s = &dest",
+				typeDefinition.Schema.TypeDecl(),
+				typeDefinition.TypeName)
 
-				caseKey, caseClause := buildUnmarshalCase(typeDefinition, caseAction, "json")
-				handledCaseClauses[caseKey] = caseClause
+			caseKey, caseClause := buildUnmarshalCase(typeDefinition, caseAction, "json")
+			handledCaseClauses[caseKey] = caseClause
 
-			// YAML:
-			case StringInArray(contentTypeName, contentTypesYAML):
-				var caseAction string
-				caseAction = fmt.Sprintf("var dest %s\n"+
-					"if err := yaml.Unmarshal(bodyBytes, &dest); err != nil { \n"+
-					" return nil, err \n"+
-					"}\n"+
-					"response.%s = &dest",
-					typeDefinition.Schema.TypeDecl(),
-					typeDefinition.TypeName)
-				caseKey, caseClause := buildUnmarshalCase(typeDefinition, caseAction, "yaml")
-				handledCaseClauses[caseKey] = caseClause
+		// YAML:
+		case StringInArray(contentTypeName, contentTypesYAML):
+			var caseAction string
+			caseAction = fmt.Sprintf("var dest %s\n"+
+				"if err := yaml.Unmarshal(bodyBytes, &dest); err != nil { \n"+
+				" return nil, err \n"+
+				"}\n"+
+				"response.%s = &dest",
+				typeDefinition.Schema.TypeDecl(),
+				typeDefinition.TypeName)
+			caseKey, caseClause := buildUnmarshalCase(typeDefinition, caseAction, "yaml")
+			handledCaseClauses[caseKey] = caseClause
 
-			// XML:
-			case StringInArray(contentTypeName, contentTypesXML):
-				var caseAction string
-				caseAction = fmt.Sprintf("var dest %s\n"+
-					"if err := xml.Unmarshal(bodyBytes, &dest); err != nil { \n"+
-					" return nil, err \n"+
-					"}\n"+
-					"response.%s = &dest",
-					typeDefinition.Schema.TypeDecl(),
-					typeDefinition.TypeName)
-				caseKey, caseClause := buildUnmarshalCase(typeDefinition, caseAction, "xml")
-				handledCaseClauses[caseKey] = caseClause
+		// XML:
+		case StringInArray(contentTypeName, contentTypesXML):
+			var caseAction string
+			caseAction = fmt.Sprintf("var dest %s\n"+
+				"if err := xml.Unmarshal(bodyBytes, &dest); err != nil { \n"+
+				" return nil, err \n"+
+				"}\n"+
+				"response.%s = &dest",
+				typeDefinition.Schema.TypeDecl(),
+				typeDefinition.TypeName)
+			caseKey, caseClause := buildUnmarshalCase(typeDefinition, caseAction, "xml")
+			handledCaseClauses[caseKey] = caseClause
 
-			// Everything else:
-			default:
-				caseAction := fmt.Sprintf("// Content-type (%s) unsupported", contentTypeName)
-				caseClauseKey := "case " + getConditionOfResponseName("rsp.StatusCode", typeDefinition.ResponseName) + ":"
-				unhandledCaseClauses[prefixLeastSpecific+caseClauseKey] = fmt.Sprintf("%s\n%s\n", caseClauseKey, caseAction)
-			}
+		// Everything else:
+		default:
+			caseAction := fmt.Sprintf("// Content-type (%s) unsupported", contentTypeName)
+			caseClauseKey := "case " + getConditionOfResponseName("rsp.StatusCode", typeDefinition.ResponseName) + ":"
+			unhandledCaseClauses[prefixLeastSpecific+caseClauseKey] = fmt.Sprintf("%s\n%s\n", caseClauseKey, caseAction)
 		}
 	}
 


### PR DESCRIPTION
This is a fixed for #329 

The bug occurs when `handledCaseClauses` map json casekey has been overridden by xml one.