### PR TITLE
Add binary version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: Release Go Binaries
+
+on: 
+  release:
+    types: [created]
+  workflow_dispatch:
+
+env:
+  CMD_PATH: ./cmd/oapi-codegen
+
+
+jobs:
+  releases-matrix:
+    name: Release Bin
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set APP_VERSION env
+      run: echo APP_VERSION=$(echo ${GITHUB_REF} | rev | cut -d'/' -f 1 | rev ) >> ${GITHUB_ENV}
+    - name: Set BUILD_TIME env
+      run: echo BUILD_TIME=$(date) >> ${GITHUB_ENV}
+    - name: Environment Printer
+      uses: managedkaos/print-env@v1.0
+
+    - uses: wangyoucao577/go-release-action@v1.16
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        goversion: https://golang.org/dl/go1.16.3.linux-amd64.tar.gz
+        project_path: ./cmd/oapi-codegen
+        build_flags: -v
+        ldflags: -X "main.appVersion=${{ env.APP_VERSION }}" -X "main.buildTime=${{ env.BUILD_TIME }}" -X main.gitCommit=${{ github.sha }} -X main.gitRef=${{ github.ref }}
+        

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea
 .DS_Store
 .vscode/
+
+# bin
+cmd/oapi-codegen/oapi-codegen
+__debug_bin

--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -44,6 +44,7 @@ var (
 	flagExcludeSchemas string
 	flagConfigFile     string
 	flagAliasTypes     bool
+	flagPrintVersion   bool
 )
 
 type configuration struct {
@@ -70,7 +71,13 @@ func main() {
 	flag.StringVar(&flagExcludeSchemas, "exclude-schemas", "", "A comma separated list of schemas which must be excluded from generation")
 	flag.StringVar(&flagConfigFile, "config", "", "a YAML config file that controls oapi-codegen behavior")
 	flag.BoolVar(&flagAliasTypes, "alias-types", false, "Alias type declarations of possible")
+	flag.BoolVar(&flagPrintVersion, "version", false, "Print version.")
 	flag.Parse()
+
+	if flagPrintVersion {
+		printVersion()
+		return
+	}
 
 	if flag.NArg() < 1 {
 		fmt.Println("Please specify a path to a OpenAPI 3.0 spec file")

--- a/cmd/oapi-codegen/version.go
+++ b/cmd/oapi-codegen/version.go
@@ -1,0 +1,18 @@
+package main
+
+import "fmt"
+
+// these information will be collected when build, by `-ldflags "-X main.appVersion=0.1"`
+var (
+	appVersion = ""
+	buildTime  = ""
+	gitCommit  = ""
+	gitRef     = ""
+)
+
+func printVersion() {
+	fmt.Printf("Version:    %s\n", appVersion)
+	fmt.Printf("Build Time: %s\n", buildTime)
+	fmt.Printf("Git Commit: %s\n", gitCommit)
+	fmt.Printf("Git Ref:    %s\n", gitRef)
+}


### PR DESCRIPTION
## Why 
Thanks for the awesome project, I can generate many codes by `oapi-codegen` from OpenAPI v3 spec. However, I usually have a question: what version of the `oapi-codegen` I use? The project still goes very fast, and I have to upgrade it per several days/weeks to fix bugs or leverage new features. It's so important to know that where am I before upgrade.       
To achieve this, I think there're several steps to do:     
1.  Add version on `oapi-codegen`;    
2. Also write version information to generated codes.      

https://github.com/deepmap/oapi-codegen/issues/251#issuecomment-760804314 describes the idea too.     

## What/How does this PR solve        
This PR intend to solve the problem 1: add version on `oapi-codegen`.       
It did below things:     
- add version related information to `oapi-codegen` binary, EMPTY by default;      
- add release automation(via Github Actions) that will be trigger when create release. It will build and upload binaries to the release page automatically. When build the binaries, version information will be set by `-ldflags`. More specific, the "AppVersion" will be set with the release tag. Several platforms(`linux/amd64`, `darwin/amd64`, `windows/amd64`) have been configured to cover most of use cases.      

https://github.com/wangyoucao577/oapi-codegen/releases/tag/v1.6.0.1-test-bin-version shows the results. If download the release binary and run `-version`, you'll get something like          
```bash
./oapi-codegen -version
Version:    v1.6.0.1-test-bin-version
Build Time: Fri Apr 9 08:30:03 UTC 2021
Git Commit: eba83236752fe3713e26828756884419c727a23a
Git Ref:    refs/tags/v1.6.0.1-test-bin-version
```

I think this approach is better than write version in code because it no need to change any process when release new versions.          

## Next    
If you're good with it, I'll create another PR to solve the step 2: Also write version information to generated codes(as comments).         
After that, we'd better to encourge to use the pre-built release binaries instead of `go get`, otherwise the version information can not be used.     


@deepmap-marcinr How's your idea?      


        

