### PR TITLE
Fix/example operationId

### DIFF
--- a/examples/petstore-expanded/README.md
+++ b/examples/petstore-expanded/README.md
@@ -13,4 +13,4 @@ This is the structure:
 
 To generate the handler glue, run:
 
-    go run cmd/oapi-codegen/oapi-codegen.go --package petstore examples/oapi-codegen/api/petstore-expanded.yaml  > examples/oapi-codegen/api/petstore.gen.go
+    go run cmd/oapi-codegen/oapi-codegen.go --package petstore examples/petstore-expanded/petstore-expanded.yaml  > examples/petstore-expanded/petstore.gen.go

--- a/examples/petstore-expanded/petstore-expanded.yaml
+++ b/examples/petstore-expanded/petstore-expanded.yaml
@@ -83,7 +83,7 @@ paths:
     get:
       summary: Returns a pet by ID
       description: Returns a pet based on a single ID
-      operationId: find pet by id
+      operationId: findPetByID
       parameters:
         - name: id
           in: path


### PR DESCRIPTION
I had a trouble when I built the mock server with [swaggerapi/swagger-codegen-cli-v3](https://github.com/swagger-api/swagger-codegen). I modified the OpenAPI Specification of example.
Also, the README has been changed to match the current directory structure.