### PR TITLE
fix: better enum deduplication

### DIFF
--- a/internal/test/issues/issue-illegal_enum_names/issue.gen.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue.gen.go
@@ -22,7 +22,13 @@ import (
 
 // Defines values for Bar.
 const (
+	Bar1 Bar = "1"
+
+	Bar1Foo Bar = "1Foo"
+
 	BarBar Bar = "Bar"
+
+	BarBar1 Bar = "Bar"
 
 	BarFoo Bar = "Foo"
 
@@ -35,10 +41,6 @@ const (
 	BarFooBar Bar = "Foo Bar"
 
 	BarFooBar1 Bar = "Foo-Bar"
-
-	BarN1 Bar = "1"
-
-	BarN1Foo Bar = "1Foo"
 )
 
 // Bar defines model for Bar.
@@ -320,11 +322,11 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/0xQQU4DMQz8SjVwDNml3HLkUMQbEKqirbcN6tpRYpCqKn9HzkIhl5kkHtszV0yyZGFi",
-	"rQhX1OlES+z0ORYD4s8F4Q07Ebj+6IxvbuxhZY//CzbrxWADh/1OZG81eHfQSyYEVC2Jj2itOSSexWZp",
-	"0rP9ee/h8EWlJmEEjH70I5qDZOKYEwKe/Oi3cMhRT33dYZbe40hqIJlK1CT8ekDAC+m6UaGahSt1yXYc",
-	"DSZhJe6qmPM5TV03fFSb/RuJsaS0dOF9oRkBd8NfeMNPcoMF0G4uYynxspo8UJ1KyrpaMoutn+8AAAD/",
-	"/y6OlsyDAQAA",
+	"H4sIAAAAAAAC/0yQzU4DMQyEX2U1cAzZtNxy5FDEMyBURVtvG9S1o8QgVVXeHSULpbnM5Gdif75ikiUJ",
+	"E2uBv6JMJ1pCty8hNyH+WuDfNwY7EZh+3P1wc0+r29w/GNZNkwEG+53IHh8GekkEj6I58hG1VoPIs7RK",
+	"GvXc7qy1MPimXKIwPJx11qEaSCIOKcLj2Tq7hUEKeurNjrP0P46kTSRRDhqF3w7weCVdu8lUknChHtk6",
+	"12QSVuKeCimd49Rz42dptf8G0lxUWnrwMdMMj4fxf3Tj79zGBl9vlCHncFkhD1SmHJOuSA2x9vUTAAD/",
+	"/35OGEmBAQAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/issues/issue-illegal_enum_names/issue_test.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/deepmap/oapi-codegen/pkg/codegen"
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,14 +43,13 @@ func TestIllegalEnumNames(t *testing.T) {
 			}
 		}
 	}
-
-	require.Equal(t, `"Bar"`, constDefs["BarBar"])
-	require.Equal(t, `"Foo"`, constDefs["BarFoo"])
-	require.Equal(t, `"Foo Bar"`, constDefs["BarFooBar"])
-	require.Equal(t, `"Foo-Bar"`, constDefs["BarFooBar1"])
-	require.Equal(t, `"1Foo"`, constDefs["BarN1Foo"])
-	require.Equal(t, `" Foo"`, constDefs["BarFoo1"])
-	require.Equal(t, `" Foo "`, constDefs["BarFoo2"])
-	require.Equal(t, `"_Foo_"`, constDefs["BarFoo3"])
-	require.Equal(t, `"1"`, constDefs["BarN1"])
+	assert.Equal(t, `"1"`, constDefs["Bar1"])
+	assert.Equal(t, `"Bar"`, constDefs["BarBar"])
+	assert.Equal(t, `"Foo"`, constDefs["BarFoo"])
+	assert.Equal(t, `"Foo Bar"`, constDefs["BarFooBar"])
+	assert.Equal(t, `"Foo-Bar"`, constDefs["BarFooBar1"])
+	assert.Equal(t, `"1Foo"`, constDefs["Bar1Foo"])
+	assert.Equal(t, `" Foo"`, constDefs["BarFoo1"])
+	assert.Equal(t, `" Foo "`, constDefs["BarFoo2"])
+	assert.Equal(t, `"_Foo_"`, constDefs["BarFoo3"])
 }

--- a/internal/test/issues/issue-illegal_enum_names/spec.yaml
+++ b/internal/test/issues/issue-illegal_enum_names/spec.yaml
@@ -21,7 +21,8 @@ components:
   schemas:
     Bar:
       type: string
-      enum: 
+      enum:
+        - 1
         - Foo
         - Bar
         - Foo Bar
@@ -31,4 +32,3 @@ components:
         - ' Foo'
         - ' Foo '
         - _Foo_
-        - "1"

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -1500,13 +1500,13 @@ func NewGetStartingWithNumberRequest(server string, n1param string) (*http.Reque
 
 	operationPath := fmt.Sprintf("/startingWithNumber/%s", pathParam0)
 	if operationPath[0] == '/' {
-		operationPath = operationPath[1:]
-	}
-	operationURL := url.URL{
-		Path: operationPath,
+		operationPath = "." + operationPath
 	}
 
-	queryURL := serverURL.ResolveReference(&operationURL)
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
@@ -2535,9 +2535,6 @@ func ParseGetStartingWithNumberResponse(rsp *http.Response) (*GetStartingWithNum
 	response := &GetStartingWithNumberResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
-	}
-
-	switch {
 	}
 
 	return response, nil

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -489,34 +489,33 @@ func SanitizeGoIdentity(str string) string {
 	return str
 }
 
-// SanitizeEnumNames fixes illegal chars in the enum names
-// and removes duplicates
-func SanitizeEnumNames(enumNames []string) map[string]string {
-	dupCheck := make(map[string]int, len(enumNames))
-	deDup := make([]string, 0, len(enumNames))
+// EnumConst holds initial enum cost definition
+type EnumConst struct {
+	Name string
+	Value string
+}
 
-	for _, n := range enumNames {
-		if _, dup := dupCheck[n]; !dup {
-			deDup = append(deDup, n)
-		}
-		dupCheck[n] = 0
+// DeDuplicateEnums creates unique enum const names
+func DeDuplicateEnums(enums []EnumConst) map[string]string {
+	dupCheck := make(map[string][]EnumConst, len(enums))
+
+	for _,n := range enums {
+		dupCheck[n.Name] = append(dupCheck[n.Name],n)
 	}
 
-	dupCheck = make(map[string]int, len(deDup))
-	sanitizedDeDup := make(map[string]string, len(deDup))
+	deDup := make(map[string]string, len(enums))
 
-	for _, n := range deDup {
-		sanitized := SanitizeGoIdentity(SchemaNameToTypeName(n))
-
-		if _, dup := dupCheck[sanitized]; !dup {
-			sanitizedDeDup[sanitized] = n
-		} else {
-			sanitizedDeDup[sanitized+strconv.Itoa(dupCheck[sanitized])] = n
+	for n, a := range dupCheck {
+		for i, e := range a {
+			name := n
+			if i > 0 {
+				name = name + strconv.Itoa(i)
+			}
+			deDup[name] = e.Value
 		}
-		dupCheck[sanitized]++
 	}
 
-	return sanitizedDeDup
+	return deDup
 }
 
 // Converts a Schema name to a valid Go type name. It converts to camel case, and makes sure the name is


### PR DESCRIPTION
Closes #341 

Fixed enum deduplication.
It will cause breaking changes in cases, when enum value starts with a number. Number char was previously removed.

```yaml
    Bar:
      type: string
      enum:
        - Foo
        - 1Foo
```
Before:
```go
const (
	BarFoo Bar = "1Foo"
	BarFoo1 Bar = "Foo"
)
```
Now:
```go
const (
	Bar1Foo Bar = "1Foo"
	BarFoo Bar = "Foo"
)
```