### PR TITLE
Use `runtime.BindStyledParameterWithLocation` to parse headers

### DIFF
--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -247,7 +247,7 @@ func (siw *ServerInterfaceWrapper) GetWithArgs(w http.ResponseWriter, r *http.Re
 			return
 		}
 
-		err = runtime.BindStyledParameter("simple", false, "header_argument", valueList[0], &HeaderArgument)
+		err = runtime.BindStyledParameterWithLocation("simple", false, "header_argument", runtime.ParamLocationHeader, valueList[0], &HeaderArgument)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Invalid format for parameter header_argument: %s", err), http.StatusBadRequest)
 			return

--- a/pkg/codegen/templates/chi-middleware.tmpl
+++ b/pkg/codegen/templates/chi-middleware.tmpl
@@ -101,7 +101,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
         {{end}}
 
         {{if .IsStyled}}
-          err = runtime.BindStyledParameter("{{.Style}}",{{.Explode}}, "{{.ParamName}}", valueList[0], &{{.GoName}})
+          err = runtime.BindStyledParameterWithLocation("{{.Style}}",{{.Explode}}, "{{.ParamName}}", runtime.ParamLocationHeader, valueList[0], &{{.GoName}})
           if err != nil {
             http.Error(w, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err), http.StatusBadRequest)
             return

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -228,7 +228,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
         {{end}}
 
         {{if .IsStyled}}
-          err = runtime.BindStyledParameter("{{.Style}}",{{.Explode}}, "{{.ParamName}}", valueList[0], &{{.GoName}})
+          err = runtime.BindStyledParameterWithLocation("{{.Style}}",{{.Explode}}, "{{.ParamName}}", runtime.ParamLocationHeader, valueList[0], &{{.GoName}})
           if err != nil {
             http.Error(w, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err), http.StatusBadRequest)
             return


### PR DESCRIPTION
because at the point we call the function we know we are reading headers,
and because `runtime.BindStyledParameter` with `ParamLocationUndefined` does query escaping of the header value

Fixes #351

After I made the change in `pkg/codegen/templates/chi-middleware.tmpl` I ran `go generate ./pkg/codegen/templates` and `go generate ./...` as per https://github.com/deepmap/oapi-codegen#making-changes-to-code-generation. This produces the change in `internal/test/server/server.gen.go` and `pkg/codegen/templates/templates.gen.go`.

I also ran `go test ./...` locally to make sure the tests are passing, which they did.