### PR TITLE
Added extension for adding extra tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,10 @@ which help you to use the various OpenAPI 3 Authentication mechanism.
  will override any default value. This extended property isn't supported in all parts of
  OpenAPI, so please refer to the spec as to where it's allowed. Swagger validation tools will
  flag incorrect usage of this property.
+- `x-oapi-codegen-extra-tags`: adds extra tags to the generated struct field. This is
+ useful for interfacing with tag based ORM or validation libraries. The extra tags that
+ are added are in addition to the regular json tags that are generated. If you attempt
+ to put a custom json tag you will end up with json tags and undefined behaviour.
 
 ## Using `oapi-codegen`
 

--- a/README.md
+++ b/README.md
@@ -438,6 +438,18 @@ which help you to use the various OpenAPI 3 Authentication mechanism.
  are added are in addition to the regular json tags that are generated. If you attempt
  to put a custom json tag you will end up with json tags and undefined behaviour.
 
+```yaml
+components:
+  schemas:
+    Object:
+      properties:
+        name:
+          type: string
+          x-oapi-codegen-extra-tags:
+            - "tag1:\"value1\""
+            - "tag2:\"value2\""
+```
+
 ## Using `oapi-codegen`
 
 The default options for `oapi-codegen` will generate everything; client, server,

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -163,7 +163,7 @@ type GetTestByNameResponse struct {
 	assert.Contains(t, code, "Top *int `json:\"$top,omitempty\"`")
 	assert.Contains(t, code, "func (c *Client) GetTestByName(ctx context.Context, name string, params *GetTestByNameParams, reqEditors ...RequestEditorFn) (*http.Response, error) {")
 	assert.Contains(t, code, "func (c *ClientWithResponses) GetTestByNameWithResponse(ctx context.Context, name string, params *GetTestByNameParams, reqEditors ...RequestEditorFn) (*GetTestByNameResponse, error) {")
-	assert.Contains(t, code, "DeadSince *time.Time    `json:\"dead_since,omitempty\" gorm:\"index\"`")
+	assert.Contains(t, code, "DeadSince *time.Time    `json:\"dead_since,omitempty\" tag1:\"value1\" tag2:\"value2\"`")
 
 	// Make sure the generated code is valid:
 	linter := new(lint.Linter)
@@ -305,7 +305,9 @@ components:
         dead_since:
           type: string
           format: date-time
-          x-oapi-codegen-extra-tags: gorm:"index"
+          x-oapi-codegen-extra-tags:
+            - "tag1:\"value1\""
+            - "tag2:\"value2\""
         cause:
           type: string
           enum: [car, dog, oldage]

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -163,6 +163,7 @@ type GetTestByNameResponse struct {
 	assert.Contains(t, code, "Top *int `json:\"$top,omitempty\"`")
 	assert.Contains(t, code, "func (c *Client) GetTestByName(ctx context.Context, name string, params *GetTestByNameParams, reqEditors ...RequestEditorFn) (*http.Response, error) {")
 	assert.Contains(t, code, "func (c *ClientWithResponses) GetTestByNameWithResponse(ctx context.Context, name string, params *GetTestByNameParams, reqEditors ...RequestEditorFn) (*GetTestByNameResponse, error) {")
+	assert.Contains(t, code, "DeadSince *time.Time    `json:\"dead_since,omitempty\" gorm:\"index\"`")
 
 	// Make sure the generated code is valid:
 	linter := new(lint.Linter)
@@ -304,6 +305,7 @@ components:
         dead_since:
           type: string
           format: date-time
+          x-oapi-codegen-extra-tags: gorm:"index"
         cause:
           type: string
           enum: [car, dog, oldage]

--- a/pkg/codegen/extension.go
+++ b/pkg/codegen/extension.go
@@ -10,6 +10,7 @@ import (
 const (
 	extPropGoType    = "x-go-type"
 	extPropOmitEmpty = "x-omitempty"
+	extPropExtraTags = "x-oapi-codegen-extra-tags"
 )
 
 func extTypeName(extPropValue interface{}) (string, error) {
@@ -26,7 +27,6 @@ func extTypeName(extPropValue interface{}) (string, error) {
 }
 
 func extParseOmitEmpty(extPropValue interface{}) (bool, error) {
-
 	raw, ok := extPropValue.(json.RawMessage)
 	if !ok {
 		return false, fmt.Errorf("failed to convert type: %T", extPropValue)

--- a/pkg/codegen/extension.go
+++ b/pkg/codegen/extension.go
@@ -39,3 +39,15 @@ func extParseOmitEmpty(extPropValue interface{}) (bool, error) {
 
 	return omitEmpty, nil
 }
+
+func extExtraTags(extPropValue interface{}) ([]string, error) {
+	raw, ok := extPropValue.(json.RawMessage)
+	if !ok {
+		return nil, fmt.Errorf("failed to convert type: %T", extPropValue)
+	}
+	var tags []string
+	if err := json.Unmarshal(raw, &tags); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal json")
+	}
+	return tags, nil
+}

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -432,8 +432,10 @@ func GenFieldsFromProperties(props []Property) []string {
 			field += fmt.Sprintf(" `json:\"%s,omitempty\"", p.JsonFieldName)
 		}
 		if extension, ok := p.ExtensionProps.Extensions[extPropExtraTags]; ok {
-			if tags, err := extTypeName(extension); err == nil {
-				field += " " + tags
+			if tags, err := extExtraTags(extension); err == nil {
+				for _, tag := range tags {
+					field += " " + tag
+				}
 			}
 		}
 		field += "`"

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -427,10 +427,16 @@ func GenFieldsFromProperties(props []Property) []string {
 		}
 
 		if p.Required || p.Nullable || !omitEmpty {
-			field += fmt.Sprintf(" `json:\"%s\"`", p.JsonFieldName)
+			field += fmt.Sprintf(" `json:\"%s\"", p.JsonFieldName)
 		} else {
-			field += fmt.Sprintf(" `json:\"%s,omitempty\"`", p.JsonFieldName)
+			field += fmt.Sprintf(" `json:\"%s,omitempty\"", p.JsonFieldName)
 		}
+		if extension, ok := p.ExtensionProps.Extensions[extPropExtraTags]; ok {
+			if tags, err := extTypeName(extension); err == nil {
+				field += " " + tags
+			}
+		}
+		field += "`"
 		fields = append(fields, field)
 	}
 	return fields


### PR DESCRIPTION
This pull request adds the ability to specify a oapi-codegen specific extension for generating struct types with extra tags. 

Web applications often need input validation and object relational mapping for databases. Several of the most popular libraries in the Go ecosystem use custom tags for implementing those functions. By allowing the user to specify extra tags we can then directly use the generated structures in those packages.