### PR TITLE
Create non-pointer map/slice fields from optional properties

### DIFF
--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -52,7 +52,7 @@ type Pet struct {
 type FindPetsParams struct {
 
 	// tags to filter by
-	Tags *[]string `json:"tags,omitempty"`
+	Tags []string `json:"tags,omitempty"`
 
 	// maximum number of results to return
 	Limit *int32 `json:"limit,omitempty"`

--- a/examples/petstore-expanded/chi/api/petstore.go
+++ b/examples/petstore-expanded/chi/api/petstore.go
@@ -47,7 +47,7 @@ func (p *PetStore) FindPets(w http.ResponseWriter, r *http.Request, params FindP
 	for _, pet := range p.Pets {
 		if params.Tags != nil {
 			// If we have tags,  filter pets by tag
-			for _, t := range *params.Tags {
+			for _, t := range params.Tags {
 				if pet.Tag != nil && (*pet.Tag == t) {
 					result = append(result, pet)
 				}

--- a/examples/petstore-expanded/echo/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/echo/api/petstore-types.gen.go
@@ -37,7 +37,7 @@ type Pet struct {
 type FindPetsParams struct {
 
 	// tags to filter by
-	Tags *[]string `json:"tags,omitempty"`
+	Tags []string `json:"tags,omitempty"`
 
 	// maximum number of results to return
 	Limit *int32 `json:"limit,omitempty"`

--- a/examples/petstore-expanded/echo/api/petstore.go
+++ b/examples/petstore-expanded/echo/api/petstore.go
@@ -59,7 +59,7 @@ func (p *PetStore) FindPets(ctx echo.Context, params FindPetsParams) error {
 	for _, pet := range p.Pets {
 		if params.Tags != nil {
 			// If we have tags,  filter pets by tag
-			for _, t := range *params.Tags {
+			for _, t := range params.Tags {
 				if pet.Tag != nil && (*pet.Tag == t) {
 					result = append(result, pet)
 				}

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -51,7 +51,7 @@ type Pet struct {
 type FindPetsParams struct {
 
 	// tags to filter by
-	Tags *[]string `json:"tags,omitempty"`
+	Tags []string `json:"tags,omitempty"`
 
 	// maximum number of results to return
 	Limit *int32 `json:"limit,omitempty"`
@@ -234,7 +234,7 @@ func NewFindPetsRequest(server string, params *FindPetsParams) (*http.Request, e
 
 	if params.Tags != nil {
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "tags", runtime.ParamLocationQuery, *params.Tags); err != nil {
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "tags", runtime.ParamLocationQuery, params.Tags); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -44,10 +44,10 @@ type GetCookieParams struct {
 	Ep *int32 `json:"ep,omitempty"`
 
 	// exploded array
-	Ea *[]int32 `json:"ea,omitempty"`
+	Ea []int32 `json:"ea,omitempty"`
 
 	// array
-	A *[]int32 `json:"a,omitempty"`
+	A []int32 `json:"a,omitempty"`
 
 	// exploded object
 	Eo *Object `json:"eo,omitempty"`
@@ -69,10 +69,10 @@ type GetHeaderParams struct {
 	XPrimitiveExploded *int32 `json:"X-Primitive-Exploded,omitempty"`
 
 	// exploded array
-	XArrayExploded *[]int32 `json:"X-Array-Exploded,omitempty"`
+	XArrayExploded []int32 `json:"X-Array-Exploded,omitempty"`
 
 	// array
-	XArray *[]int32 `json:"X-Array,omitempty"`
+	XArray []int32 `json:"X-Array,omitempty"`
 
 	// exploded object
 	XObjectExploded *Object `json:"X-Object-Exploded,omitempty"`
@@ -95,10 +95,10 @@ type GetDeepObjectParams struct {
 type GetQueryFormParams struct {
 
 	// exploded array
-	Ea *[]int32 `json:"ea,omitempty"`
+	Ea []int32 `json:"ea,omitempty"`
 
 	// array
-	A *[]int32 `json:"a,omitempty"`
+	A []int32 `json:"a,omitempty"`
 
 	// exploded object
 	Eo *Object `json:"eo,omitempty"`
@@ -571,7 +571,7 @@ func NewGetCookieRequest(server string, params *GetCookieParams) (*http.Request,
 	if params.Ea != nil {
 		var cookieParam2 string
 
-		cookieParam2, err = runtime.StyleParamWithLocation("simple", true, "ea", runtime.ParamLocationCookie, *params.Ea)
+		cookieParam2, err = runtime.StyleParamWithLocation("simple", true, "ea", runtime.ParamLocationCookie, params.Ea)
 		if err != nil {
 			return nil, err
 		}
@@ -586,7 +586,7 @@ func NewGetCookieRequest(server string, params *GetCookieParams) (*http.Request,
 	if params.A != nil {
 		var cookieParam3 string
 
-		cookieParam3, err = runtime.StyleParamWithLocation("simple", false, "a", runtime.ParamLocationCookie, *params.A)
+		cookieParam3, err = runtime.StyleParamWithLocation("simple", false, "a", runtime.ParamLocationCookie, params.A)
 		if err != nil {
 			return nil, err
 		}
@@ -697,7 +697,7 @@ func NewGetHeaderRequest(server string, params *GetHeaderParams) (*http.Request,
 	if params.XArrayExploded != nil {
 		var headerParam2 string
 
-		headerParam2, err = runtime.StyleParamWithLocation("simple", true, "X-Array-Exploded", runtime.ParamLocationHeader, *params.XArrayExploded)
+		headerParam2, err = runtime.StyleParamWithLocation("simple", true, "X-Array-Exploded", runtime.ParamLocationHeader, params.XArrayExploded)
 		if err != nil {
 			return nil, err
 		}
@@ -708,7 +708,7 @@ func NewGetHeaderRequest(server string, params *GetHeaderParams) (*http.Request,
 	if params.XArray != nil {
 		var headerParam3 string
 
-		headerParam3, err = runtime.StyleParamWithLocation("simple", false, "X-Array", runtime.ParamLocationHeader, *params.XArray)
+		headerParam3, err = runtime.StyleParamWithLocation("simple", false, "X-Array", runtime.ParamLocationHeader, params.XArray)
 		if err != nil {
 			return nil, err
 		}
@@ -1123,7 +1123,7 @@ func NewGetQueryFormRequest(server string, params *GetQueryFormParams) (*http.Re
 
 	if params.Ea != nil {
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "ea", runtime.ParamLocationQuery, *params.Ea); err != nil {
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "ea", runtime.ParamLocationQuery, params.Ea); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err
@@ -1139,7 +1139,7 @@ func NewGetQueryFormRequest(server string, params *GetQueryFormParams) (*http.Re
 
 	if params.A != nil {
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", false, "a", runtime.ParamLocationQuery, *params.A); err != nil {
+		if queryFrag, err := runtime.StyleParamWithLocation("form", false, "a", runtime.ParamLocationQuery, params.A); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err
@@ -2573,7 +2573,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ea: %s", err))
 		}
-		params.Ea = &value
+		params.Ea = value
 
 	}
 
@@ -2584,7 +2584,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter a: %s", err))
 		}
-		params.A = &value
+		params.A = value
 
 	}
 
@@ -2682,7 +2682,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx echo.Context) error {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Array-Exploded: %s", err))
 		}
 
-		params.XArrayExploded = &XArrayExploded
+		params.XArrayExploded = XArrayExploded
 	}
 	// ------------- Optional header parameter "X-Array" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Array")]; found {
@@ -2697,7 +2697,7 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx echo.Context) error {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter X-Array: %s", err))
 		}
 
-		params.XArray = &XArray
+		params.XArray = XArray
 	}
 	// ------------- Optional header parameter "X-Object-Exploded" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Object-Exploded")]; found {

--- a/internal/test/parameters/parameters_test.go
+++ b/internal/test/parameters/parameters_test.go
@@ -139,10 +139,10 @@ func (t *testServer) GetSimplePrimitive(ctx echo.Context, param int32) error {
 func (t *testServer) GetQueryForm(ctx echo.Context, params GetQueryFormParams) error {
 	t.queryParams = &params
 	if params.Ea != nil {
-		t.array = *params.Ea
+		t.array = params.Ea
 	}
 	if params.A != nil {
-		t.array = *params.A
+		t.array = params.A
 	}
 	if params.Eo != nil {
 		t.object = params.Eo
@@ -175,10 +175,10 @@ func (t *testServer) GetHeader(ctx echo.Context, params GetHeaderParams) error {
 		t.primitive = params.XPrimitiveExploded
 	}
 	if params.XArray != nil {
-		t.array = *params.XArray
+		t.array = params.XArray
 	}
 	if params.XArrayExploded != nil {
-		t.array = *params.XArrayExploded
+		t.array = params.XArrayExploded
 	}
 	if params.XObject != nil {
 		t.object = params.XObject
@@ -196,10 +196,10 @@ func (t *testServer) GetHeader(ctx echo.Context, params GetHeaderParams) error {
 func (t *testServer) GetCookie(ctx echo.Context, params GetCookieParams) error {
 	t.cookieParams = &params
 	if params.Ea != nil {
-		t.array = *params.Ea
+		t.array = params.Ea
 	}
 	if params.A != nil {
-		t.array = *params.A
+		t.array = params.A
 	}
 	if params.Eo != nil {
 		t.object = params.Eo
@@ -625,8 +625,8 @@ func TestClientQueryParams(t *testing.T) {
 
 	// Check query params
 	qParams := GetQueryFormParams{
-		Ea: &expectedArray1,
-		A:  &expectedArray2,
+		Ea: expectedArray1,
+		A:  expectedArray2,
 		Eo: &expectedObject1,
 		O:  &expectedObject2,
 		Ep: &expectedPrimitive1,
@@ -644,8 +644,8 @@ func TestClientQueryParams(t *testing.T) {
 
 	// Check cookie params
 	cParams := GetCookieParams{
-		Ea: &expectedArray1,
-		A:  &expectedArray2,
+		Ea: expectedArray1,
+		A:  expectedArray2,
 		Eo: &expectedObject1,
 		O:  &expectedObject2,
 		Ep: &expectedPrimitive1,
@@ -661,8 +661,8 @@ func TestClientQueryParams(t *testing.T) {
 
 	// Check Header parameters
 	hParams := GetHeaderParams{
-		XArrayExploded:     &expectedArray1,
-		XArray:             &expectedArray2,
+		XArrayExploded:     expectedArray1,
+		XArray:             expectedArray2,
 		XObjectExploded:    &expectedObject1,
 		XObject:            &expectedObject2,
 		XPrimitiveExploded: &expectedPrimitive1,

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -15,8 +15,8 @@ import (
 
 // EveryTypeOptional defines model for EveryTypeOptional.
 type EveryTypeOptional struct {
-	ArrayInlineField     *[]int              `json:"array_inline_field,omitempty"`
-	ArrayReferencedField *[]SomeObject       `json:"array_referenced_field,omitempty"`
+	ArrayInlineField     []int               `json:"array_inline_field,omitempty"`
+	ArrayReferencedField []SomeObject        `json:"array_referenced_field,omitempty"`
 	BoolField            *bool               `json:"bool_field,omitempty"`
 	ByteField            *[]byte             `json:"byte_field,omitempty"`
 	DateField            *openapi_types.Date `json:"date_field,omitempty"`

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -221,6 +221,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 				outType = "interface{}"
 			}
 			outSchema.GoType = outType
+			outSchema.SkipOptionalPointer = true
 		} else {
 			// We've got an object with some properties.
 			for _, pName := range SortedSchemaKeys(schema.Properties) {
@@ -341,6 +342,7 @@ func resolveType(schema *openapi3.Schema, path []string, outSchema *Schema) erro
 			outSchema.AdditionalTypes = append(outSchema.AdditionalTypes, additionalTypes...)
 		}
 		outSchema.Properties = arrayType.Properties
+		outSchema.SkipOptionalPointer = true
 	case "integer":
 		// We default to int if format doesn't ask for something else.
 		if f == "int64" {

--- a/pkg/codegen/templates/chi-middleware.tmpl
+++ b/pkg/codegen/templates/chi-middleware.tmpl
@@ -50,7 +50,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
       if paramValue := r.URL.Query().Get("{{.ParamName}}"); paramValue != "" {
 
       {{if .IsPassThrough}}
-        params.{{.GoName}} = {{if not .Required}}&{{end}}paramValue
+        params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}paramValue
       {{end}}
 
       {{if .IsJson}}
@@ -61,7 +61,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           return
         }
 
-        params.{{.GoName}} = {{if not .Required}}&{{end}}value
+        params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}value
       {{end}}
       }{{if .Required}} else {
           http.Error(w, "Query argument {{.ParamName}} is required, but not found", http.StatusBadRequest)
@@ -89,7 +89,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           }
 
         {{if .IsPassThrough}}
-          params.{{.GoName}} = {{if not .Required}}&{{end}}valueList[0]
+          params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}valueList[0]
         {{end}}
 
         {{if .IsJson}}
@@ -108,7 +108,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           }
         {{end}}
 
-          params.{{.GoName}} = {{if not .Required}}&{{end}}{{.GoName}}
+          params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}{{.GoName}}
 
         } {{if .Required}}else {
             http.Error(w, fmt.Sprintf("Header parameter {{.ParamName}} is required, but not found: %s", err), http.StatusBadRequest)
@@ -124,7 +124,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
       if cookie, err = r.Cookie("{{.ParamName}}"); err == nil {
 
       {{- if .IsPassThrough}}
-        params.{{.GoName}} = {{if not .Required}}&{{end}}cookie.Value
+        params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}cookie.Value
       {{end}}
 
       {{- if .IsJson}}
@@ -142,7 +142,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           return
         }
 
-        params.{{.GoName}} = {{if not .Required}}&{{end}}value
+        params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}value
       {{end}}
 
       {{- if .IsStyled}}
@@ -152,7 +152,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           http.Error(w, "Invalid format for parameter {{.ParamName}}: %s", http.StatusBadRequest)
           return
         }
-        params.{{.GoName}} = {{if not .Required}}&{{end}}value
+        params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}value
       {{end}}
 
       }

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -180,10 +180,10 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
 {{range $paramIdx, $param := .QueryParams}}
     {{if not .Required}} if params.{{.GoName}} != nil { {{end}}
     {{if .IsPassThrough}}
-    queryValues.Add("{{.ParamName}}", {{if not .Required}}*{{end}}params.{{.GoName}})
+    queryValues.Add("{{.ParamName}}", {{if .IndirectOptional}}*{{end}}params.{{.GoName}})
     {{end}}
     {{if .IsJson}}
-    if queryParamBuf, err := json.Marshal({{if not .Required}}*{{end}}params.{{.GoName}}); err != nil {
+    if queryParamBuf, err := json.Marshal({{if .IndirectOptional}}*{{end}}params.{{.GoName}}); err != nil {
         return nil, err
     } else {
         queryValues.Add("{{.ParamName}}", string(queryParamBuf))
@@ -191,7 +191,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
 
     {{end}}
     {{if .IsStyled}}
-    if queryFrag, err := runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationQuery, {{if not .Required}}*{{end}}params.{{.GoName}}); err != nil {
+    if queryFrag, err := runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationQuery, {{if .IndirectOptional}}*{{end}}params.{{.GoName}}); err != nil {
         return nil, err
     } else if parsed, err := url.ParseQuery(queryFrag); err != nil {
        return nil, err
@@ -217,18 +217,18 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
     {{if not .Required}} if params.{{.GoName}} != nil { {{end}}
     var headerParam{{$paramIdx}} string
     {{if .IsPassThrough}}
-    headerParam{{$paramIdx}} = {{if not .Required}}*{{end}}params.{{.GoName}}
+    headerParam{{$paramIdx}} = {{if .IndirectOptional}}*{{end}}params.{{.GoName}}
     {{end}}
     {{if .IsJson}}
     var headerParamBuf{{$paramIdx}} []byte
-    headerParamBuf{{$paramIdx}}, err = json.Marshal({{if not .Required}}*{{end}}params.{{.GoName}})
+    headerParamBuf{{$paramIdx}}, err = json.Marshal({{if .IndirectOptional}}*{{end}}params.{{.GoName}})
     if err != nil {
         return nil, err
     }
     headerParam{{$paramIdx}} = string(headerParamBuf{{$paramIdx}})
     {{end}}
     {{if .IsStyled}}
-    headerParam{{$paramIdx}}, err = runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationHeader, {{if not .Required}}*{{end}}params.{{.GoName}})
+    headerParam{{$paramIdx}}, err = runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationHeader, {{if .IndirectOptional}}*{{end}}params.{{.GoName}})
     if err != nil {
         return nil, err
     }
@@ -241,18 +241,18 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
     {{if not .Required}} if params.{{.GoName}} != nil { {{end}}
     var cookieParam{{$paramIdx}} string
     {{if .IsPassThrough}}
-    cookieParam{{$paramIdx}} = {{if not .Required}}*{{end}}params.{{.GoName}}
+    cookieParam{{$paramIdx}} = {{if .IndirectOptional}}*{{end}}params.{{.GoName}}
     {{end}}
     {{if .IsJson}}
     var cookieParamBuf{{$paramIdx}} []byte
-    cookieParamBuf{{$paramIdx}}, err = json.Marshal({{if not .Required}}*{{end}}params.{{.GoName}})
+    cookieParamBuf{{$paramIdx}}, err = json.Marshal({{if .IndirectOptional}}*{{end}}params.{{.GoName}})
     if err != nil {
         return nil, err
     }
     cookieParam{{$paramIdx}} = url.QueryEscape(string(cookieParamBuf{{$paramIdx}}))
     {{end}}
     {{if .IsStyled}}
-    cookieParam{{$paramIdx}}, err = runtime.StyleParamWithLocation("simple", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationCookie, {{if not .Required}}*{{end}}params.{{.GoName}})
+    cookieParam{{$paramIdx}}, err = runtime.StyleParamWithLocation("simple", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationCookie, {{if .IndirectOptional}}*{{end}}params.{{.GoName}})
     if err != nil {
         return nil, err
     }

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -177,7 +177,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
       if paramValue := r.URL.Query().Get("{{.ParamName}}"); paramValue != "" {
 
       {{if .IsPassThrough}}
-        params.{{.GoName}} = {{if not .Required}}&{{end}}paramValue
+        params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}paramValue
       {{end}}
 
       {{if .IsJson}}
@@ -188,7 +188,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           return
         }
 
-        params.{{.GoName}} = {{if not .Required}}&{{end}}value
+        params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}value
       {{end}}
       }{{if .Required}} else {
           http.Error(w, "Query argument {{.ParamName}} is required, but not found", http.StatusBadRequest)
@@ -216,7 +216,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           }
 
         {{if .IsPassThrough}}
-          params.{{.GoName}} = {{if not .Required}}&{{end}}valueList[0]
+          params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}valueList[0]
         {{end}}
 
         {{if .IsJson}}
@@ -235,7 +235,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           }
         {{end}}
 
-          params.{{.GoName}} = {{if not .Required}}&{{end}}{{.GoName}}
+          params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}{{.GoName}}
 
         } {{if .Required}}else {
             http.Error(w, fmt.Sprintf("Header parameter {{.ParamName}} is required, but not found: %s", err), http.StatusBadRequest)
@@ -251,7 +251,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
       if cookie, err = r.Cookie("{{.ParamName}}"); err == nil {
 
       {{- if .IsPassThrough}}
-        params.{{.GoName}} = {{if not .Required}}&{{end}}cookie.Value
+        params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}cookie.Value
       {{end}}
 
       {{- if .IsJson}}
@@ -269,7 +269,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           return
         }
 
-        params.{{.GoName}} = {{if not .Required}}&{{end}}value
+        params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}value
       {{end}}
 
       {{- if .IsStyled}}
@@ -279,7 +279,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
           http.Error(w, "Invalid format for parameter {{.ParamName}}: %s", http.StatusBadRequest)
           return
         }
-        params.{{.GoName}} = {{if not .Required}}&{{end}}value
+        params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}value
       {{end}}
 
       }
@@ -605,10 +605,10 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
 {{range $paramIdx, $param := .QueryParams}}
     {{if not .Required}} if params.{{.GoName}} != nil { {{end}}
     {{if .IsPassThrough}}
-    queryValues.Add("{{.ParamName}}", {{if not .Required}}*{{end}}params.{{.GoName}})
+    queryValues.Add("{{.ParamName}}", {{if .IndirectOptional}}*{{end}}params.{{.GoName}})
     {{end}}
     {{if .IsJson}}
-    if queryParamBuf, err := json.Marshal({{if not .Required}}*{{end}}params.{{.GoName}}); err != nil {
+    if queryParamBuf, err := json.Marshal({{if .IndirectOptional}}*{{end}}params.{{.GoName}}); err != nil {
         return nil, err
     } else {
         queryValues.Add("{{.ParamName}}", string(queryParamBuf))
@@ -616,7 +616,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
 
     {{end}}
     {{if .IsStyled}}
-    if queryFrag, err := runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationQuery, {{if not .Required}}*{{end}}params.{{.GoName}}); err != nil {
+    if queryFrag, err := runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationQuery, {{if .IndirectOptional}}*{{end}}params.{{.GoName}}); err != nil {
         return nil, err
     } else if parsed, err := url.ParseQuery(queryFrag); err != nil {
        return nil, err
@@ -642,18 +642,18 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
     {{if not .Required}} if params.{{.GoName}} != nil { {{end}}
     var headerParam{{$paramIdx}} string
     {{if .IsPassThrough}}
-    headerParam{{$paramIdx}} = {{if not .Required}}*{{end}}params.{{.GoName}}
+    headerParam{{$paramIdx}} = {{if .IndirectOptional}}*{{end}}params.{{.GoName}}
     {{end}}
     {{if .IsJson}}
     var headerParamBuf{{$paramIdx}} []byte
-    headerParamBuf{{$paramIdx}}, err = json.Marshal({{if not .Required}}*{{end}}params.{{.GoName}})
+    headerParamBuf{{$paramIdx}}, err = json.Marshal({{if .IndirectOptional}}*{{end}}params.{{.GoName}})
     if err != nil {
         return nil, err
     }
     headerParam{{$paramIdx}} = string(headerParamBuf{{$paramIdx}})
     {{end}}
     {{if .IsStyled}}
-    headerParam{{$paramIdx}}, err = runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationHeader, {{if not .Required}}*{{end}}params.{{.GoName}})
+    headerParam{{$paramIdx}}, err = runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationHeader, {{if .IndirectOptional}}*{{end}}params.{{.GoName}})
     if err != nil {
         return nil, err
     }
@@ -666,18 +666,18 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
     {{if not .Required}} if params.{{.GoName}} != nil { {{end}}
     var cookieParam{{$paramIdx}} string
     {{if .IsPassThrough}}
-    cookieParam{{$paramIdx}} = {{if not .Required}}*{{end}}params.{{.GoName}}
+    cookieParam{{$paramIdx}} = {{if .IndirectOptional}}*{{end}}params.{{.GoName}}
     {{end}}
     {{if .IsJson}}
     var cookieParamBuf{{$paramIdx}} []byte
-    cookieParamBuf{{$paramIdx}}, err = json.Marshal({{if not .Required}}*{{end}}params.{{.GoName}})
+    cookieParamBuf{{$paramIdx}}, err = json.Marshal({{if .IndirectOptional}}*{{end}}params.{{.GoName}})
     if err != nil {
         return nil, err
     }
     cookieParam{{$paramIdx}} = url.QueryEscape(string(cookieParamBuf{{$paramIdx}}))
     {{end}}
     {{if .IsStyled}}
-    cookieParam{{$paramIdx}}, err = runtime.StyleParamWithLocation("simple", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationCookie, {{if not .Required}}*{{end}}params.{{.GoName}})
+    cookieParam{{$paramIdx}}, err = runtime.StyleParamWithLocation("simple", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationCookie, {{if .IndirectOptional}}*{{end}}params.{{.GoName}})
     if err != nil {
         return nil, err
     }
@@ -953,7 +953,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
     {{else}}
     if paramValue := ctx.QueryParam("{{.ParamName}}"); paramValue != "" {
     {{if .IsPassThrough}}
-    params.{{.GoName}} = {{if not .Required}}&{{end}}paramValue
+    params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}paramValue
     {{end}}
     {{if .IsJson}}
     var value {{.TypeDef}}
@@ -961,7 +961,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
     if err != nil {
         return echo.NewHTTPError(http.StatusBadRequest, "Error unmarshaling parameter '{{.ParamName}}' as JSON")
     }
-    params.{{.GoName}} = {{if not .Required}}&{{end}}value
+    params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}value
     {{end}}
     }{{if .Required}} else {
         return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Query argument {{.ParamName}} is required, but not found"))
@@ -979,7 +979,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
             return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for {{.ParamName}}, got %d", n))
         }
 {{if .IsPassThrough}}
-        params.{{.GoName}} = {{if not .Required}}&{{end}}valueList[0]
+        params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}valueList[0]
 {{end}}
 {{if .IsJson}}
         err = json.Unmarshal([]byte(valueList[0]), &{{.GoName}})
@@ -993,7 +993,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
             return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err))
         }
 {{end}}
-        params.{{.GoName}} = {{if not .Required}}&{{end}}{{.GoName}}
+        params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}{{.GoName}}
         } {{if .Required}}else {
             return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Header parameter {{.ParamName}} is required, but not found"))
         }{{end}}
@@ -1003,7 +1003,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
 {{range .CookieParams}}
     if cookie, err := ctx.Cookie("{{.ParamName}}"); err == nil {
     {{if .IsPassThrough}}
-    params.{{.GoName}} = {{if not .Required}}&{{end}}cookie.Value
+    params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}cookie.Value
     {{end}}
     {{if .IsJson}}
     var value {{.TypeDef}}
@@ -1016,7 +1016,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
     if err != nil {
         return echo.NewHTTPError(http.StatusBadRequest, "Error unmarshaling parameter '{{.ParamName}}' as JSON")
     }
-    params.{{.GoName}} = {{if not .Required}}&{{end}}value
+    params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}value
     {{end}}
     {{if .IsStyled}}
     var value {{.TypeDef}}
@@ -1024,7 +1024,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
     if err != nil {
         return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err))
     }
-    params.{{.GoName}} = {{if not .Required}}&{{end}}value
+    params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}value
     {{end}}
     }{{if .Required}} else {
         return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Query argument {{.ParamName}} is required, but not found"))

--- a/pkg/codegen/templates/wrappers.tmpl
+++ b/pkg/codegen/templates/wrappers.tmpl
@@ -41,7 +41,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
     {{else}}
     if paramValue := ctx.QueryParam("{{.ParamName}}"); paramValue != "" {
     {{if .IsPassThrough}}
-    params.{{.GoName}} = {{if not .Required}}&{{end}}paramValue
+    params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}paramValue
     {{end}}
     {{if .IsJson}}
     var value {{.TypeDef}}
@@ -49,7 +49,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
     if err != nil {
         return echo.NewHTTPError(http.StatusBadRequest, "Error unmarshaling parameter '{{.ParamName}}' as JSON")
     }
-    params.{{.GoName}} = {{if not .Required}}&{{end}}value
+    params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}value
     {{end}}
     }{{if .Required}} else {
         return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Query argument {{.ParamName}} is required, but not found"))
@@ -67,7 +67,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
             return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for {{.ParamName}}, got %d", n))
         }
 {{if .IsPassThrough}}
-        params.{{.GoName}} = {{if not .Required}}&{{end}}valueList[0]
+        params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}valueList[0]
 {{end}}
 {{if .IsJson}}
         err = json.Unmarshal([]byte(valueList[0]), &{{.GoName}})
@@ -81,7 +81,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
             return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err))
         }
 {{end}}
-        params.{{.GoName}} = {{if not .Required}}&{{end}}{{.GoName}}
+        params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}{{.GoName}}
         } {{if .Required}}else {
             return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Header parameter {{.ParamName}} is required, but not found"))
         }{{end}}
@@ -91,7 +91,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
 {{range .CookieParams}}
     if cookie, err := ctx.Cookie("{{.ParamName}}"); err == nil {
     {{if .IsPassThrough}}
-    params.{{.GoName}} = {{if not .Required}}&{{end}}cookie.Value
+    params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}cookie.Value
     {{end}}
     {{if .IsJson}}
     var value {{.TypeDef}}
@@ -104,7 +104,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
     if err != nil {
         return echo.NewHTTPError(http.StatusBadRequest, "Error unmarshaling parameter '{{.ParamName}}' as JSON")
     }
-    params.{{.GoName}} = {{if not .Required}}&{{end}}value
+    params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}value
     {{end}}
     {{if .IsStyled}}
     var value {{.TypeDef}}
@@ -112,7 +112,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
     if err != nil {
         return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err))
     }
-    params.{{.GoName}} = {{if not .Required}}&{{end}}value
+    params.{{.GoName}} = {{if .IndirectOptional}}&{{end}}value
     {{end}}
     }{{if .Required}} else {
         return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Query argument {{.ParamName}} is required, but not found"))

--- a/pkg/runtime/bindparam_test.go
+++ b/pkg/runtime/bindparam_test.go
@@ -297,6 +297,7 @@ func TestBindQueryParameter(t *testing.T) {
 			FirstName *string     `json:"firstName"`
 			LastName  *string     `json:"lastName"`
 			Role      string      `json:"role"`
+			Roles     []string    `json:"roles"`
 			Birthday  *types.Date `json:"birthday"`
 			Married   *MockBinder `json:"married"`
 		}
@@ -305,6 +306,7 @@ func TestBindQueryParameter(t *testing.T) {
 		expectedDeepObject := &ID{
 			FirstName: &expectedName,
 			Role:      "admin",
+			Roles:     []string{"admin", "user"},
 			Birthday:  &types.Date{Time: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)},
 			Married:   &MockBinder{time.Date(2020, 2, 2, 0, 0, 0, 0, time.UTC)},
 		}
@@ -314,6 +316,8 @@ func TestBindQueryParameter(t *testing.T) {
 		queryParams := url.Values{
 			"id[firstName]": {"Alex"},
 			"id[role]":      {"admin"},
+			"id[roles][0]":  {"admin"},
+			"id[roles][1]":  {"user"},
 			"foo":           {"bar"},
 			"id[birthday]":  {"2020-01-01"},
 			"id[married]":   {"2020-02-02"},


### PR DESCRIPTION
Partially resolves #266.

No support for string, as it is still under discussion.
map/slice can represent nil without making it a pointer, so this patch should be able to resolve the issue about for map/slice.