### PR TITLE
Set SkipOptionalPointer for array types

### DIFF
--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -52,7 +52,7 @@ type Pet struct {
 type FindPetsParams struct {
 
 	// tags to filter by
-	Tags *[]string `json:"tags,omitempty"`
+	Tags []string `json:"tags,omitempty"`
 
 	// maximum number of results to return
 	Limit *int32 `json:"limit,omitempty"`

--- a/examples/petstore-expanded/echo/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/echo/api/petstore-types.gen.go
@@ -37,7 +37,7 @@ type Pet struct {
 type FindPetsParams struct {
 
 	// tags to filter by
-	Tags *[]string `json:"tags,omitempty"`
+	Tags []string `json:"tags,omitempty"`
 
 	// maximum number of results to return
 	Limit *int32 `json:"limit,omitempty"`

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -51,7 +51,7 @@ type Pet struct {
 type FindPetsParams struct {
 
 	// tags to filter by
-	Tags *[]string `json:"tags,omitempty"`
+	Tags []string `json:"tags,omitempty"`
 
 	// maximum number of results to return
 	Limit *int32 `json:"limit,omitempty"`

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -44,10 +44,10 @@ type GetCookieParams struct {
 	Ep *int32 `json:"ep,omitempty"`
 
 	// exploded array
-	Ea *[]int32 `json:"ea,omitempty"`
+	Ea []int32 `json:"ea,omitempty"`
 
 	// array
-	A *[]int32 `json:"a,omitempty"`
+	A []int32 `json:"a,omitempty"`
 
 	// exploded object
 	Eo *Object `json:"eo,omitempty"`
@@ -69,10 +69,10 @@ type GetHeaderParams struct {
 	XPrimitiveExploded *int32 `json:"X-Primitive-Exploded,omitempty"`
 
 	// exploded array
-	XArrayExploded *[]int32 `json:"X-Array-Exploded,omitempty"`
+	XArrayExploded []int32 `json:"X-Array-Exploded,omitempty"`
 
 	// array
-	XArray *[]int32 `json:"X-Array,omitempty"`
+	XArray []int32 `json:"X-Array,omitempty"`
 
 	// exploded object
 	XObjectExploded *Object `json:"X-Object-Exploded,omitempty"`
@@ -95,10 +95,10 @@ type GetDeepObjectParams struct {
 type GetQueryFormParams struct {
 
 	// exploded array
-	Ea *[]int32 `json:"ea,omitempty"`
+	Ea []int32 `json:"ea,omitempty"`
 
 	// array
-	A *[]int32 `json:"a,omitempty"`
+	A []int32 `json:"a,omitempty"`
 
 	// exploded object
 	Eo *Object `json:"eo,omitempty"`

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -15,8 +15,8 @@ import (
 
 // EveryTypeOptional defines model for EveryTypeOptional.
 type EveryTypeOptional struct {
-	ArrayInlineField     *[]int              `json:"array_inline_field,omitempty"`
-	ArrayReferencedField *[]SomeObject       `json:"array_referenced_field,omitempty"`
+	ArrayInlineField     []int               `json:"array_inline_field,omitempty"`
+	ArrayReferencedField []SomeObject        `json:"array_referenced_field,omitempty"`
 	BoolField            *bool               `json:"bool_field,omitempty"`
 	ByteField            *[]byte             `json:"byte_field,omitempty"`
 	DateField            *openapi_types.Date `json:"date_field,omitempty"`

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -165,7 +165,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 
 	outSchema := Schema{
 		Description: StringToGoComment(schema.Description),
-		OAPISchema: schema,
+		OAPISchema:  schema,
 	}
 
 	// We can't support this in any meaningful way
@@ -335,6 +335,7 @@ func resolveType(schema *openapi3.Schema, path []string, outSchema *Schema) erro
 		}
 		outSchema.ArrayType = &arrayType
 		outSchema.GoType = "[]" + arrayType.TypeDecl()
+		outSchema.SkipOptionalPointer = true
 		additionalTypes := arrayType.GetAdditionalTypeDefs()
 		// Check also types defined in array item
 		if len(additionalTypes) > 0 {


### PR DESCRIPTION
## Brief Description of Changes

Set the `SkipOptionalPointer` property to `true` for all array schema types.

Effectively, this means an optional `[]int` still has type `[]int`, instead of the old `*[]int`.

## Rationale

I don't find any functional difference in treating an `[]int` and an `*[]int`. See:
- https://play.golang.com/p/cwtJGJlPsR0 (`[]int` version)
- https://play.golang.com/p/RrO-DpY7dqD (`*[]int` version)

They both:
- Can disambiguate between absent field (`nil` value) and empty array case (where both are non-`nil`).
- Cannot disambiguate between absent field and `NULL` value.

On the other hand, `*[]T` are much more clumsy to work with, due to the additional referencing/dereferencing
required.

Some libraries that rely on the polymorphic behaviour of `len` (on arrays and maps) cannot be used,
forcing the user to check for `nil` and dereferencing the `*[]T` as input.
`ozzo-validaion`'s `Length` check is one of them.

## Breaking Change

Yes, this is a breaking change (it functionally changes some test examples).

However, I believe this makes the user experience much better.
