### PR TITLE
Added implementation of x-json-ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ which help you to use the various OpenAPI 3 Authentication mechanism.
   will override any default value. This extended property isn't supported in all parts of
   OpenAPI, so please refer to the spec as to where it's allowed. Swagger validation tools will
   flag incorrect usage of this property.
+- `x-go-json-ignore`: sets tag to `-` to ignore the field in json completely.
 - `x-oapi-codegen-extra-tags`: adds extra Go field tags to the generated struct field. This is
   useful for interfacing with tag based ORM or validation libraries. The extra tags that
   are added are in addition to the regular json tags that are generated. If you specify your 

--- a/pkg/codegen/extension.go
+++ b/pkg/codegen/extension.go
@@ -6,10 +6,11 @@ import (
 )
 
 const (
-	extPropGoType    = "x-go-type"
-	extGoName        = "x-go-name"
-	extPropOmitEmpty = "x-omitempty"
-	extPropExtraTags = "x-oapi-codegen-extra-tags"
+	extPropGoType       = "x-go-type"
+	extGoName           = "x-go-name"
+	extPropGoJsonIgnore = "x-go-json-ignore"
+	extPropOmitEmpty    = "x-omitempty"
+	extPropExtraTags    = "x-oapi-codegen-extra-tags"
 )
 
 func extString(extPropValue interface{}) (string, error) {
@@ -56,4 +57,18 @@ func extExtraTags(extPropValue interface{}) (map[string]string, error) {
 		return nil, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 	return tags, nil
+}
+
+func extParseGoJsonIgnore(extPropValue interface{}) (bool, error) {
+	raw, ok := extPropValue.(json.RawMessage)
+	if !ok {
+		return false, fmt.Errorf("failed to convert type: %T", extPropValue)
+	}
+
+	var goJsonIgnore bool
+	if err := json.Unmarshal(raw, &goJsonIgnore); err != nil {
+		return false, fmt.Errorf("failed to unmarshal json: %w", err)
+	}
+
+	return goJsonIgnore, nil
 }

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -609,6 +609,14 @@ func GenFieldsFromProperties(props []Property) []string {
 			}
 		}
 
+		// Support x-go-json-ignore
+		if _, ok := p.ExtensionProps.Extensions[extPropGoJsonIgnore]; ok {
+			if goJsonIgnore, err := extParseGoJsonIgnore(p.ExtensionProps.Extensions[extPropGoJsonIgnore]); err == nil && goJsonIgnore {
+				fieldTags["json"] = "-"
+			}
+		}
+
+		// Support x-oapi-codegen-extra-tags
 		if extension, ok := p.ExtensionProps.Extensions[extPropExtraTags]; ok {
 			if tags, err := extExtraTags(extension); err == nil {
 				keys := SortedStringKeys(tags)


### PR DESCRIPTION
The implementation of x-go-json-ignore to use with GORM when we don't need to serialize specific fields (when ObjectID and Object fields is in the same struct).