### PR TITLE
[DRAFT] Adds register function which lets us define scope validator middleware per route

### DIFF
--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -172,6 +172,228 @@ type GetTestByNameResponse struct {
 	assert.Len(t, problems, 0)
 }
 
+func TestGenerateWithOAuth2Specification(t *testing.T) {
+	// Input vars for code generation:
+	packageName := "testswagger"
+	opts := Options{
+		GenerateClient:     true,
+		GenerateEchoServer: true,
+		GenerateTypes:      true,
+		EmbedSpec:          true,
+	}
+
+	// Get a spec from the test definition in this file:
+	swagger, err := openapi3.NewLoader().LoadFromData([]byte(testOpenAPIDefinitionWithOAuth2))
+	assert.NoError(t, err)
+	// Run our code generation:
+	code, err := Generate(swagger, packageName, opts)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, code)
+
+	// Check that we have valid (formattable) code:
+	_, err = format.Source([]byte(code))
+	assert.NoError(t, err)
+
+	// Check that we have a package:
+	assert.Contains(t, code, "package testswagger")
+
+	assert.Contains(t, code, "router.GET(baseURL+\"/pets\", wrapper.FindPets, sv([]string{\"read:pets\", \"pet:pets\"}))")
+	assert.Contains(t, code, "router.GET(baseURL+\"/pets/:id\", wrapper.FindPetByID, sv([]string{}))")
+
+}
+
+const testOpenAPIDefinitionWithOAuth2 = `
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: apiteam@swagger.io
+    url: http://swagger.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+servers:
+  - url: http://petstore.swagger.io/api
+
+paths:
+  /pets:
+    get:
+      summary: Returns all pets
+      description: |
+        Returns all pets from the system that the user has access to
+        Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+
+        Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+      operationId: findPets
+      security:
+        - OAuth2:
+            - read:pets
+            - pet:pets
+        - BasicAuth:
+
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          style: form
+          schema:
+            type: array
+            items:
+              type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
+      summary: Creates a new pet
+      description: Creates a new pet in the store. Duplicates are allowed
+      operationId: addPet
+      requestBody:
+        description: Pet to add to the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /pets/{id}:
+    get:
+      summary: Returns a pet by ID
+      description: Returns a pet based on a single ID
+      operationId: findPetByID
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    delete:
+      summary: Deletes a pet by ID
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      description: This API protects it's endpoints using JWT tokens issued by the authorization server
+      flows:
+        clientCredentials:
+          authorizationUrl: "https://foo.com/auth"
+          tokenUrl: "https://foo.com/oauth/token"
+          scopes:
+            "read:pets": Read pets
+            "pet:pets": Pet pets
+    BasicAuth:
+      type: http
+      scheme: basic
+      description: foo
+      bearerFormat: JWT
+      in: header
+
+  schemas:
+    Pet:
+      allOf:
+        - $ref: '#/components/schemas/NewPet'
+        - required:
+          - id
+          properties:
+            id:
+              type: integer
+              format: int64
+              description: Unique id of the pet
+
+    NewPet:
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Name of the pet
+        tag:
+          type: string
+          description: Type of the pet
+
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+          description: Error code
+        message:
+          type: string
+          description: Error message
+
+`
 const testOpenAPIDefinition = `
 openapi: 3.0.1
 

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -758,6 +758,23 @@ func GenerateRegistration(t *template.Template, ops []OperationDefinition) (stri
 	if err != nil {
 		return "", fmt.Errorf("error generating route registration: %s", err)
 	}
+
+	//Filter out only the security definitions containing OAuth2 in the name to build the OAuth2 registration function
+	for i, op := range ops {
+
+		var oAuth2SecurityDefinitions []SecurityDefinition
+		for _, sd := range op.SecurityDefinitions {
+			if strings.Contains(sd.ProviderName, "OAuth2") {
+				oAuth2SecurityDefinitions = append(oAuth2SecurityDefinitions, sd)
+			}
+		}
+		op.SecurityDefinitions = oAuth2SecurityDefinitions
+		ops[i] = op
+	}
+	err = t.ExecuteTemplate(w, "oauth2MiddlewareRegistration.tmpl", ops)
+	if err != nil {
+		return "", fmt.Errorf("error generating oauth2 route registration: %s", err)
+	}
 	err = w.Flush()
 	if err != nil {
 		return "", fmt.Errorf("error flushing output buffer for route registration: %s", err)

--- a/pkg/codegen/templates/oauth2MiddlewareRegistration.tmpl
+++ b/pkg/codegen/templates/oauth2MiddlewareRegistration.tmpl
@@ -1,0 +1,16 @@
+//A middleware function which is given the scopes for the route and can return an echo.MiddlewareFunc
+type ScopeValidatorMiddleware func (scopes []string) echo.MiddlewareFunc
+
+// Registers handlers with per handler OAuth2 scope validation.
+func RegisterHandlersWithOAuth2ScopeValidation(router EchoRouter, si ServerInterface, baseURL string, sv ScopeValidatorMiddleware) {
+{{if .}}
+    wrapper := ServerInterfaceWrapper{
+        Handler: si,
+    }
+{{end}}
+
+{{range .}}{{if .SecurityDefinitions}}router.{{.Method}}(baseURL + "{{.Path | swaggerUriToEchoUri}}", wrapper.{{.OperationId}}, sv({{range .SecurityDefinitions}}{{toStringArray .Scopes}}{{end}})){{end}}
+{{end}}
+{{range .}}{{if not .SecurityDefinitions}}router.{{.Method}}(baseURL + "{{.Path | swaggerUriToEchoUri}}", wrapper.{{.OperationId}}, sv([]string{})){{end}}
+{{end}}
+}

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -847,6 +847,23 @@ func GetSwagger() (swagger *openapi3.T, err error) {
     return
 }
 `,
+	"oauth2MiddlewareRegistration.tmpl": `//A middleware function which is given the scopes for the route and can return an echo.MiddlewareFunc
+type ScopeValidatorMiddleware func (scopes []string) echo.MiddlewareFunc
+
+// Registers handlers with per handler OAuth2 scope validation.
+func RegisterHandlersWithOAuth2ScopeValidation(router EchoRouter, si ServerInterface, baseURL string, sv ScopeValidatorMiddleware) {
+{{if .}}
+    wrapper := ServerInterfaceWrapper{
+        Handler: si,
+    }
+{{end}}
+
+{{range .}}{{if .SecurityDefinitions}}router.{{.Method}}(baseURL + "{{.Path | swaggerUriToEchoUri}}", wrapper.{{.OperationId}}, sv({{range .SecurityDefinitions}}{{toStringArray .Scopes}}{{end}})){{end}}
+{{end}}
+{{range .}}{{if not .SecurityDefinitions}}router.{{.Method}}(baseURL + "{{.Path | swaggerUriToEchoUri}}", wrapper.{{.OperationId}}, sv([]string{})){{end}}
+{{end}}
+}
+`,
 	"param-types.tmpl": `{{range .}}{{$opid := .OperationId}}
 {{range .TypeDefinitions}}
 // {{.TypeName}} defines parameters for {{$opid}}.
@@ -1059,4 +1076,3 @@ func Parse(t *template.Template) (*template.Template, error) {
 	}
 	return t, nil
 }
-


### PR DESCRIPTION
This is an idea of how we could solve the problem with not being able to have a scope aware middleware for each route.
The idea is that the use case will be something like this:

```go
mw := func (scopes []string) echo.Handlerfunc{
  //Here you can for example read the scopes from context that your previous middleware has put there
// (pseudo code)
return func(c echo.Context) error {
     return isAuthorized(c.Get("previouslySetScopes"), scopes)
   }
}
openapi.RegisterHandlersWithOAuth2ScopeValidation(s.EchoRouter, s.Service, mw)
```