### PR TITLE
fix(codegen): RefPathToGoType depth check

### DIFF
--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -210,15 +210,25 @@ func StringInArray(str string, array []string) bool {
 // #/components/parameters/Bar -> Bar
 // #/components/responses/Baz -> Baz
 // Remote components (document.json#/Foo) are supported if they present in --import-mapping
-// URL components (http://deepmap.com/schemas/document.json#Foo) are supported if they present in --import-mapping
-//
+// URL components (http://deepmap.com/schemas/document.json#/Foo) are supported if they present in --import-mapping
+// Remote and URL also support standard local paths even though the spec doesn't mention them.
 func RefPathToGoType(refPath string) (string, error) {
+	return refPathToGoType(refPath, true)
+}
+
+// refPathToGoType returns the Go typename for refPath given its
+func refPathToGoType(refPath string, local bool) (string, error) {
 	if refPath[0] == '#' {
 		pathParts := strings.Split(refPath, "/")
-		if depth := len(pathParts); depth != 4 {
-			return "", fmt.Errorf("Parameter nesting is deeper than supported: %s has %d", refPath, depth)
+		depth := len(pathParts)
+		if local {
+			if depth != 4 {
+				return "", fmt.Errorf("unexpected reference depth: %d for ref: %s local: %t", depth, refPath, local)
+			}
+		} else if depth != 4 && depth != 2 {
+			return "", fmt.Errorf("unexpected reference depth: %d for ref: %s local: %t", depth, refPath, local)
 		}
-		return SchemaNameToTypeName(pathParts[3]), nil
+		return SchemaNameToTypeName(pathParts[len(pathParts)-1]), nil
 	}
 	pathParts := strings.Split(refPath, "#")
 	if len(pathParts) != 2 {
@@ -228,7 +238,7 @@ func RefPathToGoType(refPath string) (string, error) {
 	if goImport, ok := importMapping[remoteComponent]; !ok {
 		return "", fmt.Errorf("unrecognized external reference '%s'; please provide the known import for this reference using option --import-mapping", remoteComponent)
 	} else {
-		goType, err := RefPathToGoType("#" + flatComponent)
+		goType, err := refPathToGoType("#"+flatComponent, false)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -134,22 +134,79 @@ func TestSortedRequestBodyKeys(t *testing.T) {
 }
 
 func TestRefPathToGoType(t *testing.T) {
-	goType, err := RefPathToGoType("#/components/schemas/Foo")
-	assert.Equal(t, "Foo", goType)
-	assert.NoError(t, err, "Expecting no error")
+	old := importMapping
+	importMapping = constructImportMapping(map[string]string{
+		"doc.json":                    "externalref0",
+		"http://deepmap.com/doc.json": "externalref1",
+	})
+	defer func() { importMapping = old }()
 
-	goType, err = RefPathToGoType("#/components/parameters/foo_bar")
-	assert.Equal(t, "FooBar", goType)
-	assert.NoError(t, err, "Expecting no error")
+	tests := []struct {
+		name   string
+		path   string
+		goType string
+	}{
+		{
+			name:   "local-schemas",
+			path:   "#/components/schemas/Foo",
+			goType: "Foo",
+		},
+		{
+			name:   "local-parameters",
+			path:   "#/components/parameters/foo_bar",
+			goType: "FooBar",
+		},
+		{
+			name:   "local-responses",
+			path:   "#/components/responses/wibble",
+			goType: "Wibble",
+		},
+		{
+			name:   "remote-root",
+			path:   "doc.json#/foo",
+			goType: "externalRef0.Foo",
+		},
+		{
+			name:   "remote-pathed",
+			path:   "doc.json#/components/parameters/foo",
+			goType: "externalRef0.Foo",
+		},
+		{
+			name:   "url-root",
+			path:   "http://deepmap.com/doc.json#/foo_bar",
+			goType: "externalRef1.FooBar",
+		},
+		{
+			name:   "url-pathed",
+			path:   "http://deepmap.com/doc.json#/components/parameters/foo_bar",
+			goType: "externalRef1.FooBar",
+		},
+		{
+			name: "local-too-deep",
+			path: "#/components/parameters/foo/components/bar",
+		},
+		{
+			name: "remote-too-deep",
+			path: "doc.json#/components/parameters/foo/foo_bar",
+		},
+		{
+			name: "url-too-deep",
+			path: "http://deepmap.com/doc.json#/components/parameters/foo/foo_bar",
+		},
+	}
 
-	_, err = RefPathToGoType("http://deepmap.com/doc.json#/components/parameters/foo_bar")
-	assert.Errorf(t, err, "Expected an error on URL reference")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			goType, err := RefPathToGoType(tc.path)
+			if tc.goType == "" {
+				assert.Error(t, err)
+				return
+			}
 
-	_, err = RefPathToGoType("doc.json#/components/parameters/foo_bar")
-	assert.Errorf(t, err, "Expected an error on remote reference")
-
-	_, err = RefPathToGoType("#/components/parameters/foo/components/bar")
-	assert.Errorf(t, err, "Expected an error on reference depth")
+			assert.NoError(t, err)
+			assert.Equal(t, tc.goType, goType)
+		})
+	}
 }
 
 func TestIsWholeDocumentReference(t *testing.T) {


### PR DESCRIPTION
Fix the depth check in RefPathToGoType which was incorrectly resulting in an error when processing URL or Remote references.

Also leverage sub tests to add more tests to TestRefPathToGoType to cover all the different types of expected refs.