### PR TITLE
Support standard encoding.TextUnmarshaler interface

### DIFF
--- a/pkg/runtime/bindparam.go
+++ b/pkg/runtime/bindparam.go
@@ -14,6 +14,7 @@
 package runtime
 
 import (
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -63,6 +64,15 @@ func BindStyledParameterWithLocation(style string, explode bool, paramName strin
 		}
 	default:
 		// Headers and cookies aren't escaped.
+	}
+
+	// If the destination implements encoding.TextUnmarshaler we use it for binding
+	if tu, ok := dest.(encoding.TextUnmarshaler); ok {
+		if err := tu.UnmarshalText([]byte(value)); err != nil {
+			return fmt.Errorf("error unmarshaling '%s' text as %T: %s", value, dest, err)
+		}
+
+		return nil
 	}
 
 	// Everything comes in by pointer, dereference it

--- a/pkg/runtime/bindparam_test.go
+++ b/pkg/runtime/bindparam_test.go
@@ -16,6 +16,7 @@ package runtime
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/url"
 	"testing"
 	"time"
@@ -446,4 +447,14 @@ func TestBindParamsToExplodedObject(t *testing.T) {
 	err = bindParamsToExplodedObject("date", values, &nTDstDate)
 	assert.EqualValues(t, expectedDate, nTDstDate)
 
+}
+
+func TestBindStyledParameterWithLocation(t *testing.T) {
+	expectedBig := big.NewInt(12345678910)
+
+	var dstBigNumber big.Int
+	err := BindStyledParameterWithLocation("simple", false, "id", ParamLocationUndefined,
+		"12345678910", &dstBigNumber)
+	assert.NoError(t, err)
+	assert.Equal(t, *expectedBig, dstBigNumber)
 }


### PR DESCRIPTION
Hi,

First of all thank you for this wonderful tool it really makes my life so much easier!

There are various standard types supporting standard encoding.TextUnmarshaler interface.
Here are few very famous ones for example: 
* big.Int 
* net.IP
* google.UUID

And there are thousands of other custom types implementing this interface can be found on GitHub
Currently if you try to use such types as a parameters you're getting binding error like:
```Invalid format for parameter id: error binding string parameter: can not bind to destination of type: array``` in case of net.IP or google.UUID

I know that there was a similar PR #262 but unfortunately it doesn't allow you to use thousands of existing types and forces you to create a new type with Bind(string) error method implemented on it. This is very inconvenient and this PR solves the problem.