### PR TITLE
fix(codegen): toStringArray with empty array

### DIFF
--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -1057,7 +1057,7 @@ type ServerInterfaceWrapper struct {
 func (w *ServerInterfaceWrapper) EnsureEverythingIsReferenced(ctx echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{""})
+	ctx.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.EnsureEverythingIsReferenced(ctx)
@@ -1068,7 +1068,7 @@ func (w *ServerInterfaceWrapper) EnsureEverythingIsReferenced(ctx echo.Context) 
 func (w *ServerInterfaceWrapper) Issue127(ctx echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{""})
+	ctx.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.Issue127(ctx)
@@ -1079,7 +1079,7 @@ func (w *ServerInterfaceWrapper) Issue127(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) Issue185(ctx echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{""})
+	ctx.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.Issue185(ctx)
@@ -1097,7 +1097,7 @@ func (w *ServerInterfaceWrapper) Issue209(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter str: %s", err))
 	}
 
-	ctx.Set(Access_tokenScopes, []string{""})
+	ctx.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.Issue209(ctx, str)
@@ -1115,7 +1115,7 @@ func (w *ServerInterfaceWrapper) Issue30(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter fallthrough: %s", err))
 	}
 
-	ctx.Set(Access_tokenScopes, []string{""})
+	ctx.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.Issue30(ctx, pFallthrough)
@@ -1133,7 +1133,7 @@ func (w *ServerInterfaceWrapper) Issue41(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1param: %s", err))
 	}
 
-	ctx.Set(Access_tokenScopes, []string{""})
+	ctx.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.Issue41(ctx, n1param)
@@ -1144,7 +1144,7 @@ func (w *ServerInterfaceWrapper) Issue41(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) Issue9(ctx echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{""})
+	ctx.Set(Access_tokenScopes, []string{})
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params Issue9Params

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -250,6 +250,9 @@ func getConditionOfResponseName(statusCodeVar, responseName string) string {
 
 // This outputs a string array
 func toStringArray(sarr []string) string {
+	if len(sarr) == 0 {
+		return "[]string{}"
+	}
 	return `[]string{"` + strings.Join(sarr, `","`) + `"}`
 }
 


### PR DESCRIPTION
toStringArray called with empty array would
return []string{} which has slighlty different
meaning than empty array []string{}.
This commit fixes the behavior