### PR TITLE
Fix panic when printing a nil Date

### DIFF
--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -1500,13 +1500,13 @@ func NewGetStartingWithNumberRequest(server string, n1param string) (*http.Reque
 
 	operationPath := fmt.Sprintf("/startingWithNumber/%s", pathParam0)
 	if operationPath[0] == '/' {
-		operationPath = operationPath[1:]
-	}
-	operationURL := url.URL{
-		Path: operationPath,
+		operationPath = "." + operationPath
 	}
 
-	queryURL := serverURL.ResolveReference(&operationURL)
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
@@ -2535,9 +2535,6 @@ func ParseGetStartingWithNumberResponse(rsp *http.Response) (*GetStartingWithNum
 	response := &GetStartingWithNumberResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
-	}
-
-	switch {
 	}
 
 	return response, nil

--- a/pkg/types/date.go
+++ b/pkg/types/date.go
@@ -28,3 +28,7 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 	d.Time = parsed
 	return nil
 }
+
+func (d Date) String() string {
+	return d.Time.Format(DateFormat)
+}

--- a/pkg/types/date_test.go
+++ b/pkg/types/date_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -29,4 +30,25 @@ func TestDate_UnmarshalJSON(t *testing.T) {
 	err := json.Unmarshal([]byte(jsonStr), &b)
 	assert.NoError(t, err)
 	assert.Equal(t, testDate, b.DateField.Time)
+}
+
+func TestDate_Stringer(t *testing.T) {
+	t.Run("nil date", func(t *testing.T) {
+		var d *Date
+		assert.Equal(t, "<nil>", fmt.Sprintf("%v", d))
+	})
+
+	t.Run("ptr date", func(t *testing.T) {
+		d := &Date{
+			Time: time.Date(2019, 4, 1, 0, 0, 0, 0, time.UTC),
+		}
+		assert.Equal(t, "2019-04-01", fmt.Sprintf("%v", d))
+	})
+
+	t.Run("value date", func(t *testing.T) {
+		d := Date{
+			Time: time.Date(2019, 4, 1, 0, 0, 0, 0, time.UTC),
+		}
+		assert.Equal(t, "2019-04-01", fmt.Sprintf("%v", d))
+	})
 }


### PR DESCRIPTION
Not sure why, but this is only happening when running with delve.
It seems like printing a nil Stringer causes a panic when debugging
with delve but is handled gracefully outside of delve.

Steps to reproduce:
1. Start debugger
2. Print the value of a nil Date
```go
var d *Date
fmt.Sprintf("%v", d)
```

Theory:
`time.Time` is embedded within the `Date` type. This means that if
Date is nil and Stringer is used to get the string representation of
it, it'll try to call Date.Time.String() which will result in a nil
dereferencing error.