### PR TITLE
Abolished github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/labstack/echo/v4 v4.2.1
 	github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd
 	github.com/mattn/go-colorable v0.1.8 // indirect
-	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,6 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -20,7 +20,6 @@ import (
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/labstack/echo/v4"
-	"github.com/pkg/errors"
 )
 
 // Has additional properties of type int
@@ -155,7 +154,7 @@ func (a *ParamsWithAddPropsParams_P1) UnmarshalJSON(b []byte) error {
 			var fieldVal interface{}
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+				return fmt.Errorf("error unmarshaling field %s", fieldName)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -171,7 +170,7 @@ func (a ParamsWithAddPropsParams_P1) MarshalJSON() ([]byte, error) {
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
 		}
 	}
 	return json.Marshal(object)
@@ -208,7 +207,7 @@ func (a *ParamsWithAddPropsParams_P2_Inner) UnmarshalJSON(b []byte) error {
 			var fieldVal string
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+				return fmt.Errorf("error unmarshaling field %s", fieldName)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -224,7 +223,7 @@ func (a ParamsWithAddPropsParams_P2_Inner) MarshalJSON() ([]byte, error) {
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
 		}
 	}
 	return json.Marshal(object)
@@ -258,7 +257,7 @@ func (a *BodyWithAddPropsJSONBody) UnmarshalJSON(b []byte) error {
 	if raw, found := object["inner"]; found {
 		err = json.Unmarshal(raw, &a.Inner)
 		if err != nil {
-			return errors.Wrap(err, "error reading 'inner'")
+			return fmt.Errorf("error reading 'inner'")
 		}
 		delete(object, "inner")
 	}
@@ -266,7 +265,7 @@ func (a *BodyWithAddPropsJSONBody) UnmarshalJSON(b []byte) error {
 	if raw, found := object["name"]; found {
 		err = json.Unmarshal(raw, &a.Name)
 		if err != nil {
-			return errors.Wrap(err, "error reading 'name'")
+			return fmt.Errorf("error reading 'name'")
 		}
 		delete(object, "name")
 	}
@@ -277,7 +276,7 @@ func (a *BodyWithAddPropsJSONBody) UnmarshalJSON(b []byte) error {
 			var fieldVal interface{}
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+				return fmt.Errorf("error unmarshaling field %s", fieldName)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -292,18 +291,18 @@ func (a BodyWithAddPropsJSONBody) MarshalJSON() ([]byte, error) {
 
 	object["inner"], err = json.Marshal(a.Inner)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error marshaling 'inner'"))
+		return nil, fmt.Errorf("error marshaling 'inner'")
 	}
 
 	object["name"], err = json.Marshal(a.Name)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error marshaling 'name'"))
+		return nil, fmt.Errorf("error marshaling 'name'")
 	}
 
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
 		}
 	}
 	return json.Marshal(object)
@@ -340,7 +339,7 @@ func (a *BodyWithAddPropsJSONBody_Inner) UnmarshalJSON(b []byte) error {
 			var fieldVal int
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+				return fmt.Errorf("error unmarshaling field %s", fieldName)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -356,7 +355,7 @@ func (a BodyWithAddPropsJSONBody_Inner) MarshalJSON() ([]byte, error) {
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
 		}
 	}
 	return json.Marshal(object)
@@ -390,7 +389,7 @@ func (a *AdditionalPropertiesObject1) UnmarshalJSON(b []byte) error {
 	if raw, found := object["id"]; found {
 		err = json.Unmarshal(raw, &a.Id)
 		if err != nil {
-			return errors.Wrap(err, "error reading 'id'")
+			return fmt.Errorf("error reading 'id'")
 		}
 		delete(object, "id")
 	}
@@ -398,7 +397,7 @@ func (a *AdditionalPropertiesObject1) UnmarshalJSON(b []byte) error {
 	if raw, found := object["name"]; found {
 		err = json.Unmarshal(raw, &a.Name)
 		if err != nil {
-			return errors.Wrap(err, "error reading 'name'")
+			return fmt.Errorf("error reading 'name'")
 		}
 		delete(object, "name")
 	}
@@ -406,7 +405,7 @@ func (a *AdditionalPropertiesObject1) UnmarshalJSON(b []byte) error {
 	if raw, found := object["optional"]; found {
 		err = json.Unmarshal(raw, &a.Optional)
 		if err != nil {
-			return errors.Wrap(err, "error reading 'optional'")
+			return fmt.Errorf("error reading 'optional'")
 		}
 		delete(object, "optional")
 	}
@@ -417,7 +416,7 @@ func (a *AdditionalPropertiesObject1) UnmarshalJSON(b []byte) error {
 			var fieldVal int
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+				return fmt.Errorf("error unmarshaling field %s", fieldName)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -432,25 +431,25 @@ func (a AdditionalPropertiesObject1) MarshalJSON() ([]byte, error) {
 
 	object["id"], err = json.Marshal(a.Id)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error marshaling 'id'"))
+		return nil, fmt.Errorf("error marshaling 'id'")
 	}
 
 	object["name"], err = json.Marshal(a.Name)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error marshaling 'name'"))
+		return nil, fmt.Errorf("error marshaling 'name'")
 	}
 
 	if a.Optional != nil {
 		object["optional"], err = json.Marshal(a.Optional)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling 'optional'"))
+			return nil, fmt.Errorf("error marshaling 'optional'")
 		}
 	}
 
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
 		}
 	}
 	return json.Marshal(object)
@@ -484,7 +483,7 @@ func (a *AdditionalPropertiesObject3) UnmarshalJSON(b []byte) error {
 	if raw, found := object["name"]; found {
 		err = json.Unmarshal(raw, &a.Name)
 		if err != nil {
-			return errors.Wrap(err, "error reading 'name'")
+			return fmt.Errorf("error reading 'name'")
 		}
 		delete(object, "name")
 	}
@@ -495,7 +494,7 @@ func (a *AdditionalPropertiesObject3) UnmarshalJSON(b []byte) error {
 			var fieldVal interface{}
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+				return fmt.Errorf("error unmarshaling field %s", fieldName)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -510,13 +509,13 @@ func (a AdditionalPropertiesObject3) MarshalJSON() ([]byte, error) {
 
 	object["name"], err = json.Marshal(a.Name)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error marshaling 'name'"))
+		return nil, fmt.Errorf("error marshaling 'name'")
 	}
 
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
 		}
 	}
 	return json.Marshal(object)
@@ -550,7 +549,7 @@ func (a *AdditionalPropertiesObject4) UnmarshalJSON(b []byte) error {
 	if raw, found := object["inner"]; found {
 		err = json.Unmarshal(raw, &a.Inner)
 		if err != nil {
-			return errors.Wrap(err, "error reading 'inner'")
+			return fmt.Errorf("error reading 'inner'")
 		}
 		delete(object, "inner")
 	}
@@ -558,7 +557,7 @@ func (a *AdditionalPropertiesObject4) UnmarshalJSON(b []byte) error {
 	if raw, found := object["name"]; found {
 		err = json.Unmarshal(raw, &a.Name)
 		if err != nil {
-			return errors.Wrap(err, "error reading 'name'")
+			return fmt.Errorf("error reading 'name'")
 		}
 		delete(object, "name")
 	}
@@ -569,7 +568,7 @@ func (a *AdditionalPropertiesObject4) UnmarshalJSON(b []byte) error {
 			var fieldVal interface{}
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+				return fmt.Errorf("error unmarshaling field %s", fieldName)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -584,18 +583,18 @@ func (a AdditionalPropertiesObject4) MarshalJSON() ([]byte, error) {
 
 	object["inner"], err = json.Marshal(a.Inner)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error marshaling 'inner'"))
+		return nil, fmt.Errorf("error marshaling 'inner'")
 	}
 
 	object["name"], err = json.Marshal(a.Name)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error marshaling 'name'"))
+		return nil, fmt.Errorf("error marshaling 'name'")
 	}
 
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
 		}
 	}
 	return json.Marshal(object)
@@ -629,7 +628,7 @@ func (a *AdditionalPropertiesObject4_Inner) UnmarshalJSON(b []byte) error {
 	if raw, found := object["name"]; found {
 		err = json.Unmarshal(raw, &a.Name)
 		if err != nil {
-			return errors.Wrap(err, "error reading 'name'")
+			return fmt.Errorf("error reading 'name'")
 		}
 		delete(object, "name")
 	}
@@ -640,7 +639,7 @@ func (a *AdditionalPropertiesObject4_Inner) UnmarshalJSON(b []byte) error {
 			var fieldVal interface{}
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+				return fmt.Errorf("error unmarshaling field %s", fieldName)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -655,13 +654,13 @@ func (a AdditionalPropertiesObject4_Inner) MarshalJSON() ([]byte, error) {
 
 	object["name"], err = json.Marshal(a.Name)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("error marshaling 'name'"))
+		return nil, fmt.Errorf("error marshaling 'name'")
 	}
 
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
 		}
 	}
 	return json.Marshal(object)
@@ -698,7 +697,7 @@ func (a *AdditionalPropertiesObject5) UnmarshalJSON(b []byte) error {
 			var fieldVal SchemaObject
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+				return fmt.Errorf("error unmarshaling field %s", fieldName)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -714,7 +713,7 @@ func (a AdditionalPropertiesObject5) MarshalJSON() ([]byte, error) {
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
 		}
 	}
 	return json.Marshal(object)

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -154,7 +154,7 @@ func (a *ParamsWithAddPropsParams_P1) UnmarshalJSON(b []byte) error {
 			var fieldVal interface{}
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return fmt.Errorf("error unmarshaling field %s", fieldName)
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -170,7 +170,7 @@ func (a ParamsWithAddPropsParams_P1) MarshalJSON() ([]byte, error) {
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}
 	}
 	return json.Marshal(object)
@@ -207,7 +207,7 @@ func (a *ParamsWithAddPropsParams_P2_Inner) UnmarshalJSON(b []byte) error {
 			var fieldVal string
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return fmt.Errorf("error unmarshaling field %s", fieldName)
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -223,7 +223,7 @@ func (a ParamsWithAddPropsParams_P2_Inner) MarshalJSON() ([]byte, error) {
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}
 	}
 	return json.Marshal(object)
@@ -257,7 +257,7 @@ func (a *BodyWithAddPropsJSONBody) UnmarshalJSON(b []byte) error {
 	if raw, found := object["inner"]; found {
 		err = json.Unmarshal(raw, &a.Inner)
 		if err != nil {
-			return fmt.Errorf("error reading 'inner'")
+			return fmt.Errorf("error reading 'inner': %w", err)
 		}
 		delete(object, "inner")
 	}
@@ -265,7 +265,7 @@ func (a *BodyWithAddPropsJSONBody) UnmarshalJSON(b []byte) error {
 	if raw, found := object["name"]; found {
 		err = json.Unmarshal(raw, &a.Name)
 		if err != nil {
-			return fmt.Errorf("error reading 'name'")
+			return fmt.Errorf("error reading 'name': %w", err)
 		}
 		delete(object, "name")
 	}
@@ -276,7 +276,7 @@ func (a *BodyWithAddPropsJSONBody) UnmarshalJSON(b []byte) error {
 			var fieldVal interface{}
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return fmt.Errorf("error unmarshaling field %s", fieldName)
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -291,18 +291,18 @@ func (a BodyWithAddPropsJSONBody) MarshalJSON() ([]byte, error) {
 
 	object["inner"], err = json.Marshal(a.Inner)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling 'inner'")
+		return nil, fmt.Errorf("error marshaling 'inner': %w", err)
 	}
 
 	object["name"], err = json.Marshal(a.Name)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling 'name'")
+		return nil, fmt.Errorf("error marshaling 'name': %w", err)
 	}
 
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}
 	}
 	return json.Marshal(object)
@@ -339,7 +339,7 @@ func (a *BodyWithAddPropsJSONBody_Inner) UnmarshalJSON(b []byte) error {
 			var fieldVal int
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return fmt.Errorf("error unmarshaling field %s", fieldName)
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -355,7 +355,7 @@ func (a BodyWithAddPropsJSONBody_Inner) MarshalJSON() ([]byte, error) {
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}
 	}
 	return json.Marshal(object)
@@ -389,7 +389,7 @@ func (a *AdditionalPropertiesObject1) UnmarshalJSON(b []byte) error {
 	if raw, found := object["id"]; found {
 		err = json.Unmarshal(raw, &a.Id)
 		if err != nil {
-			return fmt.Errorf("error reading 'id'")
+			return fmt.Errorf("error reading 'id': %w", err)
 		}
 		delete(object, "id")
 	}
@@ -397,7 +397,7 @@ func (a *AdditionalPropertiesObject1) UnmarshalJSON(b []byte) error {
 	if raw, found := object["name"]; found {
 		err = json.Unmarshal(raw, &a.Name)
 		if err != nil {
-			return fmt.Errorf("error reading 'name'")
+			return fmt.Errorf("error reading 'name': %w", err)
 		}
 		delete(object, "name")
 	}
@@ -405,7 +405,7 @@ func (a *AdditionalPropertiesObject1) UnmarshalJSON(b []byte) error {
 	if raw, found := object["optional"]; found {
 		err = json.Unmarshal(raw, &a.Optional)
 		if err != nil {
-			return fmt.Errorf("error reading 'optional'")
+			return fmt.Errorf("error reading 'optional': %w", err)
 		}
 		delete(object, "optional")
 	}
@@ -416,7 +416,7 @@ func (a *AdditionalPropertiesObject1) UnmarshalJSON(b []byte) error {
 			var fieldVal int
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return fmt.Errorf("error unmarshaling field %s", fieldName)
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -431,25 +431,25 @@ func (a AdditionalPropertiesObject1) MarshalJSON() ([]byte, error) {
 
 	object["id"], err = json.Marshal(a.Id)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling 'id'")
+		return nil, fmt.Errorf("error marshaling 'id': %w", err)
 	}
 
 	object["name"], err = json.Marshal(a.Name)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling 'name'")
+		return nil, fmt.Errorf("error marshaling 'name': %w", err)
 	}
 
 	if a.Optional != nil {
 		object["optional"], err = json.Marshal(a.Optional)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling 'optional'")
+			return nil, fmt.Errorf("error marshaling 'optional': %w", err)
 		}
 	}
 
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}
 	}
 	return json.Marshal(object)
@@ -483,7 +483,7 @@ func (a *AdditionalPropertiesObject3) UnmarshalJSON(b []byte) error {
 	if raw, found := object["name"]; found {
 		err = json.Unmarshal(raw, &a.Name)
 		if err != nil {
-			return fmt.Errorf("error reading 'name'")
+			return fmt.Errorf("error reading 'name': %w", err)
 		}
 		delete(object, "name")
 	}
@@ -494,7 +494,7 @@ func (a *AdditionalPropertiesObject3) UnmarshalJSON(b []byte) error {
 			var fieldVal interface{}
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return fmt.Errorf("error unmarshaling field %s", fieldName)
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -509,13 +509,13 @@ func (a AdditionalPropertiesObject3) MarshalJSON() ([]byte, error) {
 
 	object["name"], err = json.Marshal(a.Name)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling 'name'")
+		return nil, fmt.Errorf("error marshaling 'name': %w", err)
 	}
 
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}
 	}
 	return json.Marshal(object)
@@ -549,7 +549,7 @@ func (a *AdditionalPropertiesObject4) UnmarshalJSON(b []byte) error {
 	if raw, found := object["inner"]; found {
 		err = json.Unmarshal(raw, &a.Inner)
 		if err != nil {
-			return fmt.Errorf("error reading 'inner'")
+			return fmt.Errorf("error reading 'inner': %w", err)
 		}
 		delete(object, "inner")
 	}
@@ -557,7 +557,7 @@ func (a *AdditionalPropertiesObject4) UnmarshalJSON(b []byte) error {
 	if raw, found := object["name"]; found {
 		err = json.Unmarshal(raw, &a.Name)
 		if err != nil {
-			return fmt.Errorf("error reading 'name'")
+			return fmt.Errorf("error reading 'name': %w", err)
 		}
 		delete(object, "name")
 	}
@@ -568,7 +568,7 @@ func (a *AdditionalPropertiesObject4) UnmarshalJSON(b []byte) error {
 			var fieldVal interface{}
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return fmt.Errorf("error unmarshaling field %s", fieldName)
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -583,18 +583,18 @@ func (a AdditionalPropertiesObject4) MarshalJSON() ([]byte, error) {
 
 	object["inner"], err = json.Marshal(a.Inner)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling 'inner'")
+		return nil, fmt.Errorf("error marshaling 'inner': %w", err)
 	}
 
 	object["name"], err = json.Marshal(a.Name)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling 'name'")
+		return nil, fmt.Errorf("error marshaling 'name': %w", err)
 	}
 
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}
 	}
 	return json.Marshal(object)
@@ -628,7 +628,7 @@ func (a *AdditionalPropertiesObject4_Inner) UnmarshalJSON(b []byte) error {
 	if raw, found := object["name"]; found {
 		err = json.Unmarshal(raw, &a.Name)
 		if err != nil {
-			return fmt.Errorf("error reading 'name'")
+			return fmt.Errorf("error reading 'name': %w", err)
 		}
 		delete(object, "name")
 	}
@@ -639,7 +639,7 @@ func (a *AdditionalPropertiesObject4_Inner) UnmarshalJSON(b []byte) error {
 			var fieldVal interface{}
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return fmt.Errorf("error unmarshaling field %s", fieldName)
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -654,13 +654,13 @@ func (a AdditionalPropertiesObject4_Inner) MarshalJSON() ([]byte, error) {
 
 	object["name"], err = json.Marshal(a.Name)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling 'name'")
+		return nil, fmt.Errorf("error marshaling 'name': %w", err)
 	}
 
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}
 	}
 	return json.Marshal(object)
@@ -697,7 +697,7 @@ func (a *AdditionalPropertiesObject5) UnmarshalJSON(b []byte) error {
 			var fieldVal SchemaObject
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return fmt.Errorf("error unmarshaling field %s", fieldName)
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -713,7 +713,7 @@ func (a AdditionalPropertiesObject5) MarshalJSON() ([]byte, error) {
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}
 	}
 	return json.Marshal(object)

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/labstack/echo/v4"
-	"github.com/pkg/errors"
 )
 
 // ArrayValue defines model for ArrayValue.
@@ -71,7 +70,7 @@ func (a *Document_Fields) UnmarshalJSON(b []byte) error {
 			var fieldVal Value
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+				return fmt.Errorf("error unmarshaling field %s", fieldName)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -87,7 +86,7 @@ func (a Document_Fields) MarshalJSON() ([]byte, error) {
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
 		}
 	}
 	return json.Marshal(object)

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -70,7 +70,7 @@ func (a *Document_Fields) UnmarshalJSON(b []byte) error {
 			var fieldVal Value
 			err := json.Unmarshal(fieldBuf, &fieldVal)
 			if err != nil {
-				return fmt.Errorf("error unmarshaling field %s", fieldName)
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
 			}
 			a.AdditionalProperties[fieldName] = fieldVal
 		}
@@ -86,7 +86,7 @@ func (a Document_Fields) MarshalJSON() ([]byte, error) {
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}
 	}
 	return json.Marshal(object)

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -24,7 +24,6 @@ import (
 	"text/template"
 
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/pkg/errors"
 	"golang.org/x/tools/imports"
 
 	"github.com/deepmap/oapi-codegen/pkg/codegen/templates"
@@ -118,7 +117,7 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 	// above
 	t, err := templates.Parse(t)
 	if err != nil {
-		return "", errors.Wrap(err, "error parsing oapi-codegen templates")
+		return "", fmt.Errorf("error parsing oapi-codegen templates")
 	}
 
 	// Override built-in templates with user-provided versions
@@ -126,26 +125,26 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 		if _, ok := opts.UserTemplates[tpl.Name()]; ok {
 			utpl := t.New(tpl.Name())
 			if _, err := utpl.Parse(opts.UserTemplates[tpl.Name()]); err != nil {
-				return "", errors.Wrapf(err, "error parsing user-provided template %q", tpl.Name())
+				return "", fmt.Errorf("error parsing user-provided template %q", tpl.Name())
 			}
 		}
 	}
 
 	ops, err := OperationDefinitions(swagger)
 	if err != nil {
-		return "", errors.Wrap(err, "error creating operation definitions")
+		return "", fmt.Errorf("error creating operation definitions")
 	}
 
 	var typeDefinitions, constantDefinitions string
 	if opts.GenerateTypes {
 		typeDefinitions, err = GenerateTypeDefinitions(t, swagger, ops, opts.ExcludeSchemas)
 		if err != nil {
-			return "", errors.Wrap(err, "error generating type definitions")
+			return "", fmt.Errorf("error generating type definitions")
 		}
 
 		constantDefinitions, err = GenerateConstants(t, ops)
 		if err != nil {
-			return "", errors.Wrap(err, "error generating constants")
+			return "", fmt.Errorf("error generating constants")
 		}
 
 	}
@@ -154,7 +153,7 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 	if opts.GenerateEchoServer {
 		echoServerOut, err = GenerateEchoServer(t, ops)
 		if err != nil {
-			return "", errors.Wrap(err, "error generating Go handlers for Paths")
+			return "", fmt.Errorf("error generating Go handlers for Paths")
 		}
 	}
 
@@ -162,7 +161,7 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 	if opts.GenerateChiServer {
 		chiServerOut, err = GenerateChiServer(t, ops)
 		if err != nil {
-			return "", errors.Wrap(err, "error generating Go handlers for Paths")
+			return "", fmt.Errorf("error generating Go handlers for Paths")
 		}
 	}
 
@@ -170,7 +169,7 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 	if opts.GenerateClient {
 		clientOut, err = GenerateClient(t, ops)
 		if err != nil {
-			return "", errors.Wrap(err, "error generating client")
+			return "", fmt.Errorf("error generating client")
 		}
 	}
 
@@ -178,7 +177,7 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 	if opts.GenerateClient {
 		clientWithResponsesOut, err = GenerateClientWithResponses(t, ops)
 		if err != nil {
-			return "", errors.Wrap(err, "error generating client with responses")
+			return "", fmt.Errorf("error generating client with responses")
 		}
 	}
 
@@ -186,7 +185,7 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 	if opts.EmbedSpec {
 		inlinedSpec, err = GenerateInlinedSpec(t, importMapping, swagger)
 		if err != nil {
-			return "", errors.Wrap(err, "error generating Go handlers for Paths")
+			return "", fmt.Errorf("error generating Go handlers for Paths")
 		}
 	}
 
@@ -196,60 +195,60 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 	externalImports := importMapping.GoImports()
 	importsOut, err := GenerateImports(t, externalImports, packageName)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating imports")
+		return "", fmt.Errorf("error generating imports")
 	}
 
 	_, err = w.WriteString(importsOut)
 	if err != nil {
-		return "", errors.Wrap(err, "error writing imports")
+		return "", fmt.Errorf("error writing imports")
 	}
 
 	_, err = w.WriteString(constantDefinitions)
 	if err != nil {
-		return "", errors.Wrap(err, "error writing constants")
+		return "", fmt.Errorf("error writing constants")
 	}
 
 	_, err = w.WriteString(typeDefinitions)
 	if err != nil {
-		return "", errors.Wrap(err, "error writing type definitions")
+		return "", fmt.Errorf("error writing type definitions")
 
 	}
 
 	if opts.GenerateClient {
 		_, err = w.WriteString(clientOut)
 		if err != nil {
-			return "", errors.Wrap(err, "error writing client")
+			return "", fmt.Errorf("error writing client")
 		}
 		_, err = w.WriteString(clientWithResponsesOut)
 		if err != nil {
-			return "", errors.Wrap(err, "error writing client")
+			return "", fmt.Errorf("error writing client")
 		}
 	}
 
 	if opts.GenerateEchoServer {
 		_, err = w.WriteString(echoServerOut)
 		if err != nil {
-			return "", errors.Wrap(err, "error writing server path handlers")
+			return "", fmt.Errorf("error writing server path handlers")
 		}
 	}
 
 	if opts.GenerateChiServer {
 		_, err = w.WriteString(chiServerOut)
 		if err != nil {
-			return "", errors.Wrap(err, "error writing server path handlers")
+			return "", fmt.Errorf("error writing server path handlers")
 		}
 	}
 
 	if opts.EmbedSpec {
 		_, err = w.WriteString(inlinedSpec)
 		if err != nil {
-			return "", errors.Wrap(err, "error writing inlined spec")
+			return "", fmt.Errorf("error writing inlined spec")
 		}
 	}
 
 	err = w.Flush()
 	if err != nil {
-		return "", errors.Wrap(err, "error flushing output buffer")
+		return "", fmt.Errorf("error flushing output buffer")
 	}
 
 	// remove any byte-order-marks which break Go-Code
@@ -264,7 +263,7 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 	outBytes, err := imports.Process(packageName+".go", []byte(goCode), nil)
 	if err != nil {
 		fmt.Println(goCode)
-		return "", errors.Wrap(err, "error formatting Go code")
+		return "", fmt.Errorf("error formatting Go code")
 	}
 	return string(outBytes), nil
 }
@@ -272,45 +271,45 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 func GenerateTypeDefinitions(t *template.Template, swagger *openapi3.T, ops []OperationDefinition, excludeSchemas []string) (string, error) {
 	schemaTypes, err := GenerateTypesForSchemas(t, swagger.Components.Schemas, excludeSchemas)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating Go types for component schemas")
+		return "", fmt.Errorf("error generating Go types for component schemas")
 	}
 
 	paramTypes, err := GenerateTypesForParameters(t, swagger.Components.Parameters)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating Go types for component parameters")
+		return "", fmt.Errorf("error generating Go types for component parameters")
 	}
 	allTypes := append(schemaTypes, paramTypes...)
 
 	responseTypes, err := GenerateTypesForResponses(t, swagger.Components.Responses)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating Go types for component responses")
+		return "", fmt.Errorf("error generating Go types for component responses")
 	}
 	allTypes = append(allTypes, responseTypes...)
 
 	bodyTypes, err := GenerateTypesForRequestBodies(t, swagger.Components.RequestBodies)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating Go types for component request bodies")
+		return "", fmt.Errorf("error generating Go types for component request bodies")
 	}
 	allTypes = append(allTypes, bodyTypes...)
 
 	paramTypesOut, err := GenerateTypesForOperations(t, ops)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating Go types for operation parameters")
+		return "", fmt.Errorf("error generating Go types for component request bodies")
 	}
 
 	enumsOut, err := GenerateEnums(t, allTypes)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating code for type enums")
+		return "", fmt.Errorf("error generating code for type enums")
 	}
 
 	typesOut, err := GenerateTypes(t, allTypes)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating code for type definitions")
+		return "", fmt.Errorf("error generating code for type definitions")
 	}
 
 	allOfBoilerplate, err := GenerateAdditionalPropertyBoilerplate(t, allTypes)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating allOf boilerplate")
+		return "", fmt.Errorf("error generating allOf boilerplate")
 	}
 
 	typeDefinitions := strings.Join([]string{enumsOut, typesOut, paramTypesOut, allOfBoilerplate}, "")
@@ -374,7 +373,7 @@ func GenerateTypesForSchemas(t *template.Template, schemas map[string]*openapi3.
 
 		goSchema, err := GenerateGoSchema(schemaRef, []string{schemaName})
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error converting Schema %s to Go type", schemaName))
+			return nil, fmt.Errorf("error converting Schema %s to Go type", schemaName)
 		}
 
 		types = append(types, TypeDefinition{
@@ -397,7 +396,7 @@ func GenerateTypesForParameters(t *template.Template, params map[string]*openapi
 
 		goType, err := paramToGoType(paramOrRef.Value, nil)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error generating Go type for schema in parameter %s", paramName))
+			return nil, fmt.Errorf("error generating Go type for schema in parameter %s", paramName)
 		}
 
 		typeDef := TypeDefinition{
@@ -410,7 +409,7 @@ func GenerateTypesForParameters(t *template.Template, params map[string]*openapi
 			// Generate a reference type for referenced parameters
 			refType, err := RefPathToGoType(paramOrRef.Ref)
 			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("error generating Go type for (%s) in parameter %s", paramOrRef.Ref, paramName))
+				return nil, fmt.Errorf("error generating Go type for (%s) in parameter %s", paramOrRef.Ref, paramName)
 			}
 			typeDef.TypeName = SchemaNameToTypeName(refType)
 		}
@@ -436,7 +435,7 @@ func GenerateTypesForResponses(t *template.Template, responses openapi3.Response
 		if found {
 			goType, err := GenerateGoSchema(jsonResponse.Schema, []string{responseName})
 			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("error generating Go type for schema in response %s", responseName))
+				return nil, fmt.Errorf("error generating Go type for schema in response %s", responseName)
 			}
 
 			typeDef := TypeDefinition{
@@ -449,7 +448,7 @@ func GenerateTypesForResponses(t *template.Template, responses openapi3.Response
 				// Generate a reference type for referenced parameters
 				refType, err := RefPathToGoType(responseOrRef.Ref)
 				if err != nil {
-					return nil, errors.Wrap(err, fmt.Sprintf("error generating Go type for (%s) in parameter %s", responseOrRef.Ref, responseName))
+					return nil, fmt.Errorf("error generating Go type for (%s) in parameter %s", responseOrRef.Ref, responseName)
 				}
 				typeDef.TypeName = SchemaNameToTypeName(refType)
 			}
@@ -474,7 +473,7 @@ func GenerateTypesForRequestBodies(t *template.Template, bodies map[string]*open
 		if found {
 			goType, err := GenerateGoSchema(jsonBody.Schema, []string{bodyName})
 			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("error generating Go type for schema in body %s", bodyName))
+				return nil, fmt.Errorf("error generating Go type for schema in body %s", bodyName)
 			}
 
 			typeDef := TypeDefinition{
@@ -487,7 +486,7 @@ func GenerateTypesForRequestBodies(t *template.Template, bodies map[string]*open
 				// Generate a reference type for referenced bodies
 				refType, err := RefPathToGoType(bodyOrRef.Ref)
 				if err != nil {
-					return nil, errors.Wrap(err, fmt.Sprintf("error generating Go type for (%s) in body %s", bodyOrRef.Ref, bodyName))
+					return nil, fmt.Errorf("error generating Go type for (%s) in body %s", bodyOrRef.Ref, bodyName)
 				}
 				typeDef.TypeName = SchemaNameToTypeName(refType)
 			}
@@ -511,11 +510,11 @@ func GenerateTypes(t *template.Template, types []TypeDefinition) (string, error)
 
 	err := t.ExecuteTemplate(w, "typedef.tmpl", context)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating types")
+		return "", fmt.Errorf("error generating types")
 	}
 	err = w.Flush()
 	if err != nil {
-		return "", errors.Wrap(err, "error flushing output buffer for types")
+		return "", fmt.Errorf("error flushing output buffer for types")
 	}
 	return buf.String(), nil
 }
@@ -541,11 +540,11 @@ func GenerateEnums(t *template.Template, types []TypeDefinition) (string, error)
 	}
 	err := t.ExecuteTemplate(w, "constants.tmpl", c)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating enums")
+		return "", fmt.Errorf("error generating enums")
 	}
 	err = w.Flush()
 	if err != nil {
-		return "", errors.Wrap(err, "error flushing output buffer for enums")
+		return "", fmt.Errorf("error flushing output buffer for enums")
 	}
 	return buf.String(), nil
 }
@@ -581,11 +580,11 @@ func GenerateImports(t *template.Template, externalImports []string, packageName
 	}
 	err := t.ExecuteTemplate(w, "imports.tmpl", context)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating imports")
+		return "", fmt.Errorf("error generating imports")
 	}
 	err = w.Flush()
 	if err != nil {
-		return "", errors.Wrap(err, "error flushing output buffer for imports")
+		return "", fmt.Errorf("error flushing output buffer for imports")
 	}
 	return buf.String(), nil
 }
@@ -611,11 +610,11 @@ func GenerateAdditionalPropertyBoilerplate(t *template.Template, typeDefs []Type
 
 	err := t.ExecuteTemplate(w, "additional-properties.tmpl", context)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating additional properties code")
+		return "", fmt.Errorf("error generating additional properties code")
 	}
 	err = w.Flush()
 	if err != nil {
-		return "", errors.Wrap(err, "error flushing output buffer for additional properties")
+		return "", fmt.Errorf("error flushing output buffer for additional properties")
 	}
 	return buf.String(), nil
 }

--- a/pkg/codegen/extension.go
+++ b/pkg/codegen/extension.go
@@ -3,8 +3,6 @@ package codegen
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -20,7 +18,7 @@ func extTypeName(extPropValue interface{}) (string, error) {
 	}
 	var name string
 	if err := json.Unmarshal(raw, &name); err != nil {
-		return "", errors.Wrap(err, "failed to unmarshal json")
+		return "", fmt.Errorf("failed to unmarshal json")
 	}
 
 	return name, nil
@@ -34,7 +32,7 @@ func extParseOmitEmpty(extPropValue interface{}) (bool, error) {
 
 	var omitEmpty bool
 	if err := json.Unmarshal(raw, &omitEmpty); err != nil {
-		return false, errors.Wrap(err, "failed to unmarshal json")
+		return false, fmt.Errorf("failed to unmarshal json")
 	}
 
 	return omitEmpty, nil
@@ -47,7 +45,7 @@ func extExtraTags(extPropValue interface{}) (map[string]string, error) {
 	}
 	var tags map[string]string
 	if err := json.Unmarshal(raw, &tags); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal json")
+		return nil, fmt.Errorf("failed to unmarshal json")
 	}
 	return tags, nil
 }

--- a/pkg/codegen/extension.go
+++ b/pkg/codegen/extension.go
@@ -18,7 +18,7 @@ func extTypeName(extPropValue interface{}) (string, error) {
 	}
 	var name string
 	if err := json.Unmarshal(raw, &name); err != nil {
-		return "", fmt.Errorf("failed to unmarshal json")
+		return "", fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
 	return name, nil
@@ -32,7 +32,7 @@ func extParseOmitEmpty(extPropValue interface{}) (bool, error) {
 
 	var omitEmpty bool
 	if err := json.Unmarshal(raw, &omitEmpty); err != nil {
-		return false, fmt.Errorf("failed to unmarshal json")
+		return false, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
 	return omitEmpty, nil
@@ -45,7 +45,7 @@ func extExtraTags(extPropValue interface{}) (map[string]string, error) {
 	}
 	var tags map[string]string
 	if err := json.Unmarshal(raw, &tags); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal json")
+		return nil, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 	return tags, nil
 }

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -275,7 +275,7 @@ func (o *OperationDefinition) GetResponseTypeDefinitions() ([]ResponseTypeDefini
 				if contentType.Schema != nil {
 					responseSchema, err := GenerateGoSchema(contentType.Schema, []string{responseName})
 					if err != nil {
-						return nil, fmt.Errorf("Unable to determine Go type for %s.%s", o.OperationId, contentTypeName)
+						return nil, fmt.Errorf("Unable to determine Go type for %s.%s: %w", o.OperationId, contentTypeName, err)
 					}
 
 					var typeName string
@@ -303,7 +303,7 @@ func (o *OperationDefinition) GetResponseTypeDefinitions() ([]ResponseTypeDefini
 					if IsGoTypeReference(contentType.Schema.Ref) {
 						refType, err := RefPathToGoType(contentType.Schema.Ref)
 						if err != nil {
-							return nil, fmt.Errorf("error dereferencing response Ref")
+							return nil, fmt.Errorf("error dereferencing response Ref: %w", err)
 						}
 						td.Schema.RefType = refType
 					}
@@ -428,7 +428,7 @@ func OperationDefinitions(swagger *openapi3.T) ([]OperationDefinition, error) {
 
 			bodyDefinitions, typeDefinitions, err := GenerateBodyDefinitions(op.OperationID, op.RequestBody)
 			if err != nil {
-				return nil, fmt.Errorf("error generating body definitions")
+				return nil, fmt.Errorf("error generating body definitions: %w", err)
 			}
 
 			opDef := OperationDefinition{
@@ -519,7 +519,7 @@ func GenerateBodyDefinitions(operationID string, bodyOrRef *openapi3.RequestBody
 		bodyTypeName := operationID + tag + "Body"
 		bodySchema, err := GenerateGoSchema(content.Schema, []string{bodyTypeName})
 		if err != nil {
-			return nil, nil, fmt.Errorf("error generating request body definition")
+			return nil, nil, fmt.Errorf("error generating request body definition: %w", err)
 		}
 
 		// If the body is a pre-defined type
@@ -527,7 +527,7 @@ func GenerateBodyDefinitions(operationID string, bodyOrRef *openapi3.RequestBody
 			// Convert the reference path to Go type
 			refType, err := RefPathToGoType(bodyOrRef.Ref)
 			if err != nil {
-				return nil, nil, fmt.Errorf("error turning reference (%s) into a Go type", bodyOrRef.Ref)
+				return nil, nil, fmt.Errorf("error turning reference (%s) into a Go type: %w", bodyOrRef.Ref, err)
 			}
 			bodySchema.RefType = refType
 		}
@@ -624,12 +624,12 @@ func GenerateTypesForOperations(t *template.Template, ops []OperationDefinition)
 
 	err := t.ExecuteTemplate(w, "param-types.tmpl", ops)
 	if err != nil {
-		return "", fmt.Errorf("error generating types for params objects")
+		return "", fmt.Errorf("error generating types for params objects: %w", err)
 	}
 
 	err = t.ExecuteTemplate(w, "request-bodies.tmpl", ops)
 	if err != nil {
-		return "", fmt.Errorf("error generating request bodies for operations")
+		return "", fmt.Errorf("error generating request bodies for operations: %w", err)
 	}
 
 	// Generate boiler plate for all additional types.
@@ -640,22 +640,22 @@ func GenerateTypesForOperations(t *template.Template, ops []OperationDefinition)
 
 	addProps, err := GenerateAdditionalPropertyBoilerplate(t, td)
 	if err != nil {
-		return "", fmt.Errorf("error generating additional properties boilerplate for operations")
+		return "", fmt.Errorf("error generating additional properties boilerplate for operations: %w", err)
 	}
 
 	_, err = w.WriteString("\n")
 	if err != nil {
-		return "", fmt.Errorf("error generating additional properties boilerplate for operations")
+		return "", fmt.Errorf("error generating additional properties boilerplate for operations: %w", err)
 	}
 
 	_, err = w.WriteString(addProps)
 	if err != nil {
-		return "", fmt.Errorf("error generating additional properties boilerplate for operations")
+		return "", fmt.Errorf("error generating additional properties boilerplate for operations: %w", err)
 	}
 
 	err = w.Flush()
 	if err != nil {
-		return "", fmt.Errorf("error flushing output buffer for server interface")
+		return "", fmt.Errorf("error flushing output buffer for server interface: %w", err)
 	}
 
 	return buf.String(), nil
@@ -669,22 +669,22 @@ func GenerateChiServer(t *template.Template, operations []OperationDefinition) (
 
 	err := t.ExecuteTemplate(w, "chi-interface.tmpl", operations)
 	if err != nil {
-		return "", fmt.Errorf("error generating server interface")
+		return "", fmt.Errorf("error generating server interface: %w", err)
 	}
 
 	err = t.ExecuteTemplate(w, "chi-middleware.tmpl", operations)
 	if err != nil {
-		return "", fmt.Errorf("error generating server middleware")
+		return "", fmt.Errorf("error generating server middleware: %w", err)
 	}
 
 	err = t.ExecuteTemplate(w, "chi-handler.tmpl", operations)
 	if err != nil {
-		return "", fmt.Errorf("error generating server http handler")
+		return "", fmt.Errorf("error generating server http handler: %w", err)
 	}
 
 	err = w.Flush()
 	if err != nil {
-		return "", fmt.Errorf("error flushing output buffer for server")
+		return "", fmt.Errorf("error flushing output buffer for server: %w", err)
 	}
 
 	return buf.String(), nil

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -22,7 +22,6 @@ import (
 	"unicode"
 
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/pkg/errors"
 )
 
 type ParameterDefinition struct {
@@ -276,7 +275,7 @@ func (o *OperationDefinition) GetResponseTypeDefinitions() ([]ResponseTypeDefini
 				if contentType.Schema != nil {
 					responseSchema, err := GenerateGoSchema(contentType.Schema, []string{responseName})
 					if err != nil {
-						return nil, errors.Wrap(err, fmt.Sprintf("Unable to determine Go type for %s.%s", o.OperationId, contentTypeName))
+						return nil, fmt.Errorf("Unable to determine Go type for %s.%s", o.OperationId, contentTypeName)
 					}
 
 					var typeName string
@@ -304,7 +303,7 @@ func (o *OperationDefinition) GetResponseTypeDefinitions() ([]ResponseTypeDefini
 					if IsGoTypeReference(contentType.Schema.Ref) {
 						refType, err := RefPathToGoType(contentType.Schema.Ref)
 						if err != nil {
-							return nil, errors.Wrap(err, "error dereferencing response Ref")
+							return nil, fmt.Errorf("error dereferencing response Ref")
 						}
 						td.Schema.RefType = refType
 					}
@@ -429,7 +428,7 @@ func OperationDefinitions(swagger *openapi3.T) ([]OperationDefinition, error) {
 
 			bodyDefinitions, typeDefinitions, err := GenerateBodyDefinitions(op.OperationID, op.RequestBody)
 			if err != nil {
-				return nil, errors.Wrap(err, "error generating body definitions")
+				return nil, fmt.Errorf("error generating body definitions")
 			}
 
 			opDef := OperationDefinition{
@@ -520,7 +519,7 @@ func GenerateBodyDefinitions(operationID string, bodyOrRef *openapi3.RequestBody
 		bodyTypeName := operationID + tag + "Body"
 		bodySchema, err := GenerateGoSchema(content.Schema, []string{bodyTypeName})
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "error generating request body definition")
+			return nil, nil, fmt.Errorf("error generating request body definition")
 		}
 
 		// If the body is a pre-defined type
@@ -528,7 +527,7 @@ func GenerateBodyDefinitions(operationID string, bodyOrRef *openapi3.RequestBody
 			// Convert the reference path to Go type
 			refType, err := RefPathToGoType(bodyOrRef.Ref)
 			if err != nil {
-				return nil, nil, errors.Wrap(err, fmt.Sprintf("error turning reference (%s) into a Go type", bodyOrRef.Ref))
+				return nil, nil, fmt.Errorf("error turning reference (%s) into a Go type", bodyOrRef.Ref)
 			}
 			bodySchema.RefType = refType
 		}
@@ -625,12 +624,12 @@ func GenerateTypesForOperations(t *template.Template, ops []OperationDefinition)
 
 	err := t.ExecuteTemplate(w, "param-types.tmpl", ops)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating types for params objects")
+		return "", fmt.Errorf("error generating types for params objects")
 	}
 
 	err = t.ExecuteTemplate(w, "request-bodies.tmpl", ops)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating request bodies for operations")
+		return "", fmt.Errorf("error generating request bodies for operations")
 	}
 
 	// Generate boiler plate for all additional types.
@@ -641,22 +640,22 @@ func GenerateTypesForOperations(t *template.Template, ops []OperationDefinition)
 
 	addProps, err := GenerateAdditionalPropertyBoilerplate(t, td)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating additional properties boilerplate for operations")
+		return "", fmt.Errorf("error generating additional properties boilerplate for operations")
 	}
 
 	_, err = w.WriteString("\n")
 	if err != nil {
-		return "", errors.Wrap(err, "error generating additional properties boilerplate for operations")
+		return "", fmt.Errorf("error generating additional properties boilerplate for operations")
 	}
 
 	_, err = w.WriteString(addProps)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating additional properties boilerplate for operations")
+		return "", fmt.Errorf("error generating additional properties boilerplate for operations")
 	}
 
 	err = w.Flush()
 	if err != nil {
-		return "", errors.Wrap(err, "error flushing output buffer for server interface")
+		return "", fmt.Errorf("error flushing output buffer for server interface")
 	}
 
 	return buf.String(), nil
@@ -670,22 +669,22 @@ func GenerateChiServer(t *template.Template, operations []OperationDefinition) (
 
 	err := t.ExecuteTemplate(w, "chi-interface.tmpl", operations)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating server interface")
+		return "", fmt.Errorf("error generating server interface")
 	}
 
 	err = t.ExecuteTemplate(w, "chi-middleware.tmpl", operations)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating server middleware")
+		return "", fmt.Errorf("error generating server middleware")
 	}
 
 	err = t.ExecuteTemplate(w, "chi-handler.tmpl", operations)
 	if err != nil {
-		return "", errors.Wrap(err, "error generating server http handler")
+		return "", fmt.Errorf("error generating server http handler")
 	}
 
 	err = w.Flush()
 	if err != nil {
-		return "", errors.Wrap(err, "error flushing output buffer for server")
+		return "", fmt.Errorf("error flushing output buffer for server")
 	}
 
 	return buf.String(), nil

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -45,7 +45,7 @@ func (s *Schema) MergeProperty(p Property) error {
 	// Scan all existing properties for a conflict
 	for _, e := range s.Properties {
 		if e.JsonFieldName == p.JsonFieldName && !PropertiesEqual(e, p) {
-			return fmt.Errorf("property '%s' already exists with a different type", e.JsonFieldName)
+			return errors.New(fmt.Sprintf("property '%s' already exists with a different type", e.JsonFieldName))
 		}
 	}
 	s.Properties = append(s.Properties, p)
@@ -186,7 +186,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 	if schema.AllOf != nil {
 		mergedSchema, err := MergeSchemas(schema.AllOf, path)
 		if err != nil {
-			return Schema{}, fmt.Errorf("error merging schemas")
+			return Schema{}, fmt.Errorf("error merging schemas: %w", err)
 		}
 		mergedSchema.OAPISchema = schema
 		return mergedSchema, nil
@@ -196,7 +196,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 	if extension, ok := schema.Extensions[extPropGoType]; ok {
 		typeName, err := extTypeName(extension)
 		if err != nil {
-			return outSchema, fmt.Errorf("invalid value for %q", extPropGoType)
+			return outSchema, fmt.Errorf("invalid value for %q: %w", extPropGoType, err)
 		}
 		outSchema.GoType = typeName
 		return outSchema, nil
@@ -228,7 +228,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 				propertyPath := append(path, pName)
 				pSchema, err := GenerateGoSchema(p, propertyPath)
 				if err != nil {
-					return Schema{}, fmt.Errorf("error generating Go schema for property '%s'", pName)
+					return Schema{}, fmt.Errorf("error generating Go schema for property '%s': %w", pName, err)
 				}
 
 				required := StringInArray(pName, schema.Required)
@@ -271,7 +271,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 			if schema.AdditionalProperties != nil {
 				additionalSchema, err := GenerateGoSchema(schema.AdditionalProperties, path)
 				if err != nil {
-					return Schema{}, fmt.Errorf("error generating type for additional properties")
+					return Schema{}, fmt.Errorf("error generating type for additional properties: %w", err)
 				}
 				outSchema.AdditionalPropertiesType = &additionalSchema
 			}
@@ -282,7 +282,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 	} else if len(schema.Enum) > 0 {
 		err := resolveType(schema, path, &outSchema)
 		if err != nil {
-			return Schema{}, fmt.Errorf("error resolving primitive type")
+			return Schema{}, fmt.Errorf("error resolving primitive type: %w", err)
 		}
 		enumValues := make([]string, len(schema.Enum))
 		for i, enumValue := range schema.Enum {
@@ -331,7 +331,7 @@ func resolveType(schema *openapi3.Schema, path []string, outSchema *Schema) erro
 		// [] in front of it.
 		arrayType, err := GenerateGoSchema(schema.Items, path)
 		if err != nil {
-			return fmt.Errorf("error generating type for array")
+			return fmt.Errorf("error generating type for array: %w", err)
 		}
 		outSchema.ArrayType = &arrayType
 		outSchema.GoType = "[]" + arrayType.TypeDecl()
@@ -503,20 +503,20 @@ func MergeSchemas(allOf []*openapi3.SchemaRef, path []string) (Schema, error) {
 		if IsGoTypeReference(ref) {
 			refType, err = RefPathToGoType(ref)
 			if err != nil {
-				return Schema{}, fmt.Errorf("error converting reference path to a go type")
+				return Schema{}, fmt.Errorf("error converting reference path to a go type: %w", err)
 			}
 		}
 
 		schema, err := GenerateGoSchema(schemaOrRef, path)
 		if err != nil {
-			return Schema{}, fmt.Errorf("error generating Go schema in allOf")
+			return Schema{}, fmt.Errorf("error generating Go schema in allOf: %w", err)
 		}
 		schema.RefType = refType
 
 		for _, p := range schema.Properties {
 			err = outSchema.MergeProperty(p)
 			if err != nil {
-				return Schema{}, fmt.Errorf("error merging properties")
+				return Schema{}, fmt.Errorf("error merging properties: %w", err)
 			}
 		}
 
@@ -540,7 +540,7 @@ func MergeSchemas(allOf []*openapi3.SchemaRef, path []string) (Schema, error) {
 	var err error
 	outSchema.GoType, err = GenStructFromAllOf(allOf, path)
 	if err != nil {
-		return Schema{}, fmt.Errorf("unable to generate aggregate type for AllOf")
+		return Schema{}, fmt.Errorf("unable to generate aggregate type for AllOf: %w", err)
 	}
 	return outSchema, nil
 }

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -1,11 +1,11 @@
 package codegen
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/pkg/errors"
 )
 
 // This describes a Schema, a type definition.
@@ -45,7 +45,7 @@ func (s *Schema) MergeProperty(p Property) error {
 	// Scan all existing properties for a conflict
 	for _, e := range s.Properties {
 		if e.JsonFieldName == p.JsonFieldName && !PropertiesEqual(e, p) {
-			return errors.New(fmt.Sprintf("property '%s' already exists with a different type", e.JsonFieldName))
+			return fmt.Errorf("property '%s' already exists with a different type", e.JsonFieldName)
 		}
 	}
 	s.Properties = append(s.Properties, p)
@@ -186,7 +186,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 	if schema.AllOf != nil {
 		mergedSchema, err := MergeSchemas(schema.AllOf, path)
 		if err != nil {
-			return Schema{}, errors.Wrap(err, "error merging schemas")
+			return Schema{}, fmt.Errorf("error merging schemas")
 		}
 		mergedSchema.OAPISchema = schema
 		return mergedSchema, nil
@@ -196,7 +196,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 	if extension, ok := schema.Extensions[extPropGoType]; ok {
 		typeName, err := extTypeName(extension)
 		if err != nil {
-			return outSchema, errors.Wrapf(err, "invalid value for %q", extPropGoType)
+			return outSchema, fmt.Errorf("invalid value for %q", extPropGoType)
 		}
 		outSchema.GoType = typeName
 		return outSchema, nil
@@ -228,7 +228,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 				propertyPath := append(path, pName)
 				pSchema, err := GenerateGoSchema(p, propertyPath)
 				if err != nil {
-					return Schema{}, errors.Wrap(err, fmt.Sprintf("error generating Go schema for property '%s'", pName))
+					return Schema{}, fmt.Errorf("error generating Go schema for property '%s'", pName)
 				}
 
 				required := StringInArray(pName, schema.Required)
@@ -271,7 +271,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 			if schema.AdditionalProperties != nil {
 				additionalSchema, err := GenerateGoSchema(schema.AdditionalProperties, path)
 				if err != nil {
-					return Schema{}, errors.Wrap(err, "error generating type for additional properties")
+					return Schema{}, fmt.Errorf("error generating type for additional properties")
 				}
 				outSchema.AdditionalPropertiesType = &additionalSchema
 			}
@@ -282,7 +282,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 	} else if len(schema.Enum) > 0 {
 		err := resolveType(schema, path, &outSchema)
 		if err != nil {
-			return Schema{}, errors.Wrap(err, "error resolving primitive type")
+			return Schema{}, fmt.Errorf("error resolving primitive type")
 		}
 		enumValues := make([]string, len(schema.Enum))
 		for i, enumValue := range schema.Enum {
@@ -314,7 +314,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 	} else {
 		err := resolveType(schema, path, &outSchema)
 		if err != nil {
-			return Schema{}, errors.Wrap(err, "error resolving primitive type")
+			return Schema{}, fmt.Errorf("error resolving primitive type")
 		}
 	}
 	return outSchema, nil
@@ -331,7 +331,7 @@ func resolveType(schema *openapi3.Schema, path []string, outSchema *Schema) erro
 		// [] in front of it.
 		arrayType, err := GenerateGoSchema(schema.Items, path)
 		if err != nil {
-			return errors.Wrap(err, "error generating type for array")
+			return fmt.Errorf("error generating type for array")
 		}
 		outSchema.ArrayType = &arrayType
 		outSchema.GoType = "[]" + arrayType.TypeDecl()
@@ -503,20 +503,20 @@ func MergeSchemas(allOf []*openapi3.SchemaRef, path []string) (Schema, error) {
 		if IsGoTypeReference(ref) {
 			refType, err = RefPathToGoType(ref)
 			if err != nil {
-				return Schema{}, errors.Wrap(err, "error converting reference path to a go type")
+				return Schema{}, fmt.Errorf("error converting reference path to a go type")
 			}
 		}
 
 		schema, err := GenerateGoSchema(schemaOrRef, path)
 		if err != nil {
-			return Schema{}, errors.Wrap(err, "error generating Go schema in allOf")
+			return Schema{}, fmt.Errorf("error generating Go schema in allOf")
 		}
 		schema.RefType = refType
 
 		for _, p := range schema.Properties {
 			err = outSchema.MergeProperty(p)
 			if err != nil {
-				return Schema{}, errors.Wrap(err, "error merging properties")
+				return Schema{}, fmt.Errorf("error merging properties")
 			}
 		}
 
@@ -540,7 +540,7 @@ func MergeSchemas(allOf []*openapi3.SchemaRef, path []string) (Schema, error) {
 	var err error
 	outSchema.GoType, err = GenStructFromAllOf(allOf, path)
 	if err != nil {
-		return Schema{}, errors.Wrap(err, "unable to generate aggregate type for AllOf")
+		return Schema{}, fmt.Errorf("unable to generate aggregate type for AllOf")
 	}
 	return outSchema, nil
 }

--- a/pkg/codegen/templates/additional-properties.tmpl
+++ b/pkg/codegen/templates/additional-properties.tmpl
@@ -28,7 +28,7 @@ func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
     if raw, found := object["{{.JsonFieldName}}"]; found {
         err = json.Unmarshal(raw, &a.{{.GoFieldName}})
         if err != nil {
-            return errors.Wrap(err, "error reading '{{.JsonFieldName}}'")
+            return fmt.Errorf("error reading '{{.JsonFieldName}}'")
         }
         delete(object, "{{.JsonFieldName}}")
     }
@@ -39,7 +39,7 @@ func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
             var fieldVal {{$addType}}
             err := json.Unmarshal(fieldBuf, &fieldVal)
             if err != nil {
-                return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+                return fmt.Errorf("error unmarshaling field %s", fieldName)
             }
             a.AdditionalProperties[fieldName] = fieldVal
         }
@@ -55,14 +55,14 @@ func (a {{.TypeName}}) MarshalJSON() ([]byte, error) {
 {{if not .Required}}if a.{{.GoFieldName}} != nil { {{end}}
     object["{{.JsonFieldName}}"], err = json.Marshal(a.{{.GoFieldName}})
     if err != nil {
-        return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '{{.JsonFieldName}}'"))
+        return nil, fmt.Errorf("error marshaling '{{.JsonFieldName}}'")
     }
 {{if not .Required}} }{{end}}
 {{end}}
     for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
 		}
 	}
 	return json.Marshal(object)

--- a/pkg/codegen/templates/additional-properties.tmpl
+++ b/pkg/codegen/templates/additional-properties.tmpl
@@ -28,7 +28,7 @@ func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
     if raw, found := object["{{.JsonFieldName}}"]; found {
         err = json.Unmarshal(raw, &a.{{.GoFieldName}})
         if err != nil {
-            return fmt.Errorf("error reading '{{.JsonFieldName}}'")
+            return fmt.Errorf("error reading '{{.JsonFieldName}}': %w", err)
         }
         delete(object, "{{.JsonFieldName}}")
     }
@@ -39,7 +39,7 @@ func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
             var fieldVal {{$addType}}
             err := json.Unmarshal(fieldBuf, &fieldVal)
             if err != nil {
-                return fmt.Errorf("error unmarshaling field %s", fieldName)
+                return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
             }
             a.AdditionalProperties[fieldName] = fieldVal
         }
@@ -55,14 +55,14 @@ func (a {{.TypeName}}) MarshalJSON() ([]byte, error) {
 {{if not .Required}}if a.{{.GoFieldName}} != nil { {{end}}
     object["{{.JsonFieldName}}"], err = json.Marshal(a.{{.GoFieldName}})
     if err != nil {
-        return nil, fmt.Errorf("error marshaling '{{.JsonFieldName}}'")
+        return nil, fmt.Errorf("error marshaling '{{.JsonFieldName}}': %w", err)
     }
 {{if not .Required}} }{{end}}
 {{end}}
     for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}
 	}
 	return json.Marshal(object)

--- a/pkg/codegen/templates/imports.tmpl
+++ b/pkg/codegen/templates/imports.tmpl
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"gopkg.in/yaml.v2"
 	"io"
@@ -25,7 +26,6 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-chi/chi/v5"
 	"github.com/labstack/echo/v4"
-	"github.com/pkg/errors"
 	{{- range .ExternalImports}}
 	{{ . }}
 	{{- end}}

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -32,7 +32,7 @@ func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
     if raw, found := object["{{.JsonFieldName}}"]; found {
         err = json.Unmarshal(raw, &a.{{.GoFieldName}})
         if err != nil {
-            return errors.Wrap(err, "error reading '{{.JsonFieldName}}'")
+            return fmt.Errorf("error reading '{{.JsonFieldName}}'")
         }
         delete(object, "{{.JsonFieldName}}")
     }
@@ -43,7 +43,7 @@ func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
             var fieldVal {{$addType}}
             err := json.Unmarshal(fieldBuf, &fieldVal)
             if err != nil {
-                return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
+                return fmt.Errorf("error unmarshaling field %s", fieldName)
             }
             a.AdditionalProperties[fieldName] = fieldVal
         }
@@ -59,14 +59,14 @@ func (a {{.TypeName}}) MarshalJSON() ([]byte, error) {
 {{if not .Required}}if a.{{.GoFieldName}} != nil { {{end}}
     object["{{.JsonFieldName}}"], err = json.Marshal(a.{{.GoFieldName}})
     if err != nil {
-        return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '{{.JsonFieldName}}'"))
+        return nil, fmt.Errorf("error marshaling '{{.JsonFieldName}}'")
     }
 {{if not .Required}} }{{end}}
 {{end}}
     for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
+			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
 		}
 	}
 	return json.Marshal(object)
@@ -738,6 +738,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"gopkg.in/yaml.v2"
 	"io"
@@ -753,7 +754,6 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-chi/chi/v5"
 	"github.com/labstack/echo/v4"
-	"github.com/pkg/errors"
 	{{- range .ExternalImports}}
 	{{ . }}
 	{{- end}}

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -32,7 +32,7 @@ func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
     if raw, found := object["{{.JsonFieldName}}"]; found {
         err = json.Unmarshal(raw, &a.{{.GoFieldName}})
         if err != nil {
-            return fmt.Errorf("error reading '{{.JsonFieldName}}'")
+            return fmt.Errorf("error reading '{{.JsonFieldName}}': %w", err)
         }
         delete(object, "{{.JsonFieldName}}")
     }
@@ -43,7 +43,7 @@ func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
             var fieldVal {{$addType}}
             err := json.Unmarshal(fieldBuf, &fieldVal)
             if err != nil {
-                return fmt.Errorf("error unmarshaling field %s", fieldName)
+                return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
             }
             a.AdditionalProperties[fieldName] = fieldVal
         }
@@ -59,14 +59,14 @@ func (a {{.TypeName}}) MarshalJSON() ([]byte, error) {
 {{if not .Required}}if a.{{.GoFieldName}} != nil { {{end}}
     object["{{.JsonFieldName}}"], err = json.Marshal(a.{{.GoFieldName}})
     if err != nil {
-        return nil, fmt.Errorf("error marshaling '{{.JsonFieldName}}'")
+        return nil, fmt.Errorf("error marshaling '{{.JsonFieldName}}': %w", err)
     }
 {{if not .Required}} }{{end}}
 {{end}}
     for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling '%s'", fieldName)
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
 		}
 	}
 	return json.Marshal(object)

--- a/pkg/runtime/bindparam.go
+++ b/pkg/runtime/bindparam.go
@@ -16,13 +16,12 @@ package runtime
 import (
 	"encoding"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/deepmap/oapi-codegen/pkg/types"
 )

--- a/pkg/runtime/deepobject.go
+++ b/pkg/runtime/deepobject.go
@@ -2,8 +2,8 @@ package runtime
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"github.com/deepmap/oapi-codegen/pkg/types"
 	"net/url"
 	"reflect"
 	"sort"
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/deepmap/oapi-codegen/pkg/types"
 )
 
 func marshalDeepObject(in interface{}, path []string) ([]string, error) {
@@ -25,7 +25,7 @@ func marshalDeepObject(in interface{}, path []string) ([]string, error) {
 			newPath := append(path, strconv.Itoa(i))
 			fields, err := marshalDeepObject(iface, newPath)
 			if err != nil {
-				return nil, errors.Wrap(err, "error traversing array")
+				return nil, fmt.Errorf("error traversing array")
 			}
 			result = append(result, fields...)
 		}
@@ -45,7 +45,7 @@ func marshalDeepObject(in interface{}, path []string) ([]string, error) {
 			newPath := append(path, k)
 			fields, err := marshalDeepObject(t[k], newPath)
 			if err != nil {
-				return nil, errors.Wrap(err, "error traversing map")
+				return nil, fmt.Errorf("error traversing map")
 			}
 			result = append(result, fields...)
 		}
@@ -69,16 +69,16 @@ func MarshalDeepObject(i interface{}, paramName string) (string, error) {
 	// but it's complicated, error-prone code.
 	buf, err := json.Marshal(i)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to marshal input to JSON")
+		return "", fmt.Errorf("failed to marshal input to JSON")
 	}
 	var i2 interface{}
 	err = json.Unmarshal(buf, &i2)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to unmarshal JSON")
+		return "", fmt.Errorf("failed to unmarshal JSON")
 	}
 	fields, err := marshalDeepObject(i2, nil)
 	if err != nil {
-		return "", errors.Wrap(err, "error traversing JSON structure")
+		return "", fmt.Errorf("error traversing JSON structure")
 	}
 
 	// Prefix the param name to each subscripted field.
@@ -152,7 +152,7 @@ func UnmarshalDeepObject(dst interface{}, paramName string, params url.Values) e
 	fieldPaths := makeFieldOrValue(paths, fieldValues)
 	err := assignPathValues(dst, fieldPaths)
 	if err != nil {
-		return errors.Wrap(err, "error assigning value to destination")
+		return fmt.Errorf("error assigning value to destination")
 	}
 
 	return nil
@@ -205,7 +205,7 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 		dstSlice := reflect.MakeSlice(it, sliceLength, sliceLength)
 		err := assignSlice(dstSlice, pathValues)
 		if err != nil {
-			return errors.Wrap(err, "error assigning slice")
+			return fmt.Errorf("error assigning slice")
 		}
 		iv.Set(dstSlice)
 		return nil
@@ -225,7 +225,7 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 			var err error
 			date.Time, err = time.Parse(types.DateFormat, pathValues.value)
 			if err != nil {
-				return errors.Wrap(err, "invalid date format")
+				return fmt.Errorf("invalid date format")
 			}
 			dst := iv
 			if it != reflect.TypeOf(types.Date{}) {
@@ -246,7 +246,7 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 				if err != nil {
 					return fmt.Errorf("error parsing tim as RFC3339 or 2006-01-02 time: %s", err)
 				}
-				return errors.Wrap(err, "invalid date format")
+				return fmt.Errorf("invalid date format")
 			}
 			dst := iv
 			if it != reflect.TypeOf(time.Time{}) {
@@ -259,7 +259,7 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 		}
 		fieldMap, err := fieldIndicesByJsonTag(iv.Interface())
 		if err != nil {
-			return errors.Wrap(err, "failed enumerating fields")
+			return fmt.Errorf("failed enumerating fields")
 		}
 		for _, fieldName := range sortedFieldOrValueKeys(pathValues.fields) {
 			fieldValue := pathValues.fields[fieldName]
@@ -270,7 +270,7 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 			field := iv.Field(fieldIndex)
 			err = assignPathValues(field.Addr().Interface(), fieldValue)
 			if err != nil {
-				return errors.Wrapf(err, "error assigning field [%s]", fieldName)
+				return fmt.Errorf("error assigning field [%s]", fieldName)
 			}
 		}
 		return nil
@@ -340,7 +340,7 @@ func assignSlice(dst reflect.Value, pathValues fieldOrValue) error {
 		dstElem := dst.Index(i).Addr()
 		err := assignPathValues(dstElem.Interface(), fieldOrValue{value: values[i]})
 		if err != nil {
-			return errors.Wrap(err, "error binding array")
+			return fmt.Errorf("error binding array")
 		}
 	}
 

--- a/pkg/runtime/deepobject.go
+++ b/pkg/runtime/deepobject.go
@@ -25,7 +25,7 @@ func marshalDeepObject(in interface{}, path []string) ([]string, error) {
 			newPath := append(path, strconv.Itoa(i))
 			fields, err := marshalDeepObject(iface, newPath)
 			if err != nil {
-				return nil, fmt.Errorf("error traversing array")
+				return nil, fmt.Errorf("error traversing array: %w", err)
 			}
 			result = append(result, fields...)
 		}
@@ -45,7 +45,7 @@ func marshalDeepObject(in interface{}, path []string) ([]string, error) {
 			newPath := append(path, k)
 			fields, err := marshalDeepObject(t[k], newPath)
 			if err != nil {
-				return nil, fmt.Errorf("error traversing map")
+				return nil, fmt.Errorf("error traversing map: %w", err)
 			}
 			result = append(result, fields...)
 		}
@@ -69,16 +69,16 @@ func MarshalDeepObject(i interface{}, paramName string) (string, error) {
 	// but it's complicated, error-prone code.
 	buf, err := json.Marshal(i)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal input to JSON")
+		return "", fmt.Errorf("failed to marshal input to JSON: %w", err)
 	}
 	var i2 interface{}
 	err = json.Unmarshal(buf, &i2)
 	if err != nil {
-		return "", fmt.Errorf("failed to unmarshal JSON")
+		return "", fmt.Errorf("failed to unmarshal JSON: %w", err)
 	}
 	fields, err := marshalDeepObject(i2, nil)
 	if err != nil {
-		return "", fmt.Errorf("error traversing JSON structure")
+		return "", fmt.Errorf("error traversing JSON structure: %w", err)
 	}
 
 	// Prefix the param name to each subscripted field.
@@ -152,7 +152,7 @@ func UnmarshalDeepObject(dst interface{}, paramName string, params url.Values) e
 	fieldPaths := makeFieldOrValue(paths, fieldValues)
 	err := assignPathValues(dst, fieldPaths)
 	if err != nil {
-		return fmt.Errorf("error assigning value to destination")
+		return fmt.Errorf("error assigning value to destination: %w", err)
 	}
 
 	return nil
@@ -205,7 +205,7 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 		dstSlice := reflect.MakeSlice(it, sliceLength, sliceLength)
 		err := assignSlice(dstSlice, pathValues)
 		if err != nil {
-			return fmt.Errorf("error assigning slice")
+			return fmt.Errorf("error assigning slice: %w", err)
 		}
 		iv.Set(dstSlice)
 		return nil
@@ -225,7 +225,7 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 			var err error
 			date.Time, err = time.Parse(types.DateFormat, pathValues.value)
 			if err != nil {
-				return fmt.Errorf("invalid date format")
+				return fmt.Errorf("invalid date format: %w", err)
 			}
 			dst := iv
 			if it != reflect.TypeOf(types.Date{}) {
@@ -246,7 +246,7 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 				if err != nil {
 					return fmt.Errorf("error parsing tim as RFC3339 or 2006-01-02 time: %s", err)
 				}
-				return fmt.Errorf("invalid date format")
+				return fmt.Errorf("invalid date format: %w", err)
 			}
 			dst := iv
 			if it != reflect.TypeOf(time.Time{}) {
@@ -259,7 +259,7 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 		}
 		fieldMap, err := fieldIndicesByJsonTag(iv.Interface())
 		if err != nil {
-			return fmt.Errorf("failed enumerating fields")
+			return fmt.Errorf("failed enumerating fields: %w", err)
 		}
 		for _, fieldName := range sortedFieldOrValueKeys(pathValues.fields) {
 			fieldValue := pathValues.fields[fieldName]
@@ -270,7 +270,7 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 			field := iv.Field(fieldIndex)
 			err = assignPathValues(field.Addr().Interface(), fieldValue)
 			if err != nil {
-				return fmt.Errorf("error assigning field [%s]", fieldName)
+				return fmt.Errorf("error assigning field [%s]: %w", fieldName, err)
 			}
 		}
 		return nil
@@ -340,7 +340,7 @@ func assignSlice(dst reflect.Value, pathValues fieldOrValue) error {
 		dstElem := dst.Index(i).Addr()
 		err := assignPathValues(dstElem.Interface(), fieldOrValue{value: values[i]})
 		if err != nil {
-			return fmt.Errorf("error binding array")
+			return fmt.Errorf("error binding array: %w", err)
 		}
 	}
 

--- a/pkg/runtime/styleparam.go
+++ b/pkg/runtime/styleparam.go
@@ -184,7 +184,7 @@ func styleStruct(style string, explode bool, paramName string, paramLocation Par
 	if timeVal, ok := marshalDateTimeValue(value); ok {
 		styledVal, err := stylePrimitive(style, explode, paramName, paramLocation, timeVal)
 		if err != nil {
-			return "", fmt.Errorf("failed to style time")
+			return "", fmt.Errorf("failed to style time: %w", err)
 		}
 		return styledVal, nil
 	}

--- a/pkg/runtime/styleparam.go
+++ b/pkg/runtime/styleparam.go
@@ -14,6 +14,7 @@
 package runtime
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -21,8 +22,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/deepmap/oapi-codegen/pkg/types"
 )
@@ -185,7 +184,7 @@ func styleStruct(style string, explode bool, paramName string, paramLocation Par
 	if timeVal, ok := marshalDateTimeValue(value); ok {
 		styledVal, err := stylePrimitive(style, explode, paramName, paramLocation, timeVal)
 		if err != nil {
-			return "", errors.Wrap(err, "failed to style time")
+			return "", fmt.Errorf("failed to style time")
 		}
 		return styledVal, nil
 	}


### PR DESCRIPTION
Fix for #418
To move `github.com/pkg/errors` to `erros`.