### PR TITLE
fix: wrong command on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ you can specify any combination of those.
  Go include paths. Please see below.
 
 So, for example, if you would like to produce only the server code, you could
-run `oapi-generate -generate types,server`. You could generate `types` and
+run `oapi-codegen -generate types,server`. You could generate `types` and
 `server` into separate files, but both are required for the server code.
 
 `oapi-codegen` can filter paths base on their tags in the openapi definition.


### PR DESCRIPTION
replacing:  `oapi-generate`
with: `oapi-codegen`