### PR TITLE
Add NoopAuthenticationFunction in RequestValidation

### DIFF
--- a/pkg/chi-middleware/oapi_validate.go
+++ b/pkg/chi-middleware/oapi_validate.go
@@ -34,6 +34,8 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func
 		panic(err)
 	}
 
+	addNoopAuthentication(options)
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
@@ -48,6 +50,18 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func
 		})
 	}
 
+}
+
+// Sets a NoopAuthenticationFunction in the openapi3filter Options if no other is set
+// because it is not used by echo but lets the request validation pass even with security schemes
+func addNoopAuthentication(options *Options) *Options {
+	if options == nil {
+		options = &Options{Options: openapi3filter.Options{}}
+	}
+	if options.Options.AuthenticationFunc == nil {
+		options.Options.AuthenticationFunc = openapi3filter.NoopAuthenticationFunc
+	}
+	return options
 }
 
 // This function is called from the middleware above and actually does the work

--- a/pkg/middleware/oapi_validate.go
+++ b/pkg/middleware/oapi_validate.go
@@ -73,6 +73,9 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) echo
 	}
 
 	skipper := getSkipperFromOptions(options)
+
+	options = addNoopAuthentication(options)
+
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			if skipper(c) {
@@ -86,6 +89,18 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) echo
 			return next(c)
 		}
 	}
+}
+
+// Sets a NoopAuthenticationFunction in the openapi3filter Options if no other is set
+// because it is not used by echo but lets the request validation pass even with security schemes
+func addNoopAuthentication(options *Options) *Options {
+	if options == nil {
+		options = &Options{Options: openapi3filter.Options{}}
+	}
+	if options.Options.AuthenticationFunc == nil {
+		options.Options.AuthenticationFunc = openapi3filter.NoopAuthenticationFunc
+	}
+	return options
 }
 
 // This function is called from the middleware above and actually does the work


### PR DESCRIPTION
Adresses #221.

When using security schemes, it is not possible to pass the RequestValidation, because it is enherited from openapi3filter which enforces an AuthenticationFunction in the Options. 
This function, however, is not used by the echo/chi server and can be just set to Noop.
This way the RequestValidation will pass.
For the security the server must implement some other kind of Authorization Middleware, anyway.