### PR TITLE
[#211] Generate OpenAPI dictionaries without fixed keys as maps

### DIFF
--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -57,9 +57,7 @@ type AdditionalPropertiesObject4_Inner struct {
 }
 
 // Has additional properties with schema for dictionaries
-type AdditionalPropertiesObject5 struct {
-	AdditionalProperties map[string]SchemaObject `json:"-"`
-}
+type AdditionalPropertiesObject5 map[string]SchemaObject
 
 // ObjectWithJsonField defines model for ObjectWithJsonField.
 type ObjectWithJsonField struct {
@@ -84,38 +82,23 @@ type RequestBody struct {
 	Field SchemaObject `json:"Field"`
 }
 
-// ParamsWithAddPropsParams_P1 defines parameters for ParamsWithAddProps.
-type ParamsWithAddPropsParams_P1 struct {
-	AdditionalProperties map[string]interface{} `json:"-"`
-}
-
 // ParamsWithAddPropsParams defines parameters for ParamsWithAddProps.
 type ParamsWithAddPropsParams struct {
 	// This parameter has additional properties
-	P1 ParamsWithAddPropsParams_P1 `json:"p1"`
+	P1 map[string]interface{} `json:"p1"`
 
 	// This parameter has an anonymous inner property which needs to be
 	// turned into a proper type for additionalProperties to work
 	P2 struct {
-		Inner ParamsWithAddPropsParams_P2_Inner `json:"inner"`
+		Inner map[string]string `json:"inner"`
 	} `json:"p2"`
-}
-
-// ParamsWithAddPropsParams_P2_Inner defines parameters for ParamsWithAddProps.
-type ParamsWithAddPropsParams_P2_Inner struct {
-	AdditionalProperties map[string]string `json:"-"`
 }
 
 // BodyWithAddPropsJSONBody defines parameters for BodyWithAddProps.
 type BodyWithAddPropsJSONBody struct {
-	Inner                BodyWithAddPropsJSONBody_Inner `json:"inner"`
-	Name                 string                         `json:"name"`
-	AdditionalProperties map[string]interface{}         `json:"-"`
-}
-
-// BodyWithAddPropsJSONBody_Inner defines parameters for BodyWithAddProps.
-type BodyWithAddPropsJSONBody_Inner struct {
-	AdditionalProperties map[string]int `json:"-"`
+	Inner                map[string]int         `json:"inner"`
+	Name                 string                 `json:"name"`
+	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
 // EnsureEverythingIsReferencedJSONRequestBody defines body for EnsureEverythingIsReferenced for application/json ContentType.
@@ -123,112 +106,6 @@ type EnsureEverythingIsReferencedJSONRequestBody RequestBody
 
 // BodyWithAddPropsJSONRequestBody defines body for BodyWithAddProps for application/json ContentType.
 type BodyWithAddPropsJSONRequestBody BodyWithAddPropsJSONBody
-
-// Getter for additional properties for ParamsWithAddPropsParams_P1. Returns the specified
-// element and whether it was found
-func (a ParamsWithAddPropsParams_P1) Get(fieldName string) (value interface{}, found bool) {
-	if a.AdditionalProperties != nil {
-		value, found = a.AdditionalProperties[fieldName]
-	}
-	return
-}
-
-// Setter for additional properties for ParamsWithAddPropsParams_P1
-func (a *ParamsWithAddPropsParams_P1) Set(fieldName string, value interface{}) {
-	if a.AdditionalProperties == nil {
-		a.AdditionalProperties = make(map[string]interface{})
-	}
-	a.AdditionalProperties[fieldName] = value
-}
-
-// Override default JSON handling for ParamsWithAddPropsParams_P1 to handle AdditionalProperties
-func (a *ParamsWithAddPropsParams_P1) UnmarshalJSON(b []byte) error {
-	object := make(map[string]json.RawMessage)
-	err := json.Unmarshal(b, &object)
-	if err != nil {
-		return err
-	}
-
-	if len(object) != 0 {
-		a.AdditionalProperties = make(map[string]interface{})
-		for fieldName, fieldBuf := range object {
-			var fieldVal interface{}
-			err := json.Unmarshal(fieldBuf, &fieldVal)
-			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
-			}
-			a.AdditionalProperties[fieldName] = fieldVal
-		}
-	}
-	return nil
-}
-
-// Override default JSON handling for ParamsWithAddPropsParams_P1 to handle AdditionalProperties
-func (a ParamsWithAddPropsParams_P1) MarshalJSON() ([]byte, error) {
-	var err error
-	object := make(map[string]json.RawMessage)
-
-	for fieldName, field := range a.AdditionalProperties {
-		object[fieldName], err = json.Marshal(field)
-		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
-		}
-	}
-	return json.Marshal(object)
-}
-
-// Getter for additional properties for ParamsWithAddPropsParams_P2_Inner. Returns the specified
-// element and whether it was found
-func (a ParamsWithAddPropsParams_P2_Inner) Get(fieldName string) (value string, found bool) {
-	if a.AdditionalProperties != nil {
-		value, found = a.AdditionalProperties[fieldName]
-	}
-	return
-}
-
-// Setter for additional properties for ParamsWithAddPropsParams_P2_Inner
-func (a *ParamsWithAddPropsParams_P2_Inner) Set(fieldName string, value string) {
-	if a.AdditionalProperties == nil {
-		a.AdditionalProperties = make(map[string]string)
-	}
-	a.AdditionalProperties[fieldName] = value
-}
-
-// Override default JSON handling for ParamsWithAddPropsParams_P2_Inner to handle AdditionalProperties
-func (a *ParamsWithAddPropsParams_P2_Inner) UnmarshalJSON(b []byte) error {
-	object := make(map[string]json.RawMessage)
-	err := json.Unmarshal(b, &object)
-	if err != nil {
-		return err
-	}
-
-	if len(object) != 0 {
-		a.AdditionalProperties = make(map[string]string)
-		for fieldName, fieldBuf := range object {
-			var fieldVal string
-			err := json.Unmarshal(fieldBuf, &fieldVal)
-			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
-			}
-			a.AdditionalProperties[fieldName] = fieldVal
-		}
-	}
-	return nil
-}
-
-// Override default JSON handling for ParamsWithAddPropsParams_P2_Inner to handle AdditionalProperties
-func (a ParamsWithAddPropsParams_P2_Inner) MarshalJSON() ([]byte, error) {
-	var err error
-	object := make(map[string]json.RawMessage)
-
-	for fieldName, field := range a.AdditionalProperties {
-		object[fieldName], err = json.Marshal(field)
-		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
-		}
-	}
-	return json.Marshal(object)
-}
 
 // Getter for additional properties for BodyWithAddPropsJSONBody. Returns the specified
 // element and whether it was found
@@ -299,59 +176,6 @@ func (a BodyWithAddPropsJSONBody) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("error marshaling 'name'"))
 	}
-
-	for fieldName, field := range a.AdditionalProperties {
-		object[fieldName], err = json.Marshal(field)
-		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
-		}
-	}
-	return json.Marshal(object)
-}
-
-// Getter for additional properties for BodyWithAddPropsJSONBody_Inner. Returns the specified
-// element and whether it was found
-func (a BodyWithAddPropsJSONBody_Inner) Get(fieldName string) (value int, found bool) {
-	if a.AdditionalProperties != nil {
-		value, found = a.AdditionalProperties[fieldName]
-	}
-	return
-}
-
-// Setter for additional properties for BodyWithAddPropsJSONBody_Inner
-func (a *BodyWithAddPropsJSONBody_Inner) Set(fieldName string, value int) {
-	if a.AdditionalProperties == nil {
-		a.AdditionalProperties = make(map[string]int)
-	}
-	a.AdditionalProperties[fieldName] = value
-}
-
-// Override default JSON handling for BodyWithAddPropsJSONBody_Inner to handle AdditionalProperties
-func (a *BodyWithAddPropsJSONBody_Inner) UnmarshalJSON(b []byte) error {
-	object := make(map[string]json.RawMessage)
-	err := json.Unmarshal(b, &object)
-	if err != nil {
-		return err
-	}
-
-	if len(object) != 0 {
-		a.AdditionalProperties = make(map[string]int)
-		for fieldName, fieldBuf := range object {
-			var fieldVal int
-			err := json.Unmarshal(fieldBuf, &fieldVal)
-			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
-			}
-			a.AdditionalProperties[fieldName] = fieldVal
-		}
-	}
-	return nil
-}
-
-// Override default JSON handling for BodyWithAddPropsJSONBody_Inner to handle AdditionalProperties
-func (a BodyWithAddPropsJSONBody_Inner) MarshalJSON() ([]byte, error) {
-	var err error
-	object := make(map[string]json.RawMessage)
 
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)
@@ -657,59 +481,6 @@ func (a AdditionalPropertiesObject4_Inner) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("error marshaling 'name'"))
 	}
-
-	for fieldName, field := range a.AdditionalProperties {
-		object[fieldName], err = json.Marshal(field)
-		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
-		}
-	}
-	return json.Marshal(object)
-}
-
-// Getter for additional properties for AdditionalPropertiesObject5. Returns the specified
-// element and whether it was found
-func (a AdditionalPropertiesObject5) Get(fieldName string) (value SchemaObject, found bool) {
-	if a.AdditionalProperties != nil {
-		value, found = a.AdditionalProperties[fieldName]
-	}
-	return
-}
-
-// Setter for additional properties for AdditionalPropertiesObject5
-func (a *AdditionalPropertiesObject5) Set(fieldName string, value SchemaObject) {
-	if a.AdditionalProperties == nil {
-		a.AdditionalProperties = make(map[string]SchemaObject)
-	}
-	a.AdditionalProperties[fieldName] = value
-}
-
-// Override default JSON handling for AdditionalPropertiesObject5 to handle AdditionalProperties
-func (a *AdditionalPropertiesObject5) UnmarshalJSON(b []byte) error {
-	object := make(map[string]json.RawMessage)
-	err := json.Unmarshal(b, &object)
-	if err != nil {
-		return err
-	}
-
-	if len(object) != 0 {
-		a.AdditionalProperties = make(map[string]SchemaObject)
-		for fieldName, fieldBuf := range object {
-			var fieldVal SchemaObject
-			err := json.Unmarshal(fieldBuf, &fieldVal)
-			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
-			}
-			a.AdditionalProperties[fieldName] = fieldVal
-		}
-	}
-	return nil
-}
-
-// Override default JSON handling for AdditionalPropertiesObject5 to handle AdditionalProperties
-func (a AdditionalPropertiesObject5) MarshalJSON() ([]byte, error) {
-	var err error
-	object := make(map[string]json.RawMessage)
 
 	for fieldName, field := range a.AdditionalProperties {
 		object[fieldName], err = json.Marshal(field)

--- a/internal/test/components/components_test.go
+++ b/internal/test/components/components_test.go
@@ -68,5 +68,5 @@ func TestAdditionalProperties(t *testing.T) {
 	var obj5 AdditionalPropertiesObject5
 	err = json.Unmarshal([]byte(buf2), &obj5)
 	assert.NoError(t, err)
-	assert.Equal(t, bossSchema, obj5.AdditionalProperties["boss"])
+	assert.Equal(t, bossSchema, obj5["boss"])
 }

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/labstack/echo/v4"
-	"github.com/pkg/errors"
 )
 
 // ArrayValue defines model for ArrayValue.
@@ -26,71 +25,13 @@ type ArrayValue []Value
 
 // Document defines model for Document.
 type Document struct {
-	Fields *Document_Fields `json:"fields,omitempty"`
-}
-
-// Document_Fields defines model for Document.Fields.
-type Document_Fields struct {
-	AdditionalProperties map[string]Value `json:"-"`
+	Fields *map[string]Value `json:"fields,omitempty"`
 }
 
 // Value defines model for Value.
 type Value struct {
 	ArrayValue  *ArrayValue `json:"arrayValue,omitempty"`
 	StringValue *string     `json:"stringValue,omitempty"`
-}
-
-// Getter for additional properties for Document_Fields. Returns the specified
-// element and whether it was found
-func (a Document_Fields) Get(fieldName string) (value Value, found bool) {
-	if a.AdditionalProperties != nil {
-		value, found = a.AdditionalProperties[fieldName]
-	}
-	return
-}
-
-// Setter for additional properties for Document_Fields
-func (a *Document_Fields) Set(fieldName string, value Value) {
-	if a.AdditionalProperties == nil {
-		a.AdditionalProperties = make(map[string]Value)
-	}
-	a.AdditionalProperties[fieldName] = value
-}
-
-// Override default JSON handling for Document_Fields to handle AdditionalProperties
-func (a *Document_Fields) UnmarshalJSON(b []byte) error {
-	object := make(map[string]json.RawMessage)
-	err := json.Unmarshal(b, &object)
-	if err != nil {
-		return err
-	}
-
-	if len(object) != 0 {
-		a.AdditionalProperties = make(map[string]Value)
-		for fieldName, fieldBuf := range object {
-			var fieldVal Value
-			err := json.Unmarshal(fieldBuf, &fieldVal)
-			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error unmarshaling field %s", fieldName))
-			}
-			a.AdditionalProperties[fieldName] = fieldVal
-		}
-	}
-	return nil
-}
-
-// Override default JSON handling for Document_Fields to handle AdditionalProperties
-func (a Document_Fields) MarshalJSON() ([]byte, error) {
-	var err error
-	object := make(map[string]json.RawMessage)
-
-	for fieldName, field := range a.AdditionalProperties {
-		object[fieldName], err = json.Marshal(field)
-		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("error marshaling '%s'", fieldName))
-		}
-	}
-	return json.Marshal(object)
 }
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -1500,13 +1500,13 @@ func NewGetStartingWithNumberRequest(server string, n1param string) (*http.Reque
 
 	operationPath := fmt.Sprintf("/startingWithNumber/%s", pathParam0)
 	if operationPath[0] == '/' {
-		operationPath = operationPath[1:]
-	}
-	operationURL := url.URL{
-		Path: operationPath,
+		operationPath = "." + operationPath
 	}
 
-	queryURL := serverURL.ResolveReference(&operationURL)
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
@@ -2535,9 +2535,6 @@ func ParseGetStartingWithNumberResponse(rsp *http.Response) (*GetStartingWithNum
 	response := &GetStartingWithNumberResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
-	}
-
-	switch {
 	}
 
 	return response, nil


### PR DESCRIPTION
Closes #211.

Generate all objects with the `additionalProperties` value set, but no `properties` set as maps.

For example, these schemas:
```yaml
anyMap:
    type: object
    additionalProperties: true
numberMap:
    type: object
    additionalProperties:
        type: integer
mapWithFixedKeys:
    type: object
    additionalProperties:
        type: string
    properties:
        key:
            type: string
```

produces the following

```go
type AnyMap map[string]interface{}

type NumberMap map[string]int

type MapWithFixedKeys struct {
    Key                  string
    AdditionalProperties map[string]string
}
```

instead of

```go
type AnyMap struct {
    AdditionalProperties map[string]interface{}
}

type NumberMap struct {
    AdditionalProperties map[string]int
}

type MapWithFixedKeys struct {
    Key                  string
    AdditionalProperties map[string]string
}
```

**This is a small breaking change.**
