### PR TITLE
Allow overriding primitive types with custom types

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,47 @@ This tells us that in order to resolve references generated from `some_spec.yaml
 need to import `github.com/deepmap/some-package`. You may specify multiple mappings
 by comma separating them in the form `key1:value1,key2:value2`.
 
+### Replacing primitive types
+
+Sometimes you would want to use a different type for the primitives (int, floats etc). 
+This can be done with the `primitive-mapping` option in the YAML configuration file.
+A list of supported primitives is shown below.
+
+If used inside a query parameter, the given replacement should implement `Binder`:
+```go
+type Binder interface {
+    Bind(string) error
+}
+```
+
+| Primitive | Default type used | 
+| -- | -- |
+| `int64` | `int64` |
+| `int32` | `int32` |
+| `int16` | `int16` |
+| `int` | `int` |
+| `uint64` | `uint64` |
+| `uint32` | `uint32` |
+| `uint16` | `uint16` |
+| `uint` | `uint` |
+| `double` | `float64` |
+| `float` | `float32` |
+| `bool` | `bool` |
+| `byte` | `[]byte` |
+| `email` | `openapi_types.Email` |
+| `date` | `openapi_types.Date` |
+| `date-time` | `time.Time` |
+| `json` | `json.RawMessage` |
+
+An example configuration:
+
+```yaml
+primitive-mapping:
+  int32: null.Int32
+  int64: null.Int64
+  int: float32
+```
+
 ## What's missing or incomplete
 
 This code is still young, and not complete, since we're filling it in as we

--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -45,18 +45,19 @@ var (
 	flagExcludeSchemas string
 	flagConfigFile     string
 	flagAliasTypes     bool
-	flagPrintVersion bool
+	flagPrintVersion   bool
 )
 
 type configuration struct {
-	PackageName     string            `yaml:"package"`
-	GenerateTargets []string          `yaml:"generate"`
-	OutputFile      string            `yaml:"output"`
-	IncludeTags     []string          `yaml:"include-tags"`
-	ExcludeTags     []string          `yaml:"exclude-tags"`
-	TemplatesDir    string            `yaml:"templates"`
-	ImportMapping   map[string]string `yaml:"import-mapping"`
-	ExcludeSchemas  []string          `yaml:"exclude-schemas"`
+	PackageName      string            `yaml:"package"`
+	GenerateTargets  []string          `yaml:"generate"`
+	OutputFile       string            `yaml:"output"`
+	IncludeTags      []string          `yaml:"include-tags"`
+	ExcludeTags      []string          `yaml:"exclude-tags"`
+	TemplatesDir     string            `yaml:"templates"`
+	ImportMapping    map[string]string `yaml:"import-mapping"`
+	PrimitiveMapping map[string]string `yaml:"primitive-mapping"`
+	ExcludeSchemas   []string          `yaml:"exclude-schemas"`
 }
 
 func main() {
@@ -104,7 +105,8 @@ func main() {
 	}
 
 	opts := codegen.Options{
-		AliasTypes: flagAliasTypes,
+		AliasTypes:       flagAliasTypes,
+		PrimitiveMapping: cfg.PrimitiveMapping,
 	}
 	for _, g := range cfg.GenerateTargets {
 		switch g {

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -1500,13 +1500,13 @@ func NewGetStartingWithNumberRequest(server string, n1param string) (*http.Reque
 
 	operationPath := fmt.Sprintf("/startingWithNumber/%s", pathParam0)
 	if operationPath[0] == '/' {
-		operationPath = operationPath[1:]
-	}
-	operationURL := url.URL{
-		Path: operationPath,
+		operationPath = "." + operationPath
 	}
 
-	queryURL := serverURL.ResolveReference(&operationURL)
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
@@ -2535,9 +2535,6 @@ func ParseGetStartingWithNumberResponse(rsp *http.Response) (*GetStartingWithNum
 	response := &GetStartingWithNumberResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
-	}
-
-	switch {
 	}
 
 	return response, nil

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -113,8 +113,9 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 	}
 
 	// This creates the golang templates text package
-	TemplateFunctions["opts"] = func() Options { return opts }
-	t := template.New("oapi-codegen").Funcs(TemplateFunctions)
+	tmplFns := TemplateFunctions(&opts)
+	tmplFns["opts"] = func() Options { return opts }
+	t := template.New("oapi-codegen").Funcs(tmplFns)
 	// This parses all of our own template files into the template object
 	// above
 	t, err := templates.Parse(t)

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -45,6 +45,7 @@ type Options struct {
 	ExcludeTags        []string          // Exclude operations that have one of these tags. Ignored when empty.
 	UserTemplates      map[string]string // Override built-in templates from user-provided files
 	ImportMapping      map[string]string // ImportMapping specifies the golang package path for each external reference
+	PrimitiveMapping   map[string]string // Override the primitive type with the given type.
 	ExcludeSchemas     []string          // Exclude from generation schemas with given names. Ignored when empty.
 }
 

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -344,36 +344,36 @@ func resolveType(schema *openapi3.Schema, path []string, outSchema *Schema, opts
 	case "integer":
 		// We default to int if format doesn't ask for something else.
 		if f == "int64" {
-			outSchema.GoType = "int64"
+			outSchema.GoType = primitive(opts, "int64", "int64")
 		} else if f == "int32" {
-			outSchema.GoType = "int32"
+			outSchema.GoType = primitive(opts, "int32", "int32")
 		} else if f == "int16" {
-			outSchema.GoType = "int16"
+			outSchema.GoType = primitive(opts, "int16", "int16")
 		} else if f == "int8" {
-			outSchema.GoType = "int8"
+			outSchema.GoType = primitive(opts, "int8", "int8")
 		} else if f == "int" {
-			outSchema.GoType = "int"
+			outSchema.GoType = primitive(opts, "int", "int")
 		} else if f == "uint64" {
-			outSchema.GoType = "uint64"
+			outSchema.GoType = primitive(opts, "uint64", "uint64")
 		} else if f == "uint32" {
-			outSchema.GoType = "uint32"
+			outSchema.GoType = primitive(opts, "uint32", "uint32")
 		} else if f == "uint16" {
-			outSchema.GoType = "uint16"
+			outSchema.GoType = primitive(opts, "uint16", "uint16")
 		} else if f == "uint8" {
-			outSchema.GoType = "uint8"
+			outSchema.GoType = primitive(opts, "uint8", "uint8")
 		} else if f == "uint" {
-			outSchema.GoType = "uint"
+			outSchema.GoType = primitive(opts, "uint", "uint")
 		} else if f == "" {
-			outSchema.GoType = "int"
+			outSchema.GoType = primitive(opts, "int", "int")
 		} else {
 			return fmt.Errorf("invalid integer format: %s", f)
 		}
 	case "number":
 		// We default to float for "number"
 		if f == "double" {
-			outSchema.GoType = "float64"
+			outSchema.GoType = primitive(opts, "double", "float64")
 		} else if f == "float" || f == "" {
-			outSchema.GoType = "float32"
+			outSchema.GoType = primitive(opts, "float", "float32")
 		} else {
 			return fmt.Errorf("invalid number format: %s", f)
 		}
@@ -386,24 +386,35 @@ func resolveType(schema *openapi3.Schema, path []string, outSchema *Schema, opts
 		// Special case string formats here.
 		switch f {
 		case "byte":
-			outSchema.GoType = "[]byte"
+			outSchema.GoType = primitive(opts, "byte", "[]byte")
 		case "email":
-			outSchema.GoType = "openapi_types.Email"
+			outSchema.GoType = primitive(opts, "email", "openapi_types.Email")
 		case "date":
-			outSchema.GoType = "openapi_types.Date"
+			outSchema.GoType = primitive(opts, "date", "openapi_types.Date")
 		case "date-time":
-			outSchema.GoType = "time.Time"
+			outSchema.GoType = primitive(opts, "date-time", "time.Time")
 		case "json":
-			outSchema.GoType = "json.RawMessage"
+			outSchema.GoType = primitive(opts, "json", "json.RawMessage")
 			outSchema.SkipOptionalPointer = true
 		default:
 			// All unrecognized formats are simply a regular string.
-			outSchema.GoType = "string"
+			outSchema.GoType = primitive(opts, "string", "string")
 		}
 	default:
 		return fmt.Errorf("unhandled Schema type: %s", t)
 	}
 	return nil
+}
+
+func primitive(opts *Options, key string, defaultValue string) string {
+	if opts.PrimitiveMapping == nil {
+		return defaultValue
+	}
+	if val, ok := opts.PrimitiveMapping[key]; ok {
+		fmt.Println(opts, key, opts.PrimitiveMapping[key])
+		return val
+	}
+	return defaultValue
 }
 
 // This describes a Schema, a type definition.


### PR DESCRIPTION
## Short Description

Allow primitive types (ints, floats, string types) to be replaced with an option, `primitive-mapping`, in the YAML configuration.

## Motivation

Sometimes it is desirable to use a custom wrappers or different types entirely for the hard-coded types generated in `oapi-codegen`. 
One of such reasons is for tighter controls over JSON marshalling (e.g. check for missing fields or perform some custom validation). 

This can already be done with `x-go-type` extension tag, but it is very painful to do for e.g. every integer parameter in the whole YAML spec.

## What has changed?

This is not a breaking change, no code generation change is made if there is no configuration change.

- A lot of functions now take the `*Options` object as an additional parameter.
- A new option has been added, `primitive-mapping`, which maps the primitive type to the actual type (`int32` => `null.Int32` for example). 
- README has been updated to inform users of the new functionality.

Note that `primitive-mapping` is only available in the YAML configuration at the moment (no flags). I am not sure if it is desirable to add the flags / what is the best way to do it, so I left it out.