### PR TITLE
Fix example for net/http server generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ func SetupHandler() {
 
 ```go
 type PetStoreImpl struct {}
-func (*PetStoreImpl) GetPets(r *http.Request, w *http.ResponseWriter) {
+func (*PetStoreImpl) GetPets(w http.ResponseWriter, r *http.Request) {
     // Implement me
 }
 


### PR DESCRIPTION
Fixes the net/http server generation example to use valid function
parameters.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>