### PR TITLE
fix: client response template to ignore errors

### DIFF
--- a/pkg/codegen/templates/client-with-responses.tmpl
+++ b/pkg/codegen/templates/client-with-responses.tmpl
@@ -100,7 +100,7 @@ func (c *ClientWithResponses) {{$opid}}{{.Suffix}}WithResponse(ctx context.Conte
 // Parse{{genResponseTypeName $opid | ucFirst}} parses an HTTP response from a {{$opid}}WithResponse call
 func Parse{{genResponseTypeName $opid | ucFirst}}(rsp *http.Response) (*{{genResponseTypeName $opid}}, error) {
     bodyBytes, err := ioutil.ReadAll(rsp.Body)
-    defer rsp.Body.Close()
+    defer func() { _ = rsp.Body.Close() }()
     if err != nil {
         return nil, err
     }


### PR DESCRIPTION
ref: https://github.com/deepmap/oapi-codegen/issues/432 

Presently rsp.Body.Close masks away the error without checking for them.
This code will do the same but give linters the assumption that it alteast
considering to look at them.