### PR TITLE
Fix parse forms explode object with optional args

### DIFF
--- a/pkg/runtime/bindparam_test.go
+++ b/pkg/runtime/bindparam_test.go
@@ -447,6 +447,14 @@ func TestBindParamsToExplodedObject(t *testing.T) {
 	err = bindParamsToExplodedObject("date", values, &nTDstDate)
 	assert.EqualValues(t, expectedDate, nTDstDate)
 
+	type ObjectWithOptional struct {
+		Time *time.Time `json:"time,omitempty"`
+	}
+
+	var optDstTime ObjectWithOptional
+	err = bindParamsToExplodedObject("explodedObject", values, &optDstTime)
+	assert.NoError(t, err)
+	assert.EqualValues(t, &now, optDstTime.Time)
 }
 
 func TestBindStyledParameterWithLocation(t *testing.T) {

--- a/pkg/runtime/bindstring.go
+++ b/pkg/runtime/bindstring.go
@@ -41,6 +41,16 @@ func BindStringToObject(src string, dst interface{}) error {
 		t = v.Type()
 	}
 
+	// For some optioinal args
+	if t.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			v.Set(reflect.New(t.Elem()))
+		}
+
+		v = reflect.Indirect(v)
+		t = v.Type()
+	}
+
 	// The resulting type must be settable. reflect will catch issues like
 	// passing the destination by value.
 	if !v.CanSet() {


### PR DESCRIPTION
We use explode object query params for deduplicate some code
Example OpenAPI.yaml
```yaml
openapi: 3.0.3

info:
  title: example
  version: 1.0.0

paths:
  /users:
    get:
      parameters:
        - $ref: "#/components/parameters/QueryFilters"
      responses:
        200:
          description: ok

components:
  parameters:
    QueryFilters:
      name: queryFilters
      in: query
      style: form
      schema:
        type: object
        properties:
          limit:
            type: integer
          offset:
            type: integer
```

generated code 

```go
// QueryFilters defines model for QueryFilters.
type QueryFilters struct {
	Limit  *int `json:"limit,omitempty"`
	Offset *int `json:"offset,omitempty"`
}

// GetUsersParams defines parameters for GetUsers.
type GetUsersParams struct {
	QueryFilters *QueryFilters `json:"queryFilters,omitempty"`
}

// ServerInterfaceWrapper converts contexts to parameters.
type ServerInterfaceWrapper struct {
	Handler            ServerInterface
	HandlerMiddlewares []MiddlewareFunc
}

type MiddlewareFunc func(http.HandlerFunc) http.HandlerFunc

// GetUsers operation middleware
func (siw *ServerInterfaceWrapper) GetUsers(w http.ResponseWriter, r *http.Request) {
	ctx := r.Context()

	var err error

	// Parameter object where we will unmarshal all parameters from the context
	var params GetUsersParams

	// ------------- Optional query parameter "queryFilters" -------------
	if paramValue := r.URL.Query().Get("queryFilters"); paramValue != "" {

	}

	err = runtime.BindQueryParameter("form", true, false, "queryFilters", r.URL.Query(), &params.QueryFilters)
	if err != nil {
		http.Error(w, fmt.Sprintf("Invalid format for parameter queryFilters: %s", err), http.StatusBadRequest)
		return
	}

	var handler = func(w http.ResponseWriter, r *http.Request) {
		siw.Handler.GetUsers(w, r, params)
	}

	for _, middleware := range siw.HandlerMiddlewares {
		handler = middleware(handler)
	}

	handler(w, r.WithContext(ctx))
}
```

And use limit param result into 400 Bad Request response with body
`Invalid format for parameter queryFilters: could not bind query arg 'queryFilters' to request object: error binding string parameter: can not bind to destination of type: ptr'`

this PR fix it in easy way