### PR TITLE
gin: abort request in case middleware function called abort

### DIFF
--- a/pkg/codegen/templates/gin/gin-wrappers.tmpl
+++ b/pkg/codegen/templates/gin/gin-wrappers.tmpl
@@ -168,6 +168,9 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(c *gin.Context) {
   for _, middleware := range siw.HandlerMiddlewares {
     middleware(c)
   }
+  if c.IsAborted() {
+    return
+  }
 
   siw.Handler.{{.OperationId}}(c{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
 }

--- a/pkg/codegen/templates/templates.gen.go
+++ b/pkg/codegen/templates/templates.gen.go
@@ -1175,6 +1175,9 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(c *gin.Context) {
   for _, middleware := range siw.HandlerMiddlewares {
     middleware(c)
   }
+  if c.IsAborted() {
+    return
+  }
 
   siw.Handler.{{.OperationId}}(c{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
 }


### PR DESCRIPTION
bug fix: after invoking all middleware check if middleware wants to us abort request. Fixes #485 