### PR TITLE
Query Params struct tag should be "form" instead of "json"

### DIFF
--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -48,10 +48,10 @@ type Pet struct {
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// tags to filter by
-	Tags *[]string `json:"tags,omitempty"`
+	Tags *[]string `form:"tags,omitempty"`
 
 	// maximum number of results to return
-	Limit *int32 `json:"limit,omitempty"`
+	Limit *int32 `form:"limit,omitempty"`
 }
 
 // AddPetJSONBody defines parameters for AddPet.

--- a/examples/petstore-expanded/echo/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/echo/api/petstore-types.gen.go
@@ -33,10 +33,10 @@ type Pet struct {
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// tags to filter by
-	Tags *[]string `json:"tags,omitempty"`
+	Tags *[]string `form:"tags,omitempty"`
 
 	// maximum number of results to return
-	Limit *int32 `json:"limit,omitempty"`
+	Limit *int32 `form:"limit,omitempty"`
 }
 
 // AddPetJSONBody defines parameters for AddPet.

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -47,10 +47,10 @@ type Pet struct {
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// tags to filter by
-	Tags *[]string `json:"tags,omitempty"`
+	Tags *[]string `form:"tags,omitempty"`
 
 	// maximum number of results to return
-	Limit *int32 `json:"limit,omitempty"`
+	Limit *int32 `form:"limit,omitempty"`
 }
 
 // AddPetJSONBody defines parameters for AddPet.

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d h1:
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d/go.mod h1:tmAIfUFEirG/Y8jhZ9M+h36obRZAk/1fcSpXwAVlfqE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/getkin/kin-openapi v0.61.0 h1:6awGqF5nG5zkVpMsAih1QH4VgzS8phTxECUWIFo7zko=
-github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.80.0 h1:W/s5/DNnDCR8P+pYyafEWlGk4S7/AfQUWXgrRSSAzf8=
 github.com/getkin/kin-openapi v0.80.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -91,13 +91,13 @@ type ParamsWithAddPropsParams_P1 struct {
 // ParamsWithAddPropsParams defines parameters for ParamsWithAddProps.
 type ParamsWithAddPropsParams struct {
 	// This parameter has additional properties
-	P1 ParamsWithAddPropsParams_P1 `json:"p1"`
+	P1 ParamsWithAddPropsParams_P1 `form:"p1"`
 
 	// This parameter has an anonymous inner property which needs to be
 	// turned into a proper type for additionalProperties to work
 	P2 struct {
 		Inner ParamsWithAddPropsParams_P2_Inner `json:"inner"`
-	} `json:"p2"`
+	} `form:"p2"`
 }
 
 // ParamsWithAddPropsParams_P2_Inner defines parameters for ParamsWithAddProps.

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -91,37 +91,37 @@ type GetHeaderParams struct {
 // GetDeepObjectParams defines parameters for GetDeepObject.
 type GetDeepObjectParams struct {
 	// deep object
-	DeepObj ComplexObject `json:"deepObj"`
+	DeepObj ComplexObject `form:"deepObj"`
 }
 
 // GetQueryFormParams defines parameters for GetQueryForm.
 type GetQueryFormParams struct {
 	// exploded array
-	Ea *[]int32 `json:"ea,omitempty"`
+	Ea *[]int32 `form:"ea,omitempty"`
 
 	// array
-	A *[]int32 `json:"a,omitempty"`
+	A *[]int32 `form:"a,omitempty"`
 
 	// exploded object
-	Eo *Object `json:"eo,omitempty"`
+	Eo *Object `form:"eo,omitempty"`
 
 	// object
-	O *Object `json:"o,omitempty"`
+	O *Object `form:"o,omitempty"`
 
 	// exploded primitive
-	Ep *int32 `json:"ep,omitempty"`
+	Ep *int32 `form:"ep,omitempty"`
 
 	// primitive
-	P *int32 `json:"p,omitempty"`
+	P *int32 `form:"p,omitempty"`
 
 	// primitive string
-	Ps *string `json:"ps,omitempty"`
+	Ps *string `form:"ps,omitempty"`
 
 	// complex object
-	Co *ComplexObject `json:"co,omitempty"`
+	Co *ComplexObject `form:"co,omitempty"`
 
 	// name starting with number
-	N1s *string `json:"1s,omitempty"`
+	N1s *string `form:"1s,omitempty"`
 }
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -80,7 +80,7 @@ type Issue9JSONBody interface{}
 
 // Issue9Params defines parameters for Issue9.
 type Issue9Params struct {
-	Foo string `json:"foo"`
+	Foo string `form:"foo"`
 }
 
 // Issue185JSONRequestBody defines body for Issue185 for application/json ContentType.

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -88,10 +88,10 @@ type SimpleResponse struct {
 // GetWithArgsParams defines parameters for GetWithArgs.
 type GetWithArgsParams struct {
 	// An optional query argument
-	OptionalArgument *int64 `json:"optional_argument,omitempty"`
+	OptionalArgument *int64 `form:"optional_argument,omitempty"`
 
 	// An optional query argument
-	RequiredArgument int64 `json:"required_argument"`
+	RequiredArgument int64 `form:"required_argument"`
 
 	// An optional query argument
 	HeaderArgument *int32 `json:"header_argument,omitempty"`
@@ -109,7 +109,7 @@ type CreateResource2JSONBody Resource
 // CreateResource2Params defines parameters for CreateResource2.
 type CreateResource2Params struct {
 	// Some query argument
-	InlineQueryArgument *int `json:"inline_query_argument,omitempty"`
+	InlineQueryArgument *int `form:"inline_query_argument,omitempty"`
 }
 
 // UpdateResource3JSONBody defines parameters for UpdateResource3.

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -160,7 +160,7 @@ type GetTestByNameResponse struct {
 
 	// Check the client method signatures:
 	assert.Contains(t, code, "type GetTestByNameParams struct {")
-	assert.Contains(t, code, "Top *int `json:\"$top,omitempty\"`")
+	assert.Contains(t, code, "Top *int `form:\"$top,omitempty\"`")
 	assert.Contains(t, code, "func (c *Client) GetTestByName(ctx context.Context, name string, params *GetTestByNameParams, reqEditors ...RequestEditorFn) (*http.Response, error) {")
 	assert.Contains(t, code, "func (c *ClientWithResponses) GetTestByNameWithResponse(ctx context.Context, name string, params *GetTestByNameParams, reqEditors ...RequestEditorFn) (*GetTestByNameResponse, error) {")
 	assert.Contains(t, code, "DeadSince *time.Time    `json:\"dead_since,omitempty\" tag1:\"value1\" tag2:\"value2\"`")

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -45,9 +45,9 @@ func (pd ParameterDefinition) TypeDef() string {
 // 'json:"foo"'
 func (pd *ParameterDefinition) JsonTag() string {
 	if pd.Required {
-		return fmt.Sprintf("`form:\"%s\"`", pd.ParamName)
+		return fmt.Sprintf("`json:\"%s\"`", pd.ParamName)
 	} else {
-		return fmt.Sprintf("`form:\"%s,omitempty\"`", pd.ParamName)
+		return fmt.Sprintf("`json:\"%s,omitempty\"`", pd.ParamName)
 	}
 }
 

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -45,9 +45,9 @@ func (pd ParameterDefinition) TypeDef() string {
 // 'json:"foo"'
 func (pd *ParameterDefinition) JsonTag() string {
 	if pd.Required {
-		return fmt.Sprintf("`json:\"%s\"`", pd.ParamName)
+		return fmt.Sprintf("`form:\"%s\"`", pd.ParamName)
 	} else {
-		return fmt.Sprintf("`json:\"%s,omitempty\"`", pd.ParamName)
+		return fmt.Sprintf("`form:\"%s,omitempty\"`", pd.ParamName)
 	}
 }
 
@@ -597,12 +597,17 @@ func GenerateParamsTypes(op OperationDefinition) []TypeDefinition {
 				Schema:   param.Schema,
 			})
 		}
+		var overrideFieldHintTag string
+		if param.In == "query" {
+			overrideFieldHintTag = "form" // use "form" instead of "json" for query params tag
+		}
 		prop := Property{
-			Description:    param.Spec.Description,
-			JsonFieldName:  param.ParamName,
-			Required:       param.Required,
-			Schema:         pSchema,
-			ExtensionProps: &param.Spec.ExtensionProps,
+			Description:          param.Spec.Description,
+			JsonFieldName:        param.ParamName,
+			Required:             param.Required,
+			Schema:               pSchema,
+			OverrideFieldHintTag: overrideFieldHintTag,
+			ExtensionProps:       &param.Spec.ExtensionProps,
 		}
 		s.Properties = append(s.Properties, prop)
 	}

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -62,12 +62,13 @@ func (s Schema) GetAdditionalTypeDefs() []TypeDefinition {
 }
 
 type Property struct {
-	Description    string
-	JsonFieldName  string
-	Schema         Schema
-	Required       bool
-	Nullable       bool
-	ExtensionProps *openapi3.ExtensionProps
+	Description          string
+	JsonFieldName        string
+	Schema               Schema
+	Required             bool
+	Nullable             bool
+	OverrideFieldHintTag string
+	ExtensionProps       *openapi3.ExtensionProps
 }
 
 func (p Property) GoFieldName() string {
@@ -444,10 +445,15 @@ func GenFieldsFromProperties(props []Property) []string {
 
 		fieldTags := make(map[string]string)
 
+		fieldHintTag := "json"
+		if p.OverrideFieldHintTag != "" {
+			fieldHintTag = p.OverrideFieldHintTag
+		}
+
 		if p.Required || p.Nullable || !omitEmpty {
-			fieldTags["json"] = p.JsonFieldName
+			fieldTags[fieldHintTag] = p.JsonFieldName
 		} else {
-			fieldTags["json"] = p.JsonFieldName + ",omitempty"
+			fieldTags[fieldHintTag] = p.JsonFieldName + ",omitempty"
 		}
 		if extension, ok := p.ExtensionProps.Extensions[extPropExtraTags]; ok {
 			if tags, err := extExtraTags(extension); err == nil {


### PR DESCRIPTION
Fix for issue https://github.com/deepmap/oapi-codegen/issues/500
Query params will be generated with tag "form" instead of tag "json"