### PR TITLE
GIN Middelware: return correct http status codes based on validation

### DIFF
--- a/pkg/gin-middleware/oapi_validate_test.go
+++ b/pkg/gin-middleware/oapi_validate_test.go
@@ -252,7 +252,7 @@ func TestOapiRequestValidator(t *testing.T) {
 	// Call a protected function to which we don't have access
 	{
 		rec := doGet(t, g, "http://deepmap.ai/protected_resource2")
-		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
 		assert.False(t, called, "Handler should not have been called")
 		called = false
 	}
@@ -264,7 +264,7 @@ func TestOapiRequestValidator(t *testing.T) {
 	// Call a protected function without credentials
 	{
 		rec := doGet(t, g, "http://deepmap.ai/protected_resource_401")
-		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
 		assert.False(t, called, "Handler should not have been called")
 		called = false
 	}


### PR DESCRIPTION
Hello, 

Currently, the gin middleware always returns HTTP status `400`, even for unauthorized requests.
This PR fixes this, by returning a different status code based on the validation results.

Tests have been aligned as well.

Thanks a lot, let me know if you have further suggestions