### PR TITLE
Fix customProvider RequestEditorFn example

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ which help you to use the various OpenAPI 3 Authentication mechanism.
         // Example providing your own provider using an anonymous function wrapping in the
         // InterceptoFn adapter. The behaviour between the InterceptorFn and the Interceptor interface
         // are the same as http.HandlerFunc and http.Handler.
-        customProvider := func(req *http.Request, ctx context.Context) error {
+        customProvider := func(ctx context.Context, req *http.Request) error {
             // Just log the request header, nothing else.
             log.Println(req.Header)
             return nil


### PR DESCRIPTION
The ctx and req arguments in the example appear to be ordered incorrectly.
This commit modifies the example to list ctx first, which appears to be the
correct ordering.

I'm just learning golang so I haven't dug deeply to confirm this. Just noted
that the example wasn't working as-is in my test project, but compiles
when I invert them, and ctx documentation says it should usually come first.