### PR TITLE
fix: actual error message is swallowed

### DIFF
--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -314,7 +314,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 	} else {
 		err := resolveType(schema, path, &outSchema)
 		if err != nil {
-			return Schema{}, fmt.Errorf("error resolving primitive type")
+			return Schema{}, fmt.Errorf("error resolving primitive type: %w", err)
 		}
 	}
 	return outSchema, nil


### PR DESCRIPTION
in GenerateGoSchema(), if a type isn't resolved, the error is swallowed, making it hard to track down what the actual error is. this is likely just an oversight, it seems.