### PR TITLE
chore: update moq version due to security vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/labstack/echo/v4 v4.6.3
 	github.com/lestrrat-go/jwx v1.2.7
-	github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd
+	github.com/matryer/moq v0.2.5
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/ugorji/go v1.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmt
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq0y3QnmWAArdw9PqbmotexnWx/FU8=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd h1:HvFwW+cm9bCbZ/+vuGNq7CRWXql8c0y8nGeYpqmpvmk=
-github.com/matryer/moq v0.0.0-20190312154309-6cfb0558e1bd/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
+github.com/matryer/moq v0.2.5 h1:BGQISyhl7Gc9W/gMYmAJONh9mT6AYeyeTjNupNPknMs=
+github.com/matryer/moq v0.2.5/go.mod h1:9RtPYjTnH1bSBIkpvtHkFN7nbWAnO7oRpdJkEIn6UtE=
 github.com/mattn/go-colorable v0.1.11 h1:nQ+aFkoE2TMGc0b68U2OKSexC+eq46+XwZzWXHRmPYs=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
@@ -120,6 +120,7 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.1 h1:TVEnxayobAdVkhQfrfes2IzOB6o+z4roRkPF52WA1u4=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -134,6 +135,7 @@ golang.org/x/mod v0.4.1 h1:Kvvh58BN8Y9/lBi7hTekvtMpm07eUZ0ck5pRHpsMWrY=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -169,6 +171,7 @@ golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba h1:O8mE0/t419eoIwhTFpKVkHiT
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200815165600-90abf76919f3/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200918232735-d647fc253266/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963 h1:K+NlvTLy0oONtRtkl1jRD9xIhnItbG2PiE7YOdjPb+k=
 golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=

--- a/internal/test/server/server_moq.gen.go
+++ b/internal/test/server/server_moq.gen.go
@@ -8,65 +8,52 @@ import (
 	"sync"
 )
 
-var (
-	lockServerInterfaceMockCreateResource           sync.RWMutex
-	lockServerInterfaceMockCreateResource2          sync.RWMutex
-	lockServerInterfaceMockGetEveryTypeOptional     sync.RWMutex
-	lockServerInterfaceMockGetReservedKeyword       sync.RWMutex
-	lockServerInterfaceMockGetResponseWithReference sync.RWMutex
-	lockServerInterfaceMockGetSimple                sync.RWMutex
-	lockServerInterfaceMockGetWithArgs              sync.RWMutex
-	lockServerInterfaceMockGetWithContentType       sync.RWMutex
-	lockServerInterfaceMockGetWithReferences        sync.RWMutex
-	lockServerInterfaceMockUpdateResource3          sync.RWMutex
-)
-
 // Ensure, that ServerInterfaceMock does implement ServerInterface.
 // If this is not the case, regenerate this file with moq.
 var _ ServerInterface = &ServerInterfaceMock{}
 
 // ServerInterfaceMock is a mock implementation of ServerInterface.
 //
-//     func TestSomethingThatUsesServerInterface(t *testing.T) {
+// 	func TestSomethingThatUsesServerInterface(t *testing.T) {
 //
-//         // make and configure a mocked ServerInterface
-//         mockedServerInterface := &ServerInterfaceMock{
-//             CreateResourceFunc: func(w http.ResponseWriter, r *http.Request, argument Argument)  {
-// 	               panic("mock out the CreateResource method")
-//             },
-//             CreateResource2Func: func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params)  {
-// 	               panic("mock out the CreateResource2 method")
-//             },
-//             GetEveryTypeOptionalFunc: func(w http.ResponseWriter, r *http.Request)  {
-// 	               panic("mock out the GetEveryTypeOptional method")
-//             },
-//             GetReservedKeywordFunc: func(w http.ResponseWriter, r *http.Request)  {
-// 	               panic("mock out the GetReservedKeyword method")
-//             },
-//             GetResponseWithReferenceFunc: func(w http.ResponseWriter, r *http.Request)  {
-// 	               panic("mock out the GetResponseWithReference method")
-//             },
-//             GetSimpleFunc: func(w http.ResponseWriter, r *http.Request)  {
-// 	               panic("mock out the GetSimple method")
-//             },
-//             GetWithArgsFunc: func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams)  {
-// 	               panic("mock out the GetWithArgs method")
-//             },
-//             GetWithContentTypeFunc: func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType)  {
-// 	               panic("mock out the GetWithContentType method")
-//             },
-//             GetWithReferencesFunc: func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument)  {
-// 	               panic("mock out the GetWithReferences method")
-//             },
-//             UpdateResource3Func: func(w http.ResponseWriter, r *http.Request, pFallthrough int)  {
-// 	               panic("mock out the UpdateResource3 method")
-//             },
-//         }
+// 		// make and configure a mocked ServerInterface
+// 		mockedServerInterface := &ServerInterfaceMock{
+// 			CreateResourceFunc: func(w http.ResponseWriter, r *http.Request, argument Argument)  {
+// 				panic("mock out the CreateResource method")
+// 			},
+// 			CreateResource2Func: func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params)  {
+// 				panic("mock out the CreateResource2 method")
+// 			},
+// 			GetEveryTypeOptionalFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 				panic("mock out the GetEveryTypeOptional method")
+// 			},
+// 			GetReservedKeywordFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 				panic("mock out the GetReservedKeyword method")
+// 			},
+// 			GetResponseWithReferenceFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 				panic("mock out the GetResponseWithReference method")
+// 			},
+// 			GetSimpleFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 				panic("mock out the GetSimple method")
+// 			},
+// 			GetWithArgsFunc: func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams)  {
+// 				panic("mock out the GetWithArgs method")
+// 			},
+// 			GetWithContentTypeFunc: func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType)  {
+// 				panic("mock out the GetWithContentType method")
+// 			},
+// 			GetWithReferencesFunc: func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument Argument)  {
+// 				panic("mock out the GetWithReferences method")
+// 			},
+// 			UpdateResource3Func: func(w http.ResponseWriter, r *http.Request, pFallthrough int)  {
+// 				panic("mock out the UpdateResource3 method")
+// 			},
+// 		}
 //
-//         // use mockedServerInterface in code that requires ServerInterface
-//         // and then make assertions.
+// 		// use mockedServerInterface in code that requires ServerInterface
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type ServerInterfaceMock struct {
 	// CreateResourceFunc mocks the CreateResource method.
 	CreateResourceFunc func(w http.ResponseWriter, r *http.Request, argument Argument)
@@ -187,6 +174,16 @@ type ServerInterfaceMock struct {
 			PFallthrough int
 		}
 	}
+	lockCreateResource           sync.RWMutex
+	lockCreateResource2          sync.RWMutex
+	lockGetEveryTypeOptional     sync.RWMutex
+	lockGetReservedKeyword       sync.RWMutex
+	lockGetResponseWithReference sync.RWMutex
+	lockGetSimple                sync.RWMutex
+	lockGetWithArgs              sync.RWMutex
+	lockGetWithContentType       sync.RWMutex
+	lockGetWithReferences        sync.RWMutex
+	lockUpdateResource3          sync.RWMutex
 }
 
 // CreateResource calls CreateResourceFunc.
@@ -203,9 +200,9 @@ func (mock *ServerInterfaceMock) CreateResource(w http.ResponseWriter, r *http.R
 		R:        r,
 		Argument: argument,
 	}
-	lockServerInterfaceMockCreateResource.Lock()
+	mock.lockCreateResource.Lock()
 	mock.calls.CreateResource = append(mock.calls.CreateResource, callInfo)
-	lockServerInterfaceMockCreateResource.Unlock()
+	mock.lockCreateResource.Unlock()
 	mock.CreateResourceFunc(w, r, argument)
 }
 
@@ -222,9 +219,9 @@ func (mock *ServerInterfaceMock) CreateResourceCalls() []struct {
 		R        *http.Request
 		Argument Argument
 	}
-	lockServerInterfaceMockCreateResource.RLock()
+	mock.lockCreateResource.RLock()
 	calls = mock.calls.CreateResource
-	lockServerInterfaceMockCreateResource.RUnlock()
+	mock.lockCreateResource.RUnlock()
 	return calls
 }
 
@@ -244,9 +241,9 @@ func (mock *ServerInterfaceMock) CreateResource2(w http.ResponseWriter, r *http.
 		InlineArgument: inlineArgument,
 		Params:         params,
 	}
-	lockServerInterfaceMockCreateResource2.Lock()
+	mock.lockCreateResource2.Lock()
 	mock.calls.CreateResource2 = append(mock.calls.CreateResource2, callInfo)
-	lockServerInterfaceMockCreateResource2.Unlock()
+	mock.lockCreateResource2.Unlock()
 	mock.CreateResource2Func(w, r, inlineArgument, params)
 }
 
@@ -265,9 +262,9 @@ func (mock *ServerInterfaceMock) CreateResource2Calls() []struct {
 		InlineArgument int
 		Params         CreateResource2Params
 	}
-	lockServerInterfaceMockCreateResource2.RLock()
+	mock.lockCreateResource2.RLock()
 	calls = mock.calls.CreateResource2
-	lockServerInterfaceMockCreateResource2.RUnlock()
+	mock.lockCreateResource2.RUnlock()
 	return calls
 }
 
@@ -283,9 +280,9 @@ func (mock *ServerInterfaceMock) GetEveryTypeOptional(w http.ResponseWriter, r *
 		W: w,
 		R: r,
 	}
-	lockServerInterfaceMockGetEveryTypeOptional.Lock()
+	mock.lockGetEveryTypeOptional.Lock()
 	mock.calls.GetEveryTypeOptional = append(mock.calls.GetEveryTypeOptional, callInfo)
-	lockServerInterfaceMockGetEveryTypeOptional.Unlock()
+	mock.lockGetEveryTypeOptional.Unlock()
 	mock.GetEveryTypeOptionalFunc(w, r)
 }
 
@@ -300,9 +297,9 @@ func (mock *ServerInterfaceMock) GetEveryTypeOptionalCalls() []struct {
 		W http.ResponseWriter
 		R *http.Request
 	}
-	lockServerInterfaceMockGetEveryTypeOptional.RLock()
+	mock.lockGetEveryTypeOptional.RLock()
 	calls = mock.calls.GetEveryTypeOptional
-	lockServerInterfaceMockGetEveryTypeOptional.RUnlock()
+	mock.lockGetEveryTypeOptional.RUnlock()
 	return calls
 }
 
@@ -318,9 +315,9 @@ func (mock *ServerInterfaceMock) GetReservedKeyword(w http.ResponseWriter, r *ht
 		W: w,
 		R: r,
 	}
-	lockServerInterfaceMockGetReservedKeyword.Lock()
+	mock.lockGetReservedKeyword.Lock()
 	mock.calls.GetReservedKeyword = append(mock.calls.GetReservedKeyword, callInfo)
-	lockServerInterfaceMockGetReservedKeyword.Unlock()
+	mock.lockGetReservedKeyword.Unlock()
 	mock.GetReservedKeywordFunc(w, r)
 }
 
@@ -335,9 +332,9 @@ func (mock *ServerInterfaceMock) GetReservedKeywordCalls() []struct {
 		W http.ResponseWriter
 		R *http.Request
 	}
-	lockServerInterfaceMockGetReservedKeyword.RLock()
+	mock.lockGetReservedKeyword.RLock()
 	calls = mock.calls.GetReservedKeyword
-	lockServerInterfaceMockGetReservedKeyword.RUnlock()
+	mock.lockGetReservedKeyword.RUnlock()
 	return calls
 }
 
@@ -353,9 +350,9 @@ func (mock *ServerInterfaceMock) GetResponseWithReference(w http.ResponseWriter,
 		W: w,
 		R: r,
 	}
-	lockServerInterfaceMockGetResponseWithReference.Lock()
+	mock.lockGetResponseWithReference.Lock()
 	mock.calls.GetResponseWithReference = append(mock.calls.GetResponseWithReference, callInfo)
-	lockServerInterfaceMockGetResponseWithReference.Unlock()
+	mock.lockGetResponseWithReference.Unlock()
 	mock.GetResponseWithReferenceFunc(w, r)
 }
 
@@ -370,9 +367,9 @@ func (mock *ServerInterfaceMock) GetResponseWithReferenceCalls() []struct {
 		W http.ResponseWriter
 		R *http.Request
 	}
-	lockServerInterfaceMockGetResponseWithReference.RLock()
+	mock.lockGetResponseWithReference.RLock()
 	calls = mock.calls.GetResponseWithReference
-	lockServerInterfaceMockGetResponseWithReference.RUnlock()
+	mock.lockGetResponseWithReference.RUnlock()
 	return calls
 }
 
@@ -388,9 +385,9 @@ func (mock *ServerInterfaceMock) GetSimple(w http.ResponseWriter, r *http.Reques
 		W: w,
 		R: r,
 	}
-	lockServerInterfaceMockGetSimple.Lock()
+	mock.lockGetSimple.Lock()
 	mock.calls.GetSimple = append(mock.calls.GetSimple, callInfo)
-	lockServerInterfaceMockGetSimple.Unlock()
+	mock.lockGetSimple.Unlock()
 	mock.GetSimpleFunc(w, r)
 }
 
@@ -405,9 +402,9 @@ func (mock *ServerInterfaceMock) GetSimpleCalls() []struct {
 		W http.ResponseWriter
 		R *http.Request
 	}
-	lockServerInterfaceMockGetSimple.RLock()
+	mock.lockGetSimple.RLock()
 	calls = mock.calls.GetSimple
-	lockServerInterfaceMockGetSimple.RUnlock()
+	mock.lockGetSimple.RUnlock()
 	return calls
 }
 
@@ -425,9 +422,9 @@ func (mock *ServerInterfaceMock) GetWithArgs(w http.ResponseWriter, r *http.Requ
 		R:      r,
 		Params: params,
 	}
-	lockServerInterfaceMockGetWithArgs.Lock()
+	mock.lockGetWithArgs.Lock()
 	mock.calls.GetWithArgs = append(mock.calls.GetWithArgs, callInfo)
-	lockServerInterfaceMockGetWithArgs.Unlock()
+	mock.lockGetWithArgs.Unlock()
 	mock.GetWithArgsFunc(w, r, params)
 }
 
@@ -444,9 +441,9 @@ func (mock *ServerInterfaceMock) GetWithArgsCalls() []struct {
 		R      *http.Request
 		Params GetWithArgsParams
 	}
-	lockServerInterfaceMockGetWithArgs.RLock()
+	mock.lockGetWithArgs.RLock()
 	calls = mock.calls.GetWithArgs
-	lockServerInterfaceMockGetWithArgs.RUnlock()
+	mock.lockGetWithArgs.RUnlock()
 	return calls
 }
 
@@ -464,9 +461,9 @@ func (mock *ServerInterfaceMock) GetWithContentType(w http.ResponseWriter, r *ht
 		R:           r,
 		ContentType: contentType,
 	}
-	lockServerInterfaceMockGetWithContentType.Lock()
+	mock.lockGetWithContentType.Lock()
 	mock.calls.GetWithContentType = append(mock.calls.GetWithContentType, callInfo)
-	lockServerInterfaceMockGetWithContentType.Unlock()
+	mock.lockGetWithContentType.Unlock()
 	mock.GetWithContentTypeFunc(w, r, contentType)
 }
 
@@ -483,9 +480,9 @@ func (mock *ServerInterfaceMock) GetWithContentTypeCalls() []struct {
 		R           *http.Request
 		ContentType GetWithContentTypeParamsContentType
 	}
-	lockServerInterfaceMockGetWithContentType.RLock()
+	mock.lockGetWithContentType.RLock()
 	calls = mock.calls.GetWithContentType
-	lockServerInterfaceMockGetWithContentType.RUnlock()
+	mock.lockGetWithContentType.RUnlock()
 	return calls
 }
 
@@ -505,9 +502,9 @@ func (mock *ServerInterfaceMock) GetWithReferences(w http.ResponseWriter, r *htt
 		GlobalArgument: globalArgument,
 		Argument:       argument,
 	}
-	lockServerInterfaceMockGetWithReferences.Lock()
+	mock.lockGetWithReferences.Lock()
 	mock.calls.GetWithReferences = append(mock.calls.GetWithReferences, callInfo)
-	lockServerInterfaceMockGetWithReferences.Unlock()
+	mock.lockGetWithReferences.Unlock()
 	mock.GetWithReferencesFunc(w, r, globalArgument, argument)
 }
 
@@ -526,9 +523,9 @@ func (mock *ServerInterfaceMock) GetWithReferencesCalls() []struct {
 		GlobalArgument int64
 		Argument       Argument
 	}
-	lockServerInterfaceMockGetWithReferences.RLock()
+	mock.lockGetWithReferences.RLock()
 	calls = mock.calls.GetWithReferences
-	lockServerInterfaceMockGetWithReferences.RUnlock()
+	mock.lockGetWithReferences.RUnlock()
 	return calls
 }
 
@@ -546,9 +543,9 @@ func (mock *ServerInterfaceMock) UpdateResource3(w http.ResponseWriter, r *http.
 		R:            r,
 		PFallthrough: pFallthrough,
 	}
-	lockServerInterfaceMockUpdateResource3.Lock()
+	mock.lockUpdateResource3.Lock()
 	mock.calls.UpdateResource3 = append(mock.calls.UpdateResource3, callInfo)
-	lockServerInterfaceMockUpdateResource3.Unlock()
+	mock.lockUpdateResource3.Unlock()
 	mock.UpdateResource3Func(w, r, pFallthrough)
 }
 
@@ -565,8 +562,8 @@ func (mock *ServerInterfaceMock) UpdateResource3Calls() []struct {
 		R            *http.Request
 		PFallthrough int
 	}
-	lockServerInterfaceMockUpdateResource3.RLock()
+	mock.lockUpdateResource3.RLock()
 	calls = mock.calls.UpdateResource3
-	lockServerInterfaceMockUpdateResource3.RUnlock()
+	mock.lockUpdateResource3.RUnlock()
 	return calls
 }


### PR DESCRIPTION
This is causing issues for me with a library that has `oapi-codegen` as a dependency in a snyk security scan.

The current version of moq has a security vulnerability, this updates the version to one with the fix see here: https://github.com/matryer/moq/commit/b052143b5aa66e4da5b72ec250818f557aff2177

I've re-run the code generation and verified all the tests still pass.