### PR TITLE
Fix tyme and date as object parameter field

### DIFF
--- a/pkg/runtime/styleparam.go
+++ b/pkg/runtime/styleparam.go
@@ -348,6 +348,12 @@ func stylePrimitive(style string, explode bool, paramName string, paramLocation 
 func primitiveToString(value interface{}) (string, error) {
 	var output string
 
+	// sometimes time and date used like primitive types
+	// it can happen if paramether is object and has time or date as field
+	if res, ok := marshalDateTimeValue(value); ok {
+		return res, nil
+	}
+
 	// Values may come in by pointer for optionals, so make sure to dereferene.
 	v := reflect.Indirect(reflect.ValueOf(value))
 	t := v.Type()

--- a/pkg/runtime/styleparam_test.go
+++ b/pkg/runtime/styleparam_test.go
@@ -520,4 +520,23 @@ func TestStyleParam(t *testing.T) {
 	result, err = StyleParamWithLocation("simple", false, "id", ParamLocationQuery, object2)
 	assert.NoError(t, err)
 	assert.EqualValues(t, "firstName,Alex", result)
+
+	// Test handling of time and date inside objects
+	type testObject3 struct {
+		TimeField time.Time  `json:"time_field"`
+		DateField types.Date `json:"date_field"`
+	}
+	timeVal := time.Date(1996, time.March, 19, 0, 0, 0, 0, time.UTC)
+	dateVal := types.Date{
+		Time: timeVal,
+	}
+
+	object3 := testObject3{
+		TimeField: timeVal,
+		DateField: dateVal,
+	}
+
+	result, err = StyleParamWithLocation("simple", false, "id", ParamLocationQuery, object3)
+	assert.NoError(t, err)
+	assert.EqualValues(t, "date_field,1996-03-19,time_field,1996-03-19T00%3A00%3A00Z", result)
 }


### PR DESCRIPTION
It is possible to create a object parameter with time.Time or types.Date field. 
Now it is ended with `error formatting 'queryFilters': unsupported type *time.Time`