### PR TITLE
Improve gin support (interface, error, middlewares)

### DIFF
--- a/pkg/codegen/templates/gin/gin-register.tmpl
+++ b/pkg/codegen/templates/gin/gin-register.tmpl
@@ -1,21 +1,26 @@
 // GinServerOptions provides options for the Gin server.
 type GinServerOptions struct {
     BaseURL string
-    Middlewares []MiddlewareFunc
+    Middlewares []gin.HandlerFunc
 }
 
+// keeping for backward compatibility
+type MiddlewareFunc = gin.HandlerFunc
+
 // RegisterHandlers creates http.Handler with routing matching OpenAPI spec.
-func RegisterHandlers(router *gin.Engine, si ServerInterface) *gin.Engine {
+func RegisterHandlers(router gin.IRouter, si ServerInterface) gin.IRouter {
   return RegisterHandlersWithOptions(router, si, GinServerOptions{})
 }
 
 // RegisterHandlersWithOptions creates http.Handler with additional options
-func RegisterHandlersWithOptions(router *gin.Engine, si ServerInterface, options GinServerOptions) *gin.Engine {
+func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options GinServerOptions) gin.IRouter {
 {{if .}}wrapper := ServerInterfaceWrapper{
 Handler: si,
-HandlerMiddlewares: options.Middlewares,
 }
 {{end}}
+
+router = router.Group("/", options.Middlewares...)
+
 {{range .}}
 router.{{.Method }}(options.BaseURL+"{{.Path | swaggerUriToGinUri }}", wrapper.{{.OperationId}})
 {{end}}

--- a/pkg/codegen/templates/gin/gin-wrappers.tmpl
+++ b/pkg/codegen/templates/gin/gin-wrappers.tmpl
@@ -1,10 +1,7 @@
 // ServerInterfaceWrapper converts contexts to parameters.
 type ServerInterfaceWrapper struct {
     Handler ServerInterface
-    HandlerMiddlewares []MiddlewareFunc
 }
-
-type MiddlewareFunc func(c *gin.Context)
 
 {{range .}}{{$opid := .OperationId}}
 
@@ -164,10 +161,6 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(c *gin.Context) {
       {{- end}}
     {{end}}
   {{end}}
-
-  for _, middleware := range siw.HandlerMiddlewares {
-    middleware(c)
-  }
 
   siw.Handler.{{.OperationId}}(c{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
 }

--- a/pkg/gin-middleware/oapi_validate.go
+++ b/pkg/gin-middleware/oapi_validate.go
@@ -72,6 +72,8 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) gin.
 		err := ValidateRequestFromContext(c, router, options)
 		if err != nil {
 			// note: i am not sure if this is the best way to handle this
+			// todo: the error message should be customizable by the user
+			c.Error(err)
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		}
 		c.Next()
@@ -124,6 +126,9 @@ func ValidateRequestFromContext(c *gin.Context, router routers.Router, options *
 			errorLines := strings.Split(e.Error(), "\n")
 			return fmt.Errorf("error in openapi3filter.RequestError: %s", errorLines[0])
 		case *openapi3filter.SecurityRequirementsError:
+			for _, e := range e.Errors {
+				c.Error(e)
+			}
 			return fmt.Errorf("error in openapi3filter.SecurityRequirementsError: %s", e.Error())
 		default:
 			// This should never happen today, but if our upstream code changes,


### PR DESCRIPTION
1. Use gin.IRouter interface instead of *gin.Engine
    this will allow us to support nested router mounting using engine/routergroup/other routers
    fixes https://github.com/deepmap/oapi-codegen/issues/507 
2. switch custom middleware code to gin middleware
    the custom middleware code doesn't support context abort or c.Next() in normal gin middleware, this also fixes https://github.com/deepmap/oapi-codegen/pull/494  https://github.com/deepmap/oapi-codegen/issues/485
3. add errors from validation middleware to gin context
    huge fix for debugging authentication func. before this change the nested e.Errors[] is completely hidden not surfaced anywhere.
