### PR TITLE
fmt.Println -> fmt.Print

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -163,7 +163,7 @@ func main() {
 			errExit("error writing generated code to file: %s", err)
 		}
 	} else {
-		fmt.Println(code)
+		fmt.Print(code)
 	}
 }
 


### PR DESCRIPTION
- fix #470 
- the generated code already ends with a newline, `fmt.Println` appends a second erroneous newline 