### PR TITLE
Fix: Unsigned values as parameters

### DIFF
--- a/pkg/runtime/styleparam.go
+++ b/pkg/runtime/styleparam.go
@@ -356,6 +356,8 @@ func primitiveToString(value interface{}) (string, error) {
 	switch kind {
 	case reflect.Int8, reflect.Int32, reflect.Int64, reflect.Int:
 		output = strconv.FormatInt(v.Int(), 10)
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
+		output = strconv.FormatUint(v.Uint(), 10)
 	case reflect.Float64:
 		output = strconv.FormatFloat(v.Float(), 'f', -1, 64)
 	case reflect.Float32:

--- a/pkg/runtime/styleparam.go
+++ b/pkg/runtime/styleparam.go
@@ -354,7 +354,7 @@ func primitiveToString(value interface{}) (string, error) {
 	kind := t.Kind()
 
 	switch kind {
-	case reflect.Int8, reflect.Int32, reflect.Int64, reflect.Int:
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
 		output = strconv.FormatInt(v.Int(), 10)
 	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
 		output = strconv.FormatUint(v.Uint(), 10)

--- a/pkg/runtime/styleparam_test.go
+++ b/pkg/runtime/styleparam_test.go
@@ -490,6 +490,31 @@ func TestStyleParam(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, "7", result)
 
+	type UintType uint
+	result, err = StyleParamWithLocation("simple", false, "foo", ParamLocationQuery, UintType(9))
+	assert.NoError(t, err)
+	assert.EqualValues(t, "9", result)
+
+	type Uint8Type uint8
+	result, err = StyleParamWithLocation("simple", false, "foo", ParamLocationQuery, Uint8Type(9))
+	assert.NoError(t, err)
+	assert.EqualValues(t, "9", result)
+
+	type Uint16Type uint16
+	result, err = StyleParamWithLocation("simple", false, "foo", ParamLocationQuery, Uint16Type(9))
+	assert.NoError(t, err)
+	assert.EqualValues(t, "9", result)
+
+	type Uint32Type uint32
+	result, err = StyleParamWithLocation("simple", false, "foo", ParamLocationQuery, Uint32Type(9))
+	assert.NoError(t, err)
+	assert.EqualValues(t, "9", result)
+
+	type Uint64Type uint64
+	result, err = StyleParamWithLocation("simple", false, "foo", ParamLocationQuery, Uint64Type(9))
+	assert.NoError(t, err)
+	assert.EqualValues(t, "9", result)
+
 	type FloatType64 float64
 	result, err = StyleParamWithLocation("simple", false, "foo", ParamLocationQuery, FloatType64(7.5))
 	assert.NoError(t, err)


### PR DESCRIPTION
Server and client generated code correctly support uint types, but using uint in client code causes a runtime error. This adds the full complement of int and uint types to the parameter parser.

Thanks to @AABY2022 for the suggested fix.

Fixes #521 