### PR TITLE
POC for flattening allOf

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -368,10 +368,6 @@ func GenerateConstants(t *template.Template, ops []OperationDefinition) (string,
 // dereference schemas from another part of the tree.
 var Schemas = make(map[string]*openapi3.SchemaRef)
 
-// Even worse for now, we need to have a list of additional schemas to go
-// create to avoid anonymous structs
-var AdditionalSchemas = make(map[string]*openapi3.SchemaRef)
-
 // Generates type definitions for any custom types defined in the
 // components/schemas section of the Swagger spec.
 func GenerateTypesForSchemas(t *template.Template, schemas map[string]*openapi3.SchemaRef, excludeSchemas []string) ([]TypeDefinition, error) {
@@ -404,13 +400,6 @@ func GenerateTypesForSchemas(t *template.Template, schemas map[string]*openapi3.
 		if _, ok := excludeSchemasMap[schemaName]; ok {
 			continue
 		}
-		err := schemaLoop(schemaName)
-		if err != nil {
-			return nil, err
-		}
-	}
-	// Now go back and add any added schemas
-	for _, schemaName := range SortedSchemaKeys(AdditionalSchemas) {
 		err := schemaLoop(schemaName)
 		if err != nil {
 			return nil, err

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -363,6 +363,11 @@ func GenerateConstants(t *template.Template, ops []OperationDefinition) (string,
 	return GenerateTemplates([]string{"constants.tmpl"}, t, constants)
 }
 
+// Not the best, but let's do it this way for now.
+// Define a package variable that holds the Schemas to allow us to
+// dereference schemas from another part of the tree.
+var Schemas = make(map[string]*openapi3.SchemaRef)
+
 // Generates type definitions for any custom types defined in the
 // components/schemas section of the Swagger spec.
 func GenerateTypesForSchemas(t *template.Template, schemas map[string]*openapi3.SchemaRef, excludeSchemas []string) ([]TypeDefinition, error) {
@@ -370,6 +375,8 @@ func GenerateTypesForSchemas(t *template.Template, schemas map[string]*openapi3.
 	for _, schema := range excludeSchemas {
 		excludeSchemasMap[schema] = true
 	}
+	// Set the package variable to reference the local variable
+	Schemas = schemas
 	types := make([]TypeDefinition, 0)
 	// We're going to define Go types for every object under components/schemas
 	for _, schemaName := range SortedSchemaKeys(schemas) {

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -401,7 +401,6 @@ func OperationDefinitions(swagger *openapi3.T) ([]OperationDefinition, error) {
 					return nil, fmt.Errorf("error generating default OperationID for %s/%s: %s",
 						opName, requestPath, err)
 				}
-				op.OperationID = op.OperationID
 			} else {
 				op.OperationID = ToCamelCase(op.OperationID)
 			}

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -576,16 +576,11 @@ func GenStructFromAllOf(allOf []*openapi3.SchemaRef, path []string) (string, err
 	if refCount == 1 && propCount == 0 {
 		// We have just one reference and no properties
 		// so flatten it and just use the referenced struct.
-		goType, err := RefPathToGoType(savedRef)
-		if err != nil {
-			return "", err
-		}
-		return goType, nil
+		return RefPathToGoType(savedRef)
 	}
 
 	// Start out with struct {
 	objectParts := []string{"struct {"}
-
 	for _, schemaOrRef := range allOf {
 		ref := schemaOrRef.Ref
 		if IsGoTypeReference(ref) {

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -574,7 +574,8 @@ func GenStructFromAllOf(allOf []*openapi3.SchemaRef, path []string) (string, err
 		}
 	}
 	if refCount == 1 && propCount == 0 {
-		// We have just one reference - flatten it and just use the referenced struct
+		// We have just one reference and no properties
+		// so flatten it and just use the referenced struct.
 		goType, err := RefPathToGoType(savedRef)
 		if err != nil {
 			return "", err
@@ -593,7 +594,7 @@ func GenStructFromAllOf(allOf []*openapi3.SchemaRef, path []string) (string, err
 				return "", err
 			}
 			if true {
-				// We have a referenced type, we will flatten
+				// We have a referenced type, we will add a new struct to be included later
 				rSchema, err := GetReferencedSchema(goType)
 				if err != nil {
 					return "", err

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -594,7 +594,7 @@ func GenStructFromAllOf(allOf []*openapi3.SchemaRef, path []string) (string, err
 				return "", err
 			}
 			if true {
-				// We have a referenced type, we will add a new struct to be included later
+				// We have a referenced type; use it
 				rSchema, err := GetReferencedSchema(goType)
 				if err != nil {
 					return "", err

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -149,9 +149,7 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 			// JSON:
 			case StringInArray(contentTypeName, contentTypesJSON):
 				if typeDefinition.ContentTypeName == contentTypeName {
-					var caseAction string
-
-					caseAction = fmt.Sprintf("var dest %s\n"+
+					caseAction := fmt.Sprintf("var dest %s\n"+
 						"if err := json.Unmarshal(bodyBytes, &dest); err != nil { \n"+
 						" return nil, err \n"+
 						"}\n"+
@@ -166,8 +164,7 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 			// YAML:
 			case StringInArray(contentTypeName, contentTypesYAML):
 				if typeDefinition.ContentTypeName == contentTypeName {
-					var caseAction string
-					caseAction = fmt.Sprintf("var dest %s\n"+
+					caseAction := fmt.Sprintf("var dest %s\n"+
 						"if err := yaml.Unmarshal(bodyBytes, &dest); err != nil { \n"+
 						" return nil, err \n"+
 						"}\n"+
@@ -181,8 +178,7 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 			// XML:
 			case StringInArray(contentTypeName, contentTypesXML):
 				if typeDefinition.ContentTypeName == contentTypeName {
-					var caseAction string
-					caseAction = fmt.Sprintf("var dest %s\n"+
+					caseAction := fmt.Sprintf("var dest %s\n"+
 						"if err := xml.Unmarshal(bodyBytes, &dest); err != nil { \n"+
 						" return nil, err \n"+
 						"}\n"+


### PR DESCRIPTION
Based on a need I have, and it seems others have too (#531, #502)
I thought I'd see what the appetite is for a change that looks something like this being accepted back upstream. What it does now is it flattens any allOf structs, either by referencing the struct directly if there is only one ref and no extra props, or by flattening and pulling in the fields directly into the current struct.

Still to do:
- [ ] Add mechanism to switch flattening on/off - possibly by specifying a spec extension? `x-oapi-codegen-flatten-allof: true` perhaps? 
- [ ] Add tests

Looking for suggestions and thoughts on whether this could be accepted upstream - thanks in advance.