### PR TITLE
Integrated go-playground/validator annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,3 +639,38 @@ on-the-fly at run time. Example:
         -templates my-templates/ \
         -generate types,client \
         petstore-expanded.yaml
+
+## Validator-Integration
+The [go-playground/validator](https://github.com/go-playground/validator) has been integrated so we can generate fitting annotations based on the OpenAPI-Definition.
+The following constraints from the OpenAPI are supported:
+
+| Type | Constraint | Validator-Annotation | Comment|
+|---|---|---|---|
+|integer|minimum|gt/gte| gt or gte depending on if ExclusiveMinimum is set|
+|integer|maximum|lt/lte| lt or lte depending on if ExclusiveMaximum is set|
+|number|minimum|gt/gte| gt or gte depending on if ExclusiveMinimum is set|
+|number|maximum|lt/lte| lt or lte depending on if ExclusiveMaximum is set|
+|string|email|email| |
+|string|uuid|uuid| |
+|string|uri|uri| |
+|string|hostname|hostname| |
+|string|ipv4|ipv4| |
+|string|ipv6|ipv6| |
+|string|minLength|min| |
+|string|maxLength|max| |
+|string|pattern|pattern| Some special characters need to be encoded: Quote (") = 0x22, Comma (,) = 0x2c, Backtick(`) = 0x60 |
+
+In order to support the pattern-constraint a custom validator needs to be registered like so:
+```
+import (
+    "github.com/go-playground/validator/v10"
+    pv "github.com/deepmap/oapi-codegen/pkg/validator"
+)
+
+// get a preconfigured validator
+v1 := pv.NewWithPatternValidator()
+
+// add the pattern validator to your own instance manually
+v := validator.New()
+_ = v.RegisterValidation("pattern", pv.PatternValidator)
+```

--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -35,17 +35,18 @@ func errExit(format string, args ...interface{}) {
 }
 
 var (
-	flagPackageName    string
-	flagGenerate       string
-	flagOutputFile     string
-	flagIncludeTags    string
-	flagExcludeTags    string
-	flagTemplatesDir   string
-	flagImportMapping  string
-	flagExcludeSchemas string
-	flagConfigFile     string
-	flagAliasTypes     bool
-	flagPrintVersion   bool
+	flagPackageName       string
+	flagGenerate          string
+	flagOutputFile        string
+	flagIncludeTags       string
+	flagExcludeTags       string
+	flagTemplatesDir      string
+	flagImportMapping     string
+	flagExcludeSchemas    string
+	flagConfigFile        string
+	flagAliasTypes        bool
+	flagPrintVersion      bool
+	flagIncludeValidation bool
 )
 
 type configuration struct {
@@ -73,6 +74,7 @@ func main() {
 	flag.StringVar(&flagConfigFile, "config", "", "a YAML config file that controls oapi-codegen behavior")
 	flag.BoolVar(&flagAliasTypes, "alias-types", false, "Alias type declarations of possible")
 	flag.BoolVar(&flagPrintVersion, "version", false, "when specified, print version and exit")
+	flag.BoolVar(&flagIncludeValidation, "include-validation", false, "when specified, include validation code")
 	flag.Parse()
 
 	if flagPrintVersion {
@@ -134,6 +136,7 @@ func main() {
 	opts.IncludeTags = cfg.IncludeTags
 	opts.ExcludeTags = cfg.ExcludeTags
 	opts.ExcludeSchemas = cfg.ExcludeSchemas
+	opts.IncludeValidation = flagIncludeValidation
 
 	if opts.GenerateEchoServer && opts.GenerateChiServer {
 		errExit("can not specify both server and chi-server targets simultaneously")

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -49,6 +49,7 @@ type Options struct {
 	UserTemplates      map[string]string // Override built-in templates from user-provided files
 	ImportMapping      map[string]string // ImportMapping specifies the golang package path for each external reference
 	ExcludeSchemas     []string          // Exclude from generation schemas with given names. Ignored when empty.
+	IncludeValidation  bool              // Whether to include validation code
 }
 
 // goImport represents a go package to be imported in the generated code
@@ -136,14 +137,14 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 		}
 	}
 
-	ops, err := OperationDefinitions(swagger)
+	ops, err := OperationDefinitions(swagger, opts.IncludeValidation)
 	if err != nil {
 		return "", fmt.Errorf("error creating operation definitions: %w", err)
 	}
 
 	var typeDefinitions, constantDefinitions string
 	if opts.GenerateTypes {
-		typeDefinitions, err = GenerateTypeDefinitions(t, swagger, ops, opts.ExcludeSchemas)
+		typeDefinitions, err = GenerateTypeDefinitions(t, swagger, ops, opts.ExcludeSchemas, opts.IncludeValidation)
 		if err != nil {
 			return "", fmt.Errorf("error generating type definitions: %w", err)
 		}
@@ -289,25 +290,25 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 	return string(outBytes), nil
 }
 
-func GenerateTypeDefinitions(t *template.Template, swagger *openapi3.T, ops []OperationDefinition, excludeSchemas []string) (string, error) {
-	schemaTypes, err := GenerateTypesForSchemas(t, swagger.Components.Schemas, excludeSchemas)
+func GenerateTypeDefinitions(t *template.Template, swagger *openapi3.T, ops []OperationDefinition, excludeSchemas []string, includeValidation bool) (string, error) {
+	schemaTypes, err := GenerateTypesForSchemas(t, swagger.Components.Schemas, excludeSchemas, includeValidation)
 	if err != nil {
 		return "", fmt.Errorf("error generating Go types for component schemas: %w", err)
 	}
 
-	paramTypes, err := GenerateTypesForParameters(t, swagger.Components.Parameters)
+	paramTypes, err := GenerateTypesForParameters(t, swagger.Components.Parameters, includeValidation)
 	if err != nil {
 		return "", fmt.Errorf("error generating Go types for component parameters: %w", err)
 	}
 	allTypes := append(schemaTypes, paramTypes...)
 
-	responseTypes, err := GenerateTypesForResponses(t, swagger.Components.Responses)
+	responseTypes, err := GenerateTypesForResponses(t, swagger.Components.Responses, includeValidation)
 	if err != nil {
 		return "", fmt.Errorf("error generating Go types for component responses: %w", err)
 	}
 	allTypes = append(allTypes, responseTypes...)
 
-	bodyTypes, err := GenerateTypesForRequestBodies(t, swagger.Components.RequestBodies)
+	bodyTypes, err := GenerateTypesForRequestBodies(t, swagger.Components.RequestBodies, includeValidation)
 	if err != nil {
 		return "", fmt.Errorf("error generating Go types for component request bodies: %w", err)
 	}
@@ -365,7 +366,7 @@ func GenerateConstants(t *template.Template, ops []OperationDefinition) (string,
 
 // Generates type definitions for any custom types defined in the
 // components/schemas section of the Swagger spec.
-func GenerateTypesForSchemas(t *template.Template, schemas map[string]*openapi3.SchemaRef, excludeSchemas []string) ([]TypeDefinition, error) {
+func GenerateTypesForSchemas(t *template.Template, schemas map[string]*openapi3.SchemaRef, excludeSchemas []string, includeValidation bool) ([]TypeDefinition, error) {
 	var excludeSchemasMap = make(map[string]bool)
 	for _, schema := range excludeSchemas {
 		excludeSchemasMap[schema] = true
@@ -378,7 +379,7 @@ func GenerateTypesForSchemas(t *template.Template, schemas map[string]*openapi3.
 		}
 		schemaRef := schemas[schemaName]
 
-		goSchema, err := GenerateGoSchema(schemaRef, []string{schemaName})
+		goSchema, err := GenerateGoSchema(schemaRef, []string{schemaName}, includeValidation)
 		if err != nil {
 			return nil, fmt.Errorf("error converting Schema %s to Go type: %w", schemaName, err)
 		}
@@ -396,12 +397,12 @@ func GenerateTypesForSchemas(t *template.Template, schemas map[string]*openapi3.
 
 // Generates type definitions for any custom types defined in the
 // components/parameters section of the Swagger spec.
-func GenerateTypesForParameters(t *template.Template, params map[string]*openapi3.ParameterRef) ([]TypeDefinition, error) {
+func GenerateTypesForParameters(t *template.Template, params map[string]*openapi3.ParameterRef, includeValidation bool) ([]TypeDefinition, error) {
 	var types []TypeDefinition
 	for _, paramName := range SortedParameterKeys(params) {
 		paramOrRef := params[paramName]
 
-		goType, err := paramToGoType(paramOrRef.Value, nil)
+		goType, err := paramToGoType(paramOrRef.Value, nil, includeValidation)
 		if err != nil {
 			return nil, fmt.Errorf("error generating Go type for schema in parameter %s: %w", paramName, err)
 		}
@@ -428,7 +429,7 @@ func GenerateTypesForParameters(t *template.Template, params map[string]*openapi
 
 // Generates type definitions for any custom types defined in the
 // components/responses section of the Swagger spec.
-func GenerateTypesForResponses(t *template.Template, responses openapi3.Responses) ([]TypeDefinition, error) {
+func GenerateTypesForResponses(t *template.Template, responses openapi3.Responses, includeValidation bool) ([]TypeDefinition, error) {
 	var types []TypeDefinition
 
 	for _, responseName := range SortedResponsesKeys(responses) {
@@ -440,7 +441,7 @@ func GenerateTypesForResponses(t *template.Template, responses openapi3.Response
 		response := responseOrRef.Value
 		jsonResponse, found := response.Content["application/json"]
 		if found {
-			goType, err := GenerateGoSchema(jsonResponse.Schema, []string{responseName})
+			goType, err := GenerateGoSchema(jsonResponse.Schema, []string{responseName}, includeValidation)
 			if err != nil {
 				return nil, fmt.Errorf("error generating Go type for schema in response %s: %w", responseName, err)
 			}
@@ -467,7 +468,7 @@ func GenerateTypesForResponses(t *template.Template, responses openapi3.Response
 
 // Generates type definitions for any custom types defined in the
 // components/requestBodies section of the Swagger spec.
-func GenerateTypesForRequestBodies(t *template.Template, bodies map[string]*openapi3.RequestBodyRef) ([]TypeDefinition, error) {
+func GenerateTypesForRequestBodies(t *template.Template, bodies map[string]*openapi3.RequestBodyRef, includeValidation bool) ([]TypeDefinition, error) {
 	var types []TypeDefinition
 
 	for _, bodyName := range SortedRequestBodyKeys(bodies) {
@@ -478,7 +479,7 @@ func GenerateTypesForRequestBodies(t *template.Template, bodies map[string]*open
 		response := bodyOrRef.Value
 		jsonBody, found := response.Content["application/json"]
 		if found {
-			goType, err := GenerateGoSchema(jsonBody.Schema, []string{bodyName})
+			goType, err := GenerateGoSchema(jsonBody.Schema, []string{bodyName}, includeValidation)
 			if err != nil {
 				return nil, fmt.Errorf("error generating Go type for schema in body %s: %w", bodyName, err)
 			}

--- a/pkg/codegen/prune.go
+++ b/pkg/codegen/prune.go
@@ -394,7 +394,7 @@ func findComponentRefs(swagger *openapi3.T) []string {
 func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 	countRemoved := 0
 
-	for key, _ := range swagger.Components.Schemas {
+	for key := range swagger.Components.Schemas {
 		ref := fmt.Sprintf("#/components/schemas/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++
@@ -402,7 +402,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 		}
 	}
 
-	for key, _ := range swagger.Components.Parameters {
+	for key := range swagger.Components.Parameters {
 		ref := fmt.Sprintf("#/components/parameters/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++
@@ -421,7 +421,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 	// 	}
 	// }
 
-	for key, _ := range swagger.Components.RequestBodies {
+	for key := range swagger.Components.RequestBodies {
 		ref := fmt.Sprintf("#/components/requestBodies/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++
@@ -429,7 +429,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 		}
 	}
 
-	for key, _ := range swagger.Components.Responses {
+	for key := range swagger.Components.Responses {
 		ref := fmt.Sprintf("#/components/responses/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++
@@ -437,7 +437,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 		}
 	}
 
-	for key, _ := range swagger.Components.Headers {
+	for key := range swagger.Components.Headers {
 		ref := fmt.Sprintf("#/components/headers/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++
@@ -445,7 +445,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 		}
 	}
 
-	for key, _ := range swagger.Components.Examples {
+	for key := range swagger.Components.Examples {
 		ref := fmt.Sprintf("#/components/examples/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++
@@ -453,7 +453,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 		}
 	}
 
-	for key, _ := range swagger.Components.Links {
+	for key := range swagger.Components.Links {
 		ref := fmt.Sprintf("#/components/links/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++
@@ -461,7 +461,7 @@ func removeOrphanedComponents(swagger *openapi3.T, refs []string) int {
 		}
 	}
 
-	for key, _ := range swagger.Components.Callbacks {
+	for key := range swagger.Components.Callbacks {
 		ref := fmt.Sprintf("#/components/callbacks/%s", key)
 		if !stringInSlice(ref, refs) {
 			countRemoved++

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -94,12 +94,12 @@ func genResponsePayload(operationID string) string {
 }
 
 // genResponseUnmarshal generates unmarshaling steps for structured response payloads
-func genResponseUnmarshal(op *OperationDefinition) string {
+func genResponseUnmarshal(op *OperationDefinition, includeValidation bool) string {
 	var handledCaseClauses = make(map[string]string)
 	var unhandledCaseClauses = make(map[string]string)
 
 	// Get the type definitions from the operation:
-	typeDefinitions, err := op.GetResponseTypeDefinitions()
+	typeDefinitions, err := op.GetResponseTypeDefinitions(includeValidation)
 	if err != nil {
 		panic(err)
 	}
@@ -237,8 +237,8 @@ func genResponseTypeName(operationID string) string {
 	return fmt.Sprintf("%s%s", UppercaseFirstCharacter(operationID), responseTypeSuffix)
 }
 
-func getResponseTypeDefinitions(op *OperationDefinition) []ResponseTypeDefinition {
-	td, err := op.GetResponseTypeDefinitions()
+func getResponseTypeDefinitions(op *OperationDefinition, includeValidation bool) []ResponseTypeDefinition {
+	td, err := op.GetResponseTypeDefinitions(includeValidation)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -1,0 +1,25 @@
+package validator
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+func NewWithPatternValidator() *validator.Validate {
+	v := validator.New()
+	_ = v.RegisterValidation("pattern", PatternValidator)
+	return v
+}
+
+func PatternValidator(fl validator.FieldLevel) bool {
+	p := fl.Param()
+	// decode the 3 characters that would have broken the annotation-syntax
+	p = strings.ReplaceAll(p, "0x22", "\"")
+	p = strings.ReplaceAll(p, "0x2c", ",")
+	p = strings.ReplaceAll(p, "0x60", "`")
+
+	reg := regexp.MustCompile(p)
+	return reg.MatchString(fl.Field().String())
+}


### PR DESCRIPTION
Added a validator integration that can be used by passing the `-include-validation` flag that will create go-playground/validator compatible annotations for your structs