### PR TITLE
Fix possible empty values in ReadBuildInfo()

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -121,7 +121,6 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 	// This parses all of our own template files into the template object
 	// above
 	err := LoadTemplates(templates, t)
-
 	if err != nil {
 		return "", fmt.Errorf("error parsing oapi-codegen templates: %w", err)
 	}
@@ -225,7 +224,6 @@ func Generate(swagger *openapi3.T, packageName string, opts Options) (string, er
 	_, err = w.WriteString(typeDefinitions)
 	if err != nil {
 		return "", fmt.Errorf("error writing type definitions: %w", err)
-
 	}
 
 	if opts.GenerateClient {
@@ -366,7 +364,7 @@ func GenerateConstants(t *template.Template, ops []OperationDefinition) (string,
 // Generates type definitions for any custom types defined in the
 // components/schemas section of the Swagger spec.
 func GenerateTypesForSchemas(t *template.Template, schemas map[string]*openapi3.SchemaRef, excludeSchemas []string) ([]TypeDefinition, error) {
-	var excludeSchemasMap = make(map[string]bool)
+	excludeSchemasMap := make(map[string]bool)
 	for _, schema := range excludeSchemas {
 		excludeSchemasMap[schema] = true
 	}
@@ -556,22 +554,23 @@ func GenerateEnums(t *template.Template, types []TypeDefinition) (string, error)
 	}
 
 	return GenerateTemplates([]string{"constants.tmpl"}, t, c)
-
 }
 
 // Generate our import statements and package definition.
 func GenerateImports(t *template.Template, externalImports []string, packageName string) (string, error) {
 	// Read build version for incorporating into generated files
-	var modulePath string
-	var moduleVersion string
+	// Unit tests have ok=false, so we'll just use "unknown" for the
+	// version if we can't read this.
+
+	modulePath := "unknown module path"
+	moduleVersion := "unknown version"
 	if bi, ok := debug.ReadBuildInfo(); ok {
-		modulePath = bi.Main.Path
-		moduleVersion = bi.Main.Version
-	} else {
-		// Unit tests have ok=false, so we'll just use "unknown" for the
-		// version if we can't read this.
-		modulePath = "unknown module path"
-		moduleVersion = "unknown version"
+		if bi.Main.Path != "" {
+			modulePath = bi.Main.Path
+		}
+		if bi.Main.Version != "" {
+			moduleVersion = bi.Main.Version
+		}
 	}
 
 	context := struct {
@@ -615,7 +614,6 @@ func GenerateAdditionalPropertyBoilerplate(t *template.Template, typeDefs []Type
 	}
 
 	return GenerateTemplates([]string{"additional-properties.tmpl"}, t, context)
-
 }
 
 // SanitizeCode runs sanitizers across the generated Go code to ensure the


### PR DESCRIPTION
Hi! Go 1.18 have a possible bug, https://github.com/golang/go/issues/51915  when `debug.ReadBuildInfo()` could return true, and empty values for Path and Version fields.