### PR TITLE
Fix reference to undefined variable in gin codegen

### DIFF
--- a/pkg/codegen/templates/gin/gin-wrappers.tmpl
+++ b/pkg/codegen/templates/gin/gin-wrappers.tmpl
@@ -77,7 +77,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(c *gin.Context) {
   {{end}}
 
     {{if .HeaderParams}}
-      headers := r.Header
+      headers := c.Request.Header
 
       {{range .HeaderParams}}// ------------- {{if .Required}}Required{{else}}Optional{{end}} header parameter "{{.ParamName}}" -------------
         if valueList, found := headers[http.CanonicalHeaderKey("{{.ParamName}}")]; found {


### PR DESCRIPTION
We tried using the gin server generation on our project, but it seems to be referring to an undefined variable `r`.