### PR TITLE
Add ErrorHandler for middleware

### DIFF
--- a/pkg/chi-middleware/oapi_validate_test.go
+++ b/pkg/chi-middleware/oapi_validate_test.go
@@ -134,6 +134,9 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 	// Set up an authenticator to check authenticated function. It will allow
 	// access to "someScope", but disallow others.
 	options := Options{
+		ErrorHandler: func(w http.ResponseWriter, message string, statusCode int) {
+			http.Error(w, "test: "+message, statusCode)
+		},
 		Options: openapi3filter.Options{
 			AuthenticationFunc: func(c context.Context, input *openapi3filter.AuthenticationInput) error {
 
@@ -188,6 +191,7 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 	{
 		rec := doGet(t, r, "http://deepmap.ai/protected_resource_401")
 		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Equal(t, "test: Security requirements failed\n", rec.Body.String())
 		assert.False(t, called, "Handler should not have been called")
 		called = false
 	}

--- a/pkg/gin-middleware/oapi_validate_test.go
+++ b/pkg/gin-middleware/oapi_validate_test.go
@@ -136,6 +136,9 @@ func TestOapiRequestValidator(t *testing.T) {
 	// Set up an authenticator to check authenticated function. It will allow
 	// access to "someScope", but disallow others.
 	options := Options{
+		ErrorHandler: func(c *gin.Context, message string, statusCode int) {
+			c.String(statusCode, "test: "+message)
+		},
 		Options: openapi3filter.Options{
 			AuthenticationFunc: func(c context.Context, input *openapi3filter.AuthenticationInput) error {
 				// The gin context should be propagated into here.
@@ -265,6 +268,7 @@ func TestOapiRequestValidator(t *testing.T) {
 	{
 		rec := doGet(t, g, "http://deepmap.ai/protected_resource_401")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "test: error in openapi3filter.SecurityRequirementsError: Security requirements failed", rec.Body.String())
 		assert.False(t, called, "Handler should not have been called")
 		called = false
 	}

--- a/pkg/middleware/oapi_validate.go
+++ b/pkg/middleware/oapi_validate.go
@@ -29,8 +29,10 @@ import (
 	echomiddleware "github.com/labstack/echo/v4/middleware"
 )
 
-const EchoContextKey = "oapi-codegen/echo-context"
-const UserDataKey = "oapi-codegen/user-data"
+const (
+	EchoContextKey = "oapi-codegen/echo-context"
+	UserDataKey    = "oapi-codegen/user-data"
+)
 
 // This is an Echo middleware function which validates incoming HTTP requests
 // to make sure that they conform to the given OAPI 3.0 specification. When
@@ -56,9 +58,13 @@ func OapiRequestValidator(swagger *openapi3.T) echo.MiddlewareFunc {
 	return OapiRequestValidatorWithOptions(swagger, nil)
 }
 
+// ErrorHandler is called when there is an error in validation
+type ErrorHandler func(c echo.Context, err *echo.HTTPError) error
+
 // Options to customize request validation. These are passed through to
 // openapi3filter.
 type Options struct {
+	ErrorHandler ErrorHandler
 	Options      openapi3filter.Options
 	ParamDecoder openapi3filter.ContentParameterDecoder
 	UserData     interface{}
@@ -81,6 +87,9 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) echo
 
 			err := ValidateRequestFromContext(c, router, options)
 			if err != nil {
+				if options != nil && options.ErrorHandler != nil {
+					return options.ErrorHandler(c, err)
+				}
 				return err
 			}
 			return next(c)
@@ -90,7 +99,7 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) echo
 
 // ValidateRequestFromContext is called from the middleware above and actually does the work
 // of validating a request.
-func ValidateRequestFromContext(ctx echo.Context, router routers.Router, options *Options) error {
+func ValidateRequestFromContext(ctx echo.Context, router routers.Router, options *Options) *echo.HTTPError {
 	req := ctx.Request()
 	route, pathParams, err := router.FindRoute(req)
 

--- a/pkg/middleware/oapi_validate_test.go
+++ b/pkg/middleware/oapi_validate_test.go
@@ -137,6 +137,9 @@ func TestOapiRequestValidator(t *testing.T) {
 	// Set up an authenticator to check authenticated function. It will allow
 	// access to "someScope", but disallow others.
 	options := Options{
+		ErrorHandler: func(c echo.Context, err *echo.HTTPError) error {
+			return c.String(err.Code, "test: "+err.Error())
+		},
 		Options: openapi3filter.Options{
 			AuthenticationFunc: func(c context.Context, input *openapi3filter.AuthenticationInput) error {
 				// The echo context should be propagated into here.
@@ -268,6 +271,7 @@ func TestOapiRequestValidator(t *testing.T) {
 	{
 		rec := doGet(t, e, "http://deepmap.ai/protected_resource_401")
 		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Equal(t, "test: code=401, message=Unauthorized", rec.Body.String())
 		assert.False(t, called, "Handler should not have been called")
 		called = false
 	}


### PR DESCRIPTION
This adds roughly the same custom error handling logic across all three openapi validation middleware. For the particular API that I'm working with I want to standardize error messages across all API endpoints and responses originating from middleware. Since the current middleware make opinionated decisions around how errors coming from the validation middleware are sent, the thought is just to add an `ErrorHandler` option (similar to `ErrorHandlerFunc` in the generated server code) that allows you to do some custom error formatting.