### PR TITLE
Add gin to imports template

### DIFF
--- a/pkg/codegen/templates/imports.tmpl
+++ b/pkg/codegen/templates/imports.tmpl
@@ -26,6 +26,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-chi/chi/v5"
 	"github.com/labstack/echo/v4"
+	"github.com/gin-gonic/gin"
 	{{- range .ExternalImports}}
 	{{ . }}
 	{{- end}}


### PR DESCRIPTION
Gin should be imported by default (as other frameworks) and removed only if need by the `go fmt` step.