### PR TITLE
Make UUID an alias of uuid.UUID

### DIFF
--- a/pkg/types/uuid.go
+++ b/pkg/types/uuid.go
@@ -1,27 +1,7 @@
 package types
 
 import (
-	"encoding/json"
-	"errors"
-
 	"github.com/google/uuid"
 )
 
-type UUID uuid.UUID
-
-func (u UUID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(uuid.UUID(u).String())
-}
-
-func (u *UUID) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-	parsed, err := uuid.Parse(s)
-	if err != nil {
-		return errors.New("uuid: failed to pass validation")
-	}
-	*u = UUID(parsed)
-	return nil
-}
+type UUID = uuid.UUID

--- a/pkg/types/uuid_test.go
+++ b/pkg/types/uuid_test.go
@@ -25,7 +25,7 @@ func TestUUID_MarshalJSON_Pass(t *testing.T) {
 	b := struct {
 		UUIDField UUID `json:"uuid"`
 	}{
-		UUIDField: UUID(testUUID),
+		UUIDField: testUUID,
 	}
 	jsonBytes, err := json.Marshal(b)
 	assert.NoError(t, err)
@@ -42,7 +42,7 @@ func TestUUID_UnmarshalJSON_Fail(t *testing.T) {
 }
 
 func TestUUID_UnmarshalJSON_Pass(t *testing.T) {
-	testUUID := UUID(uuid.MustParse("9cb14230-b640-11ec-b909-0242ac120002"))
+	testUUID := uuid.MustParse("9cb14230-b640-11ec-b909-0242ac120002")
 	jsonStr := `{"uuid":"9cb14230-b640-11ec-b909-0242ac120002"}`
 	b := struct {
 		UUIDField UUID `json:"uuid"`


### PR DESCRIPTION
Instead of wrapping Google's `uuid.UUID`, and reimplementing the
JSON logic, simply make it an alias instead.

The current version already leaks the implementation detail, so I
don't see any reason to also wrap it, and make its usage harder.

Continuation of #546 and #556.