### PR TITLE
Use lower-cased `x-go-name` for parameters var name

### DIFF
--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -119,7 +119,13 @@ func (pd ParameterDefinition) GoVariableName() string {
 }
 
 func (pd ParameterDefinition) GoName() string {
-	return SchemaNameToTypeName(pd.Schema.GoType)
+	goName := pd.ParamName
+	if _, ok := pd.Spec.ExtensionProps.Extensions[extGoFieldName]; ok {
+		if extGoFieldName, err := extParseGoFieldName(pd.Spec.ExtensionProps.Extensions[extGoFieldName]); err == nil {
+			goName = extGoFieldName
+		}
+	}
+	return SchemaNameToTypeName(goName)
 }
 
 func (pd ParameterDefinition) IndirectOptional() bool {

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -119,7 +119,7 @@ func (pd ParameterDefinition) GoVariableName() string {
 }
 
 func (pd ParameterDefinition) GoName() string {
-	return SchemaNameToTypeName(pd.ParamName)
+	return SchemaNameToTypeName(pd.Schema.GoType)
 }
 
 func (pd ParameterDefinition) IndirectOptional() bool {


### PR DESCRIPTION
Small change to how variable names are generated (a follow up to a [comment](https://github.com/deepmap/oapi-codegen/pull/517#issuecomment-1118934346) on my previous MR and extension to it).
```yaml
components:
  parameters:
    PetID:
      name: pet_id
      x-go-name: PetID
      in: path
      schema:
        type: string
      required: true
```
Before:
```go
func (c *ClientWithResponses) UpdatePetWithResponse(ctx context.Context, petId PetID,  ...)
```
Now:
```go
func (c *ClientWithResponses) UpdatePetWithResponse(ctx context.Context, petID PetID,  ...)
```