### PR TITLE
Allow custom JSON media types to be marked as `IsJson`

### DIFF
--- a/internal/test/client/client.yaml
+++ b/internal/test/client/client.yaml
@@ -80,6 +80,15 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SchemaObject'
+  /with_vendor_json:
+    post:
+      operationId: PostVendorJson
+      requestBody:
+        required: true
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
 components:
   schemas:
     SchemaObject:

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -23,6 +23,7 @@ import (
 	"text/template"
 	"unicode"
 
+	"github.com/deepmap/oapi-codegen/pkg/util"
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
@@ -56,8 +57,11 @@ func (pd *ParameterDefinition) JsonTag() string {
 func (pd *ParameterDefinition) IsJson() bool {
 	p := pd.Spec
 	if len(p.Content) == 1 {
-		_, found := p.Content["application/json"]
-		return found
+		for k := range p.Content {
+			if util.IsMediaTypeJson(k) {
+				return true
+			}
+		}
 	}
 	return false
 }
@@ -621,7 +625,7 @@ func GenerateBodyDefinitions(operationID string, bodyOrRef *openapi3.RequestBody
 		var defaultBody bool
 
 		switch {
-		case contentType == "application/json":
+		case util.IsMediaTypeJson(contentType):
 			tag = "JSON"
 			defaultBody = true
 		case strings.HasPrefix(contentType, "multipart/"):
@@ -710,7 +714,7 @@ func GenerateResponseDefinitions(operationID string, responses openapi3.Response
 			content := response.Content[contentType]
 			var tag string
 			switch {
-			case contentType == "application/json":
+			case util.IsMediaTypeJson(contentType):
 				tag = "JSON"
 			case contentType == "application/x-www-form-urlencoded":
 				tag = "Formdata"

--- a/pkg/codegen/operations_test.go
+++ b/pkg/codegen/operations_test.go
@@ -16,7 +16,74 @@ package codegen
 import (
 	"net/http"
 	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
+
+func TestIsJson(t *testing.T) {
+	type test struct {
+		name       string
+		mediaTypes []string
+		want       bool
+	}
+
+	suite := []test{
+		{
+			name:       "When no MediaType, returns false",
+			mediaTypes: []string{},
+			want:       false,
+		},
+		{
+			name:       "When not a JSON MediaType, returns false",
+			mediaTypes: []string{"application/pdf"},
+			want:       false,
+		},
+		{
+			name:       "When more than one MediaTypes, returns false",
+			mediaTypes: []string{"application/pdf", "application/json"},
+			want:       false,
+		},
+		{
+			name:       "When MediaType ends with json, but isn't JSON, returns false",
+			mediaTypes: []string{"application/notjson"},
+			want:       false,
+		},
+		{
+			name:       "When MediaType is application/json, returns true",
+			mediaTypes: []string{"application/json"},
+			want:       true,
+		},
+		{
+			name:       "When MediaType is application/json-patch+json, returns true",
+			mediaTypes: []string{"application/json-patch+json"},
+			want:       true,
+		},
+		{
+			name:       "When MediaType is application/vnd.api+json, returns true",
+			mediaTypes: []string{"application/vnd.api+json"},
+			want:       true,
+		},
+	}
+	for _, test := range suite {
+		t.Run(test.name, func(t *testing.T) {
+			pd := ParameterDefinition{
+				Spec: &openapi3.Parameter{
+					Content: make(map[string]*openapi3.MediaType),
+				},
+			}
+			for _, mediaType := range test.mediaTypes {
+				pd.Spec.Content[mediaType] = nil
+			}
+
+			got := pd.IsJson()
+
+			if got != test.want {
+				t.Fatalf("IsJson validation failed. Want [%v] Got [%v]", test.want, got)
+			}
+
+		})
+	}
+}
 
 func TestGenerateDefaultOperationID(t *testing.T) {
 	type test struct {

--- a/pkg/util/isjson.go
+++ b/pkg/util/isjson.go
@@ -1,0 +1,7 @@
+package util
+
+import "strings"
+
+func IsMediaTypeJson(mediaType string) bool {
+	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+}

--- a/pkg/util/isjson_test.go
+++ b/pkg/util/isjson_test.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestIsMediaTypeJson(t *testing.T) {
+	type test struct {
+		name      string
+		mediaType string
+		want      bool
+	}
+
+	suite := []test{
+		{
+			name: "When no MediaType, returns false",
+			want: false,
+		},
+		{
+			name:      "When not a JSON MediaType, returns false",
+			mediaType: "application/pdf",
+			want:      false,
+		},
+		{
+			name:      "When MediaType ends with json, but isn't JSON, returns false",
+			mediaType: "application/notjson",
+			want:      false,
+		},
+		{
+			name:      "When MediaType is application/json, returns true",
+			mediaType: "application/json",
+			want:      true,
+		},
+		{
+			name:      "When MediaType is application/json-patch+json, returns true",
+			mediaType: "application/json-patch+json",
+			want:      true,
+		},
+		{
+			name:      "When MediaType is application/vnd.api+json, returns true",
+			mediaType: "application/vnd.api+json",
+			want:      true,
+		},
+	}
+	for _, test := range suite {
+		t.Run(test.name, func(t *testing.T) {
+			got := IsMediaTypeJson(test.mediaType)
+
+			if got != test.want {
+				t.Fatalf("IsJson validation failed. Want [%v] Got [%v]", test.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As noted in #581, we won't currently support custom media types using
the suffixes, such as custom or vendor media types.

This also adds coverage for the OpenAPI spec's requirement for only a
single MediaType to be defined.

Closes #581.
