### PR TITLE
docs: replace go get with go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ write a lot of boilerplate code to perform all the marshalling and unmarshalling
 into objects which match the OpenAPI 3.0 definition. The code generator in this
 directory does a lot of that for you. You would run it like so:
 
-    go get github.com/deepmap/oapi-codegen/cmd/oapi-codegen
-    oapi-codegen petstore-expanded.yaml  > petstore.gen.go
+    go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@latest
+    oapi-codegen petstore-expanded.yaml > petstore.gen.go
 
 Let's go through that `petstore.gen.go` file to show you everything which was
 generated.


### PR DESCRIPTION
As of Go 1.18, `go get` will no longer install packages/binaries. We therefore should update the docs to use `go install` with version suffix syntax.

See https://go.dev/doc/go-get-install-deprecation