### PR TITLE
Correct reference to flag for backwards compatible configuration

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -258,7 +258,7 @@ func updateConfigFromFlags(cfg configuration) (configuration, error) {
 
 	if len(unsupportedFlags) > 0 {
 		return configuration{}, fmt.Errorf("flags %s aren't supported in "+
-			"new config style, please use --old-style-config or update your configuration",
+			"new config style, please use -old-config-style or update your configuration",
 			strings.Join(unsupportedFlags, ", "))
 	}
 


### PR DESCRIPTION
As raised in #591, the flag we're reporting as available for backwards
compatibility does not exist.
