### PR TITLE
Generate type names in GoDoc comments

### DIFF
--- a/examples/authenticated-api/echo/api/api.gen.go
+++ b/examples/authenticated-api/echo/api/api.gen.go
@@ -27,10 +27,10 @@ const (
 
 // Error defines model for Error.
 type Error struct {
-	// Error code
+	// Code Error code
 	Code int32 `json:"code"`
 
-	// Error message
+	// Message Error message
 	Message string `json:"message"`
 }
 

--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -20,40 +20,40 @@ import (
 
 // Error defines model for Error.
 type Error struct {
-	// Error code
+	// Code Error code
 	Code int32 `json:"code"`
 
-	// Error message
+	// Message Error message
 	Message string `json:"message"`
 }
 
 // NewPet defines model for NewPet.
 type NewPet struct {
-	// Name of the pet
+	// Name Name of the pet
 	Name string `json:"name"`
 
-	// Type of the pet
+	// Tag Type of the pet
 	Tag *string `json:"tag,omitempty"`
 }
 
 // Pet defines model for Pet.
 type Pet struct {
-	// Unique id of the pet
+	// Id Unique id of the pet
 	Id int64 `json:"id"`
 
-	// Name of the pet
+	// Name Name of the pet
 	Name string `json:"name"`
 
-	// Type of the pet
+	// Tag Type of the pet
 	Tag *string `json:"tag,omitempty"`
 }
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
-	// tags to filter by
+	// Tags tags to filter by
 	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty"`
 
-	// maximum number of results to return
+	// Limit maximum number of results to return
 	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
 }
 

--- a/examples/petstore-expanded/echo/api/models/models.gen.go
+++ b/examples/petstore-expanded/echo/api/models/models.gen.go
@@ -5,40 +5,40 @@ package models
 
 // Error defines model for Error.
 type Error struct {
-	// Error code
+	// Code Error code
 	Code int32 `json:"code"`
 
-	// Error message
+	// Message Error message
 	Message string `json:"message"`
 }
 
 // NewPet defines model for NewPet.
 type NewPet struct {
-	// Name of the pet
+	// Name Name of the pet
 	Name string `json:"name"`
 
-	// Type of the pet
+	// Tag Type of the pet
 	Tag *string `json:"tag,omitempty"`
 }
 
 // Pet defines model for Pet.
 type Pet struct {
-	// Unique id of the pet
+	// Id Unique id of the pet
 	Id int64 `json:"id"`
 
-	// Name of the pet
+	// Name Name of the pet
 	Name string `json:"name"`
 
-	// Type of the pet
+	// Tag Type of the pet
 	Tag *string `json:"tag,omitempty"`
 }
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
-	// tags to filter by
+	// Tags tags to filter by
 	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty"`
 
-	// maximum number of results to return
+	// Limit maximum number of results to return
 	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
 }
 

--- a/examples/petstore-expanded/gin/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/gin/api/petstore-types.gen.go
@@ -5,40 +5,40 @@ package api
 
 // Error defines model for Error.
 type Error struct {
-	// Error code
+	// Code Error code
 	Code int32 `json:"code"`
 
-	// Error message
+	// Message Error message
 	Message string `json:"message"`
 }
 
 // NewPet defines model for NewPet.
 type NewPet struct {
-	// Name of the pet
+	// Name Name of the pet
 	Name string `json:"name"`
 
-	// Type of the pet
+	// Tag Type of the pet
 	Tag *string `json:"tag,omitempty"`
 }
 
 // Pet defines model for Pet.
 type Pet struct {
-	// Unique id of the pet
+	// Id Unique id of the pet
 	Id int64 `json:"id"`
 
-	// Name of the pet
+	// Name Name of the pet
 	Name string `json:"name"`
 
-	// Type of the pet
+	// Tag Type of the pet
 	Tag *string `json:"tag,omitempty"`
 }
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
-	// tags to filter by
+	// Tags tags to filter by
 	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty"`
 
-	// maximum number of results to return
+	// Limit maximum number of results to return
 	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
 }
 

--- a/examples/petstore-expanded/gorilla/api/petstore.gen.go
+++ b/examples/petstore-expanded/gorilla/api/petstore.gen.go
@@ -20,40 +20,40 @@ import (
 
 // Error defines model for Error.
 type Error struct {
-	// Error code
+	// Code Error code
 	Code int32 `json:"code"`
 
-	// Error message
+	// Message Error message
 	Message string `json:"message"`
 }
 
 // NewPet defines model for NewPet.
 type NewPet struct {
-	// Name of the pet
+	// Name Name of the pet
 	Name string `json:"name"`
 
-	// Type of the pet
+	// Tag Type of the pet
 	Tag *string `json:"tag,omitempty"`
 }
 
 // Pet defines model for Pet.
 type Pet struct {
-	// Unique id of the pet
+	// Id Unique id of the pet
 	Id int64 `json:"id"`
 
-	// Name of the pet
+	// Name Name of the pet
 	Name string `json:"name"`
 
-	// Type of the pet
+	// Tag Type of the pet
 	Tag *string `json:"tag,omitempty"`
 }
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
-	// tags to filter by
+	// Tags tags to filter by
 	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty"`
 
-	// maximum number of results to return
+	// Limit maximum number of results to return
 	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
 }
 

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -19,40 +19,40 @@ import (
 
 // Error defines model for Error.
 type Error struct {
-	// Error code
+	// Code Error code
 	Code int32 `json:"code"`
 
-	// Error message
+	// Message Error message
 	Message string `json:"message"`
 }
 
 // NewPet defines model for NewPet.
 type NewPet struct {
-	// Name of the pet
+	// Name Name of the pet
 	Name string `json:"name"`
 
-	// Type of the pet
+	// Tag Type of the pet
 	Tag *string `json:"tag,omitempty"`
 }
 
 // Pet defines model for Pet.
 type Pet struct {
-	// Unique id of the pet
+	// Id Unique id of the pet
 	Id int64 `json:"id"`
 
-	// Name of the pet
+	// Name Name of the pet
 	Name string `json:"name"`
 
-	// Type of the pet
+	// Tag Type of the pet
 	Tag *string `json:"tag,omitempty"`
 }
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
-	// tags to filter by
+	// Tags tags to filter by
 	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty"`
 
-	// maximum number of results to return
+	// Limit maximum number of results to return
 	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
 }
 

--- a/examples/petstore-expanded/strict/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/strict/api/petstore-types.gen.go
@@ -5,40 +5,40 @@ package api
 
 // Error defines model for Error.
 type Error struct {
-	// Error code
+	// Code Error code
 	Code int32 `json:"code"`
 
-	// Error message
+	// Message Error message
 	Message string `json:"message"`
 }
 
 // NewPet defines model for NewPet.
 type NewPet struct {
-	// Name of the pet
+	// Name Name of the pet
 	Name string `json:"name"`
 
-	// Type of the pet
+	// Tag Type of the pet
 	Tag *string `json:"tag,omitempty"`
 }
 
 // Pet defines model for Pet.
 type Pet struct {
-	// Unique id of the pet
+	// Id Unique id of the pet
 	Id int64 `json:"id"`
 
-	// Name of the pet
+	// Name Name of the pet
 	Name string `json:"name"`
 
-	// Type of the pet
+	// Tag Type of the pet
 	Tag *string `json:"tag,omitempty"`
 }
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
-	// tags to filter by
+	// Tags tags to filter by
 	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty"`
 
-	// maximum number of results to return
+	// Limit maximum number of results to return
 	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
 }
 

--- a/internal/test/all_of/v1/openapi.gen.go
+++ b/internal/test/all_of/v1/openapi.gen.go
@@ -22,7 +22,7 @@ type Person struct {
 	// Embedded fields due to inline allOf schema
 }
 
-// These are fields that specify a person. They are all optional, and
+// PersonProperties These are fields that specify a person. They are all optional, and
 // would be used by an `Edit` style API endpoint, where each is optional.
 type PersonProperties struct {
 	FirstName          *string `json:"FirstName,omitempty"`

--- a/internal/test/all_of/v2/openapi.gen.go
+++ b/internal/test/all_of/v2/openapi.gen.go
@@ -22,7 +22,7 @@ type Person struct {
 	LastName           string `json:"LastName"`
 }
 
-// These are fields that specify a person. They are all optional, and
+// PersonProperties These are fields that specify a person. They are all optional, and
 // would be used by an `Edit` style API endpoint, where each is optional.
 type PersonProperties struct {
 	FirstName          *string `json:"FirstName,omitempty"`

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -89,7 +89,7 @@ const (
 	Eve   EnumParam3 = "eve"
 )
 
-// Has additional properties of type int
+// AdditionalPropertiesObject1 Has additional properties of type int
 type AdditionalPropertiesObject1 struct {
 	Id                   int            `json:"id"`
 	Name                 string         `json:"name"`
@@ -97,19 +97,19 @@ type AdditionalPropertiesObject1 struct {
 	AdditionalProperties map[string]int `json:"-"`
 }
 
-// Does not allow additional properties
+// AdditionalPropertiesObject2 Does not allow additional properties
 type AdditionalPropertiesObject2 struct {
 	Id   int    `json:"id"`
 	Name string `json:"name"`
 }
 
-// Allows any additional property
+// AdditionalPropertiesObject3 Allows any additional property
 type AdditionalPropertiesObject3 struct {
 	Name                 string                 `json:"name"`
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
-// Has anonymous field which has additional properties
+// AdditionalPropertiesObject4 Has anonymous field which has additional properties
 type AdditionalPropertiesObject4 struct {
 	Inner                AdditionalPropertiesObject4_Inner `json:"inner"`
 	Name                 string                            `json:"name"`
@@ -122,33 +122,33 @@ type AdditionalPropertiesObject4_Inner struct {
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
-// Has additional properties with schema for dictionaries
+// AdditionalPropertiesObject5 Has additional properties with schema for dictionaries
 type AdditionalPropertiesObject5 map[string]SchemaObject
 
-// Array of object with additional properties
+// AdditionalPropertiesObject6 Array of object with additional properties
 type AdditionalPropertiesObject6 = []map[string]SchemaObject
 
-// simple anyOf case
+// AnyOfObject1 simple anyOf case
 type AnyOfObject1 struct {
 	union json.RawMessage
 }
 
-// Conflicts with Enum2, enum values need to be prefixed with type
+// Enum1 Conflicts with Enum2, enum values need to be prefixed with type
 // name.
 type Enum1 string
 
-// Conflicts with Enum1, enum values need to be prefixed with type
+// Enum2 Conflicts with Enum1, enum values need to be prefixed with type
 // name.
 type Enum2 string
 
-// Enum values conflict with Enums above, need to be prefixed
+// Enum3 Enum values conflict with Enums above, need to be prefixed
 // with type name.
 type Enum3 string
 
-// No conflicts here, should have unmodified enums
+// Enum4 No conflicts here, should have unmodified enums
 type Enum4 string
 
-// Numerical enum
+// Enum5 Numerical enum
 type Enum5 int
 
 // EnumUnion defines model for EnumUnion.
@@ -157,7 +157,7 @@ type EnumUnion string
 // EnumUnion2 defines model for EnumUnion2.
 type EnumUnion2 string
 
-// Edge cases for enum names
+// FunnyValues Edge cases for enum names
 type FunnyValues string
 
 // ObjectWithJsonField defines model for ObjectWithJsonField.
@@ -167,12 +167,12 @@ type ObjectWithJsonField struct {
 	Value2 json.RawMessage `json:"value2,omitempty"`
 }
 
-// oneOf with references and no disciminator
+// OneOfObject1 oneOf with references and no disciminator
 type OneOfObject1 struct {
 	union json.RawMessage
 }
 
-// fixed properties, variable required - will compile, but not much sense
+// OneOfObject10 fixed properties, variable required - will compile, but not much sense
 type OneOfObject10 struct {
 	One   *string `json:"one,omitempty"`
 	Three *bool   `json:"three,omitempty"`
@@ -186,7 +186,7 @@ type OneOfObject100 = interface{}
 // OneOfObject101 defines model for .
 type OneOfObject101 = interface{}
 
-// additional properties of oneOf
+// OneOfObject11 additional properties of oneOf
 type OneOfObject11 map[string]OneOfObject11_AdditionalProperties
 
 // OneOfObject110 defines model for .
@@ -214,7 +214,7 @@ type OneOfObject120 = string
 // OneOfObject121 defines model for .
 type OneOfObject121 = float32
 
-// oneOf with inline elements
+// OneOfObject2 oneOf with inline elements
 type OneOfObject2 struct {
 	union json.RawMessage
 }
@@ -230,7 +230,7 @@ type OneOfObject21 = []float32
 // OneOfObject22 defines model for .
 type OneOfObject22 = bool
 
-// inline OneOf
+// OneOfObject3 inline OneOf
 type OneOfObject3 struct {
 	Union *OneOfObject3_Union `json:"union,omitempty"`
 }
@@ -240,23 +240,23 @@ type OneOfObject3_Union struct {
 	union json.RawMessage
 }
 
-// oneOf plus fixed type - custom marshaling/unmarshaling
+// OneOfObject4 oneOf plus fixed type - custom marshaling/unmarshaling
 type OneOfObject4 struct {
 	FixedProperty *string `json:"fixedProperty,omitempty"`
 	union         json.RawMessage
 }
 
-// oneOf with disciminator but no mapping
+// OneOfObject5 oneOf with disciminator but no mapping
 type OneOfObject5 struct {
 	union json.RawMessage
 }
 
-// oneOf with discriminator and mapping
+// OneOfObject6 oneOf with discriminator and mapping
 type OneOfObject6 struct {
 	union json.RawMessage
 }
 
-// array of oneOf
+// OneOfObject7 array of oneOf
 type OneOfObject7 = []OneOfObject7_Item
 
 // OneOfObject7_Item defines model for OneOfObject7.Item.
@@ -264,13 +264,13 @@ type OneOfObject7_Item struct {
 	union json.RawMessage
 }
 
-// oneOf with fixed properties
+// OneOfObject8 oneOf with fixed properties
 type OneOfObject8 struct {
 	Fixed *string `json:"fixed,omitempty"`
 	union json.RawMessage
 }
 
-// oneOf with fixed descriminator
+// OneOfObject9 oneOf with fixed descriminator
 type OneOfObject9 struct {
 	Type  string `json:"type"`
 	union json.RawMessage
@@ -304,13 +304,13 @@ type OneOfVariant6 struct {
 	Values OneOfVariant2 `json:"values"`
 }
 
-// When a Schema is renamed, $ref should refer to the new name
+// ReferenceToRenameMe When a Schema is renamed, $ref should refer to the new name
 type ReferenceToRenameMe struct {
-	// This schema should be renamed via x-go-name when generating
+	// ToNewName This schema should be renamed via x-go-name when generating
 	NewName NewName `json:"ToNewName"`
 }
 
-// This schema should be renamed via x-go-name when generating
+// NewName This schema should be renamed via x-go-name when generating
 type NewName struct {
 	Prop1 string `json:"prop1"`
 	Prop2 string `json:"prop2"`
@@ -320,7 +320,7 @@ type NewName struct {
 type SchemaObject struct {
 	FirstName string `json:"firstName"`
 
-	// This property is required and readOnly, so the go model should have it as a pointer,
+	// ReadOnlyRequiredProp This property is required and readOnly, so the go model should have it as a pointer,
 	// as it will not be included when it is sent from client to server.
 	ReadOnlyRequiredProp  *string `json:"readOnlyRequiredProp,omitempty"`
 	Role                  string  `json:"role"`
@@ -336,7 +336,7 @@ type EnumParam2 string
 // EnumParam3 defines model for EnumParam3.
 type EnumParam3 string
 
-// a parameter
+// RenamedParameterObject // a parameter
 type RenamedParameterObject string
 
 // RenamedResponseObject defines model for ResponseObject.
@@ -359,10 +359,10 @@ type EnsureEverythingIsReferencedTextBody = string
 
 // ParamsWithAddPropsParams defines parameters for ParamsWithAddProps.
 type ParamsWithAddPropsParams struct {
-	// This parameter has additional properties
+	// P1 This parameter has additional properties
 	P1 map[string]interface{} `json:"p1"`
 
-	// This parameter has an anonymous inner property which needs to be
+	// P2 This parameter has an anonymous inner property which needs to be
 	// turned into a proper type for additionalProperties to work
 	P2 struct {
 		Inner map[string]string `json:"inner"`

--- a/internal/test/issues/issue-312/issue.gen.go
+++ b/internal/test/issues/issue-312/issue.gen.go
@@ -24,22 +24,22 @@ import (
 
 // Error defines model for Error.
 type Error struct {
-	// Error code
+	// Code Error code
 	Code int32 `json:"code"`
 
-	// Error message
+	// Message Error message
 	Message string `json:"message"`
 }
 
 // Pet defines model for Pet.
 type Pet struct {
-	// The name of the pet.
+	// Name The name of the pet.
 	Name string `json:"name"`
 }
 
 // PetNames defines model for PetNames.
 type PetNames struct {
-	// The names of the pets.
+	// Names The names of the pets.
 	Names []string `json:"names"`
 }
 

--- a/internal/test/issues/issue-grab_import_names/issue.gen.go
+++ b/internal/test/issues/issue-grab_import_names/issue.gen.go
@@ -23,10 +23,10 @@ import (
 
 // GetFooParams defines parameters for GetFoo.
 type GetFooParams struct {
-	// base64. bytes. chi. context. echo. errors. fmt. gzip. http. io. ioutil. json. openapi3.
+	// Foo base64. bytes. chi. context. echo. errors. fmt. gzip. http. io. ioutil. json. openapi3.
 	Foo *string `json:"Foo,omitempty"`
 
-	// openapi_types. path. runtime. strings. time.Duration time.Time url. xml. yaml.
+	// Bar openapi_types. path. runtime. strings. time.Duration time.Time url. xml. yaml.
 	Bar *string `json:"Bar,omitempty"`
 }
 

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -42,34 +42,34 @@ type Object struct {
 
 // GetCookieParams defines parameters for GetCookie.
 type GetCookieParams struct {
-	// primitive
+	// P primitive
 	P *int32 `form:"p,omitempty" json:"p,omitempty"`
 
-	// primitive
+	// Ep primitive
 	Ep *int32 `form:"ep,omitempty" json:"ep,omitempty"`
 
-	// exploded array
+	// Ea exploded array
 	Ea *[]int32 `form:"ea,omitempty" json:"ea,omitempty"`
 
-	// array
+	// A array
 	A *[]int32 `form:"a,omitempty" json:"a,omitempty"`
 
-	// exploded object
+	// Eo exploded object
 	Eo *Object `form:"eo,omitempty" json:"eo,omitempty"`
 
-	// object
+	// O object
 	O *Object `form:"o,omitempty" json:"o,omitempty"`
 
-	// complex object
+	// Co complex object
 	Co *ComplexObject `form:"co,omitempty" json:"co,omitempty"`
 
-	// name starting with number
+	// N1s name starting with number
 	N1s *string `form:"1s,omitempty" json:"1s,omitempty"`
 }
 
 // EnumParamsParams defines parameters for EnumParams.
 type EnumParamsParams struct {
-	// Parameter with enum values
+	// EnumPathParam Parameter with enum values
 	EnumPathParam *EnumParamsParamsEnumPathParam `form:"enumPathParam,omitempty" json:"enumPathParam,omitempty"`
 }
 
@@ -78,64 +78,64 @@ type EnumParamsParamsEnumPathParam int32
 
 // GetHeaderParams defines parameters for GetHeader.
 type GetHeaderParams struct {
-	// primitive
+	// XPrimitive primitive
 	XPrimitive *int32 `json:"X-Primitive,omitempty"`
 
-	// primitive
+	// XPrimitiveExploded primitive
 	XPrimitiveExploded *int32 `json:"X-Primitive-Exploded,omitempty"`
 
-	// exploded array
+	// XArrayExploded exploded array
 	XArrayExploded *[]int32 `json:"X-Array-Exploded,omitempty"`
 
-	// array
+	// XArray array
 	XArray *[]int32 `json:"X-Array,omitempty"`
 
-	// exploded object
+	// XObjectExploded exploded object
 	XObjectExploded *Object `json:"X-Object-Exploded,omitempty"`
 
-	// object
+	// XObject object
 	XObject *Object `json:"X-Object,omitempty"`
 
-	// complex object
+	// XComplexObject complex object
 	XComplexObject *ComplexObject `json:"X-Complex-Object,omitempty"`
 
-	// name starting with number
+	// N1StartingWithNumber name starting with number
 	N1StartingWithNumber *string `json:"1-Starting-With-Number,omitempty"`
 }
 
 // GetDeepObjectParams defines parameters for GetDeepObject.
 type GetDeepObjectParams struct {
-	// deep object
+	// DeepObj deep object
 	DeepObj ComplexObject `json:"deepObj"`
 }
 
 // GetQueryFormParams defines parameters for GetQueryForm.
 type GetQueryFormParams struct {
-	// exploded array
+	// Ea exploded array
 	Ea *[]int32 `form:"ea,omitempty" json:"ea,omitempty"`
 
-	// array
+	// A array
 	A *[]int32 `form:"a,omitempty" json:"a,omitempty"`
 
-	// exploded object
+	// Eo exploded object
 	Eo *Object `form:"eo,omitempty" json:"eo,omitempty"`
 
-	// object
+	// O object
 	O *Object `form:"o,omitempty" json:"o,omitempty"`
 
-	// exploded primitive
+	// Ep exploded primitive
 	Ep *int32 `form:"ep,omitempty" json:"ep,omitempty"`
 
-	// primitive
+	// P primitive
 	P *int32 `form:"p,omitempty" json:"p,omitempty"`
 
-	// primitive string
+	// Ps primitive string
 	Ps *string `form:"ps,omitempty" json:"ps,omitempty"`
 
-	// complex object
+	// Co complex object
 	Co *ComplexObject `form:"co,omitempty" json:"co,omitempty"`
 
-	// name starting with number
+	// N1s name starting with number
 	N1s *string `form:"1s,omitempty" json:"1s,omitempty"`
 }
 

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -35,13 +35,13 @@ const (
 	Second EnumInObjInArrayVal = "second"
 )
 
-// This schema name starts with a number
+// N5StartsWithNumber This schema name starts with a number
 type N5StartsWithNumber = map[string]interface{}
 
 // AnyType1 defines model for AnyType1.
 type AnyType1 = interface{}
 
-// AnyType2 represents any type.
+// AnyType2 AnyType2 represents any type.
 //
 // This should be an interface{}
 type AnyType2 = interface{}
@@ -664,7 +664,7 @@ type EnsureEverythingIsReferencedResponse struct {
 	JSON200      *struct {
 		AnyType1 *AnyType1 `json:"anyType1,omitempty"`
 
-		// AnyType2 represents any type.
+		// AnyType2 AnyType2 represents any type.
 		//
 		// This should be an interface{}
 		AnyType2         *AnyType2         `json:"anyType2,omitempty"`
@@ -946,7 +946,7 @@ func ParseEnsureEverythingIsReferencedResponse(rsp *http.Response) (*EnsureEvery
 		var dest struct {
 			AnyType1 *AnyType1 `json:"anyType1,omitempty"`
 
-			// AnyType2 represents any type.
+			// AnyType2 AnyType2 represents any type.
 			//
 			// This should be an interface{}
 			AnyType2         *AnyType2         `json:"anyType2,omitempty"`

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -93,13 +93,13 @@ type SimpleResponse struct {
 
 // GetWithArgsParams defines parameters for GetWithArgs.
 type GetWithArgsParams struct {
-	// An optional query argument
+	// OptionalArgument An optional query argument
 	OptionalArgument *int64 `form:"optional_argument,omitempty" json:"optional_argument,omitempty"`
 
-	// An optional query argument
+	// RequiredArgument An optional query argument
 	RequiredArgument int64 `form:"required_argument" json:"required_argument"`
 
-	// An optional query argument
+	// HeaderArgument An optional query argument
 	HeaderArgument *int32 `json:"header_argument,omitempty"`
 }
 
@@ -108,7 +108,7 @@ type GetWithContentTypeParamsContentType string
 
 // CreateResource2Params defines parameters for CreateResource2.
 type CreateResource2Params struct {
-	// Some query argument
+	// InlineQueryArgument Some query argument
 	InlineQueryArgument *int `form:"inline_query_argument,omitempty" json:"inline_query_argument,omitempty"`
 }
 

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -50,7 +50,7 @@ func TestExamplePetStoreCodeGeneration(t *testing.T) {
 	assert.Contains(t, code, "func (c *Client) FindPetByID(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error) {")
 
 	// Check that the property comments were generated
-	assert.Contains(t, code, "// Unique id of the pet")
+	assert.Contains(t, code, "// Id Unique id of the pet")
 
 	// Check that the summary comment contains newlines
 	assert.Contains(t, code, `// Deletes a pet by ID

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -216,13 +216,13 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 		}
 		return Schema{
 			GoType:         refType,
-			Description:    StringToGoComment(schema.Description),
+			Description:    schema.Description,
 			DefineViaAlias: true,
 		}, nil
 	}
 
 	outSchema := Schema{
-		Description: StringToGoComment(schema.Description),
+		Description: schema.Description,
 		OAPISchema:  schema,
 	}
 
@@ -563,6 +563,14 @@ func GenFieldsFromProperties(props []Property) []string {
 	var fields []string
 	for i, p := range props {
 		field := ""
+
+		goFieldName := p.GoFieldName()
+		if _, ok := p.ExtensionProps.Extensions[extGoName]; ok {
+			if extGoFieldName, err := extParseGoFieldName(p.ExtensionProps.Extensions[extGoName]); err == nil {
+				goFieldName = extGoFieldName
+			}
+		}
+
 		// Add a comment to a field in case we have one, otherwise skip.
 		if p.Description != "" {
 			// Separate the comment from a previous-defined, unrelated field.
@@ -570,14 +578,7 @@ func GenFieldsFromProperties(props []Property) []string {
 			if i != 0 {
 				field += "\n"
 			}
-			field += fmt.Sprintf("%s\n", StringToGoComment(p.Description))
-		}
-
-		goFieldName := p.GoFieldName()
-		if _, ok := p.ExtensionProps.Extensions[extGoName]; ok {
-			if extGoFieldName, err := extParseGoFieldName(p.ExtensionProps.Extensions[extGoName]); err == nil {
-				goFieldName = extGoFieldName
-			}
+			field += fmt.Sprintf("%s\n", StringWithTypeNameToGoComment(p.Description, p.GoFieldName()))
 		}
 
 		field += fmt.Sprintf("    %s %s", goFieldName, p.GoTypeDef())

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -287,4 +287,5 @@ var TemplateFunctions = template.FuncMap{
 	"title":                      strings.Title,
 	"stripNewLines":              stripNewLines,
 	"sanitizeGoIdentity":         SanitizeGoIdentity,
+	"toGoComment":                StringWithTypeNameToGoComment,
 }

--- a/pkg/codegen/templates/typedef.tmpl
+++ b/pkg/codegen/templates/typedef.tmpl
@@ -1,4 +1,4 @@
 {{range .Types}}
-{{ with .Schema.Description }}{{ . }}{{ else }}// {{.TypeName}} defines model for {{.JsonName}}.{{ end }}
+{{ if .Schema.Description }}{{ toGoComment .Schema.Description .TypeName  }}{{ else }}// {{.TypeName}} defines model for {{.JsonName}}.{{ end }}
 type {{.TypeName}} {{if .IsAlias }}={{end}} {{.Schema.TypeDecl}}
 {{end}}

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -652,6 +652,17 @@ func PathToTypeName(path []string) string {
 // StringToGoComment renders a possible multi-line string as a valid Go-Comment.
 // Each line is prefixed as a comment.
 func StringToGoComment(in string) string {
+	return stringToGoCommentWithPrefix(in, "")
+}
+
+// StringWithTypeNameToGoComment renders a possible multi-line string as a
+// valid Go-Comment, including the name of the type being referenced. Each line
+// is prefixed as a comment.
+func StringWithTypeNameToGoComment(in, typeName string) string {
+	return stringToGoCommentWithPrefix(in, typeName)
+}
+
+func stringToGoCommentWithPrefix(in, prefix string) string {
 	if len(in) == 0 || len(strings.TrimSpace(in)) == 0 { // ignore empty comment
 		return ""
 	}
@@ -662,8 +673,12 @@ func StringToGoComment(in string) string {
 
 	// Add comment to each line
 	var lines []string
-	for _, line := range strings.Split(in, "\n") {
-		lines = append(lines, fmt.Sprintf("// %s", line))
+	for i, line := range strings.Split(in, "\n") {
+		s := "//"
+		if i == 0 && len(prefix) > 0 {
+			s += " " + prefix
+		}
+		lines = append(lines, fmt.Sprintf("%s %s", s, line))
 	}
 	in = strings.Join(lines, "\n")
 

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -344,6 +344,62 @@ Line
 	}
 }
 
+func TestStringWithTypeNameToGoComment(t *testing.T) {
+	testCases := []struct {
+		input     string
+		inputName string
+		expected  string
+		message   string
+	}{
+		{
+			input:     "",
+			inputName: "",
+			expected:  "",
+			message:   "blank string should be ignored due to human unreadable",
+		},
+		{
+			input:    " ",
+			expected: "",
+			message:  "whitespace should be ignored due to human unreadable",
+		},
+		{
+			input:     "Single Line",
+			inputName: "SingleLine",
+			expected:  "// SingleLine Single Line",
+			message:   "single line comment",
+		},
+		{
+			input:     "    Single Line",
+			inputName: "SingleLine",
+			expected:  "// SingleLine     Single Line",
+			message:   "single line comment preserving whitespace",
+		},
+		{
+			input: `Multi
+Line
+  With
+    Spaces
+	And
+		Tabs
+`,
+			inputName: "MultiLine",
+			expected: `// MultiLine Multi
+// Line
+//   With
+//     Spaces
+// 	And
+// 		Tabs`,
+			message: "multi line preserving whitespaces using tabs or spaces",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.message, func(t *testing.T) {
+			result := StringWithTypeNameToGoComment(testCase.input, testCase.inputName)
+			assert.EqualValues(t, testCase.expected, result, testCase.message)
+		})
+	}
+}
+
 func TestEscapePathElements(t *testing.T) {
 	p := "/foo/bar/baz"
 	assert.Equal(t, p, EscapePathElements(p))

--- a/pkg/runtime/styleparam_test.go
+++ b/pkg/runtime/styleparam_test.go
@@ -14,7 +14,6 @@
 package runtime
 
 import (
-	"github.com/google/uuid"
 	"testing"
 	"time"
 
@@ -679,7 +678,7 @@ func TestStyleParam(t *testing.T) {
 	assert.EqualValues(t, "date_field,1996-03-19,time_field,1996-03-19T00%3A00%3A00Z,uuid_field,baa07328-452e-40bd-aa2e-fa823ec13605", result)
 
 	// Test handling of struct that implement encoding.TextMarshaler
-  timeVal = time.Date(1996, time.March, 19, 0, 0, 0, 0, time.UTC)
+	timeVal = time.Date(1996, time.March, 19, 0, 0, 0, 0, time.UTC)
 
 	result, err = StyleParamWithLocation("simple", false, "id", ParamLocationQuery, timeVal)
 	assert.NoError(t, err)


### PR DESCRIPTION

To make sure that our commented types appear as "official" GoDoc
comments, we need to prefix each

To avoid duplicating too much code, we can create an overloaded
`StringWithTypeNameToGoComment` which delegates to a shared
`stringToGoCommentWithPrefix`.

We then need to move this execution into the template, as we do not have
access to the `TypeName` at the point prior that we're attempting to
generate our comments.

This also includes the fields that are generated inside structs.

This includes any `make generate` changes, too.

