### PR TITLE
Add basic automated builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Build project
+on: [push, pull_request]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Test
+        run: make test
+
+      - name: Build
+        run: go build ./cmd/oapi-codegen

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,20 @@
+name: Ensure generated files are up-to-date
+on: [push, pull_request]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run `make generate`
+        run: make generate
+
+      - name: Check for no untracked files
+        run: git status && git diff-index --quiet HEAD --

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -1,0 +1,20 @@
+name: Ensure `go mod tidy` has been run
+on: [push, pull_request]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run `make tidy`
+        run: make tidy
+
+      - name: Check for no untracked files
+        run: git diff-index --quiet HEAD --

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -352,13 +352,13 @@ type RenamedRequestBody struct {
 	Field SchemaObject `json:"Field"`
 }
 
-// EnsureEverythingIsReferencedTextBody defines parameters for EnsureEverythingIsReferenced.
-type EnsureEverythingIsReferencedTextBody = string
-
 // EnsureEverythingIsReferencedJSONBody defines parameters for EnsureEverythingIsReferenced.
 type EnsureEverythingIsReferencedJSONBody struct {
 	Field SchemaObject `json:"Field"`
 }
+
+// EnsureEverythingIsReferencedTextBody defines parameters for EnsureEverythingIsReferenced.
+type EnsureEverythingIsReferencedTextBody = string
 
 // ParamsWithAddPropsParams defines parameters for ParamsWithAddProps.
 type ParamsWithAddPropsParams struct {


### PR DESCRIPTION
To ensure that contributions are well-formed, we can set up basic CI.

We can do this following [0] as inspiration, and using our `make` tasks
to automate the process.

We can also create a separate workflow for validating that the `make
generate` has been run, and no untracked changes are present.

[0]: https://blog.kowalczyk.info/article/8dd9c2c0413047c589a321b1ccba7129/using-github-actions-with-go.html
[1]: https://www.jvt.me/posts/2022/04/29/git-uncommitted-changes/

Example failed execution from `generate.yml`: https://github.com/jamietanna/oapi-codegen/runs/7560083866?check_suite_focus=true