### PR TITLE
Fix UUID query param binding

### DIFF
--- a/pkg/runtime/bindparam.go
+++ b/pkg/runtime/bindparam.go
@@ -279,10 +279,8 @@ func bindSplitPartsToDestinationStruct(paramName string, parts []string, explode
 // the Content parameter form.
 func BindQueryParameter(style string, explode bool, required bool, paramName string,
 	queryParams url.Values, dest interface{}) error {
-
 	// dv = destination value.
 	dv := reflect.Indirect(reflect.ValueOf(dest))
-
 	// intermediate value form which is either dv or dv dereferenced.
 	v := dv
 

--- a/pkg/runtime/bindparam.go
+++ b/pkg/runtime/bindparam.go
@@ -279,8 +279,10 @@ func bindSplitPartsToDestinationStruct(paramName string, parts []string, explode
 // the Content parameter form.
 func BindQueryParameter(style string, explode bool, required bool, paramName string,
 	queryParams url.Values, dest interface{}) error {
+
 	// dv = destination value.
 	dv := reflect.Indirect(reflect.ValueOf(dest))
+
 	// intermediate value form which is either dv or dv dereferenced.
 	v := dv
 

--- a/pkg/runtime/bindstring.go
+++ b/pkg/runtime/bindstring.go
@@ -14,6 +14,7 @@
 package runtime
 
 import (
+	"encoding"
 	"errors"
 	"fmt"
 	"reflect"
@@ -85,6 +86,15 @@ func BindStringToObject(src string, dst interface{}) error {
 		if err == nil {
 			v.SetBool(val)
 		}
+	case reflect.Array:
+		if tu, ok := dst.(encoding.TextUnmarshaler); ok {
+			if err := tu.UnmarshalText([]byte(src)); err != nil {
+				return fmt.Errorf("error unmarshaling '%s' text as %T: %s", src, dst, err)
+			}
+
+			return nil
+		}
+		fallthrough
 	case reflect.Struct:
 		// if this is not of type Time or of type Date look to see if this is of type Binder.
 		if dstType, ok := dst.(Binder); ok {

--- a/pkg/runtime/bindstring_test.go
+++ b/pkg/runtime/bindstring_test.go
@@ -169,4 +169,11 @@ func TestBindStringToObject(t *testing.T) {
 	var dstEmbeddedMockBinder EmbeddedMockBinder
 	assert.NoError(t, BindStringToObject(dateString, &dstEmbeddedMockBinder))
 	assert.EqualValues(t, dateString, dstEmbeddedMockBinder.Time.Format("2006-01-02"))
+
+	// Checks UUID binding
+	uuidString := "bbca1470-5e1f-4c64-ba99-fa7a6d2687b0"
+	var dstUUID types.UUID
+	assert.NoError(t, BindStringToObject(uuidString, &dstUUID))
+	assert.Equal(t, dstUUID.String(), uuidString)
+
 }


### PR DESCRIPTION
Fix for #616.

Adds a case to check if the destination object is an array and then tries to unmarshal using TextUnmarshaler (which UUID implements). If that fails, fallthrough to default.