### PR TITLE
Add support for the x-order extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,34 @@ which help you to use the various OpenAPI 3 Authentication mechanism.
   ```
   Name string `json:"name" tag1:"value1" tag2:"value2"`
   ```
+- `x-order`: specifies the order of the fields in the structure. It allows you to specify the order
+  of the fields in the generated structure and will override any default value. This extended
+  property is not supported in all parts of OpenAPI, so check the specification to see where it is
+  allowed. Swagger validation tools will flag misuse of this property.
+
+    ```yaml
+    DateInterval:
+      type: object
+      required:
+        - name
+      properties:
+        start:
+          type: string
+          format: date
+          x-order: 1
+        end:
+          type: string
+          format: date
+          x-order: 2
+    ```
+  In the example above, struct will be declared as:
+
+    ```go
+    type DateInterval struct {
+      Start *openapi_types.Date `json:"start,omitempty"`
+      End   *openapi_types.Date `json:"end,omitempty"`
+    }
+    ```
   
 
 

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -14,6 +14,8 @@
 package codegen
 
 import (
+	"encoding/json"
+	"strconv"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -39,6 +41,32 @@ func TestSortedSchemaKeys(t *testing.T) {
 	}
 
 	expected := []string{"a", "b", "c", "d", "e", "f"}
+
+	assert.EqualValues(t, expected, SortedSchemaKeys(dict), "Keys are not sorted properly")
+}
+
+func TestSortedSchemaKeysWithXOrder(t *testing.T) {
+	withOrder := func(i int) *openapi3.SchemaRef {
+		return &openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				ExtensionProps: openapi3.ExtensionProps{
+					Extensions: map[string]interface{}{"x-order": json.RawMessage(strconv.Itoa(i))},
+				},
+			},
+		}
+	}
+	dict := map[string]*openapi3.SchemaRef{
+		"minusHundredth": withOrder(-100),
+		"minusTenth":     withOrder(-10),
+		"zero":           withOrder(0),
+		"first":          withOrder(1),
+		"middleA":        nil,
+		"middleB":        nil,
+		"middleC":        nil,
+		"last":           withOrder(100),
+	}
+
+	expected := []string{"minusHundredth", "minusTenth", "zero", "first", "middleA", "middleB", "middleC", "last"}
 
 	assert.EqualValues(t, expected, SortedSchemaKeys(dict), "Keys are not sorted properly")
 }


### PR DESCRIPTION
Fix for #458.
Can be used when you need to set the order of fields in the model:
```yaml
    NewPet:
      type: object
      required:
        - name
      properties:
        name:
          type: string
          x-order: 1
        tag:
          type: string
          x-order: 2
```