### PR TITLE
Allow binding types as parameters through `String()` methods

### DIFF
--- a/pkg/runtime/styleparam.go
+++ b/pkg/runtime/styleparam.go
@@ -377,7 +377,12 @@ func primitiveToString(value interface{}) (string, error) {
 	case reflect.String:
 		output = v.String()
 	default:
-		return "", fmt.Errorf("unsupported type %s", reflect.TypeOf(value).String())
+		v, ok := value.(fmt.Stringer)
+		if !ok {
+			return "", fmt.Errorf("unsupported type %s", reflect.TypeOf(value).String())
+		}
+
+		output = v.String()
 	}
 	return output, nil
 }

--- a/pkg/runtime/styleparam_test.go
+++ b/pkg/runtime/styleparam_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/deepmap/oapi-codegen/pkg/types"
@@ -524,6 +525,11 @@ func TestStyleParam(t *testing.T) {
 	result, err = StyleParamWithLocation("simple", false, "foo", ParamLocationQuery, FloatType32(1.05))
 	assert.NoError(t, err)
 	assert.EqualValues(t, "1.05", result)
+
+	uuidValue := uuid.MustParse("c2d07ba4-5106-4eab-bcad-0bd6068dcb1a")
+	result, err = StyleParamWithLocation("simple", false, "foo", ParamLocationQuery, types.UUID(uuidValue))
+	assert.NoError(t, err)
+	assert.EqualValues(t, "c2d07ba4-5106-4eab-bcad-0bd6068dcb1a", result)
 
 	// Test that we handle optional fields
 	type TestObject2 struct {


### PR DESCRIPTION
If trying to use a type, such as a UUID in a path parameter, we'd
previously receive an error at runtime to say that `types.UUID` isn't
supported.

As this is a common use case, we should support it. Instead of adding
support for it manually, we can instead look at whether the there's a
`String` method, and if so use that to serialise the field.
