### PR TITLE
Add template overrides from files in new config

### DIFF
--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -73,11 +73,13 @@ type CompatibilityOptions struct {
 
 // OutputOptions are used to modify the output code in some way.
 type OutputOptions struct {
-	SkipFmt       bool              `yaml:"skip-fmt,omitempty"`       // Whether to skip go imports on the generated code
-	SkipPrune     bool              `yaml:"skip-prune,omitempty"`     // Whether to skip pruning unused components on the generated code
-	IncludeTags   []string          `yaml:"include-tags,omitempty"`   // Only include operations that have one of these tags. Ignored when empty.
-	ExcludeTags   []string          `yaml:"exclude-tags,omitempty"`   // Exclude operations that have one of these tags. Ignored when empty.
-	UserTemplates map[string]string `yaml:"user-templates,omitempty"` // Override built-in templates from user-provided files
+	SkipFmt           bool              `yaml:"skip-fmt,omitempty"`            // Whether to skip go imports on the generated code
+	SkipPrune         bool              `yaml:"skip-prune,omitempty"`          // Whether to skip pruning unused components on the generated code
+	IncludeTags       []string          `yaml:"include-tags,omitempty"`        // Only include operations that have one of these tags. Ignored when empty.
+	ExcludeTags       []string          `yaml:"exclude-tags,omitempty"`        // Exclude operations that have one of these tags. Ignored when empty.
+	UserTemplates     map[string]string `yaml:"user-templates,omitempty"`      // Override built-in templates from user-provided files
+	UserTemplateFiles map[string]string `yaml:"user-template-files,omitempty"` // Same as UserTemplates, with filenames as values instead
+	UserTemplatesDir  string            `yaml:"user-templates-dir,omitempty"`
 
 	ExcludeSchemas     []string `yaml:"exclude-schemas,omitempty"`      // Exclude from generation schemas with given names. Ignored when empty.
 	ResponseTypeSuffix string   `yaml:"response-type-suffix,omitempty"` // The suffix used for responses types

--- a/pkg/codegen/testdata/chi-interface.tmpl
+++ b/pkg/codegen/testdata/chi-interface.tmpl
@@ -1,0 +1,1 @@
+// file override

--- a/pkg/codegen/testdata/chi/chi-interface.tmpl
+++ b/pkg/codegen/testdata/chi/chi-interface.tmpl
@@ -1,0 +1,1 @@
+// directory override


### PR DESCRIPTION
Closes #607.

This PR introduces template file overrides from filenames. Overrides listed in `output-options.user-template-files` will just override whatever is given by `output-options.user-templates`, so this doesn't break any existing configuration files.

Example usage:

```yaml
package: mypackage
generate:
  models: true
  client: true
output:
  test.gen.go
output-options:
  user-template-files:
    client.tmpl: ./templates/my-client.tmpl
    client-with-responses.tmpl: ./templates/my-client-with-responses.tmpl
```