### PR TITLE
Add option to validate enum values

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -623,6 +623,7 @@ func GenerateEnums(t *template.Template, types []TypeDefinition) (string, error)
 			enums = append(enums, EnumDefinition{
 				Schema:       tp.Schema,
 				TypeName:     tp.TypeName,
+				TypeDecl:     tp.Schema.TypeDecl(),
 				ValueWrapper: wrapper,
 			})
 		}
@@ -673,7 +674,10 @@ func GenerateEnums(t *template.Template, types []TypeDefinition) (string, error)
 
 	// Now see if enums conflict with any non-enum typenames
 
-	return GenerateTemplates([]string{"constants.tmpl"}, t, Constants{EnumDefinitions: enums})
+	return GenerateTemplates([]string{"constants.tmpl"}, t, Constants{
+		EnumDefinitions:    enums,
+		ValidateEnumValues: globalState.options.Compatibility.ValidateEnumValues,
+	})
 }
 
 // Generate our import statements and package definition.

--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -26,7 +26,7 @@ type GenerateOptions struct {
 	EchoServer    bool `yaml:"echo-server,omitempty"`    // EchoServer specifies whether to generate echo server boilerplate
 	GinServer     bool `yaml:"gin-server,omitempty"`     // GinServer specifies whether to generate gin server boilerplate
 	GorillaServer bool `yaml:"gorilla-server,omitempty"` // GorillaServer specifies whether to generate Gorilla server boilerplate
-	Strict        bool `yaml:"strict-server,omitempty"` // Strict specifies whether to generate strict server wrapper
+	Strict        bool `yaml:"strict-server,omitempty"`  // Strict specifies whether to generate strict server wrapper
 	Client        bool `yaml:"client,omitempty"`         // Client specifies whether to generate client boilerplate
 	Models        bool `yaml:"models,omitempty"`         // Models specifies whether to generate type definitions
 	EmbeddedSpec  bool `yaml:"embedded-spec,omitempty"`  // Whether to embed the swagger spec in the generated code
@@ -57,6 +57,8 @@ type CompatibilityOptions struct {
 	// When an object contains no members, and only an additionalProperties specification,
 	// it is flattened to a map. Set
 	DisableFlattenAdditionalProperties bool `yaml:"disable-flatten-additional-properties,omitempty"`
+	// When set to true, generate a custom unmarshaler that validates the values of enum types.
+	ValidateEnumValues bool `yaml:"validate-enum-values,omitempty"`
 }
 
 // OutputOptions are used to modify the output code in some way.

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -108,6 +108,8 @@ type EnumDefinition struct {
 	Schema Schema
 	// TypeName is the name of the enum's type, usually aliased from something.
 	TypeName string
+	// TypeDecl is the name of the enum's base type.
+	TypeDecl string
 	// ValueWrapper wraps the value. It's used to conditionally apply quotes
 	// around strings.
 	ValueWrapper string
@@ -136,6 +138,9 @@ type Constants struct {
 	SecuritySchemeProviderNames []string
 	// EnumDefinitions holds type and value information for all enums
 	EnumDefinitions []EnumDefinition
+	// ValidateEnumValues generates a custom unmarshaler that validates the enum
+	// values.
+	ValidateEnumValues bool
 }
 
 // TypeDefinition describes a Go type definition in generated code.

--- a/pkg/codegen/templates/constants.tmpl
+++ b/pkg/codegen/templates/constants.tmpl
@@ -12,4 +12,26 @@ const (
   {{$name}} {{$Enum.TypeName}} = {{$Enum.ValueWrapper}}{{$value}}{{$Enum.ValueWrapper -}}
 {{end}}
 )
+
+{{if $.ValidateEnumValues}}
+// UnmarshalJSON validates the enum values for {{$Enum.TypeName}} and returns an error if the
+// provided value is not defined.
+func (v *{{$Enum.TypeName}}) UnmarshalJSON(b []byte) error {
+    var s {{$Enum.TypeDecl}} 
+
+    if err := json.Unmarshal(b, &s); err != nil {
+        return err
+    }
+    {{$first := true}}
+    switch {{$Enum.TypeName}}(s) {
+    case {{range $name, $value := $Enum.GetValues}}{{if $first}}{{$first = false}}{{else}},
+        {{end}}{{$name}}{{end}}:
+        *v = {{$Enum.TypeName}}(s)
+
+        return nil
+    default:
+        return fmt.Errorf("invalid enum value: %v", s)
+    }
+}
+{{end}}
 {{end}}


### PR DESCRIPTION
Add a compatibility option to generate a custom unmarshaler that validates the enum values.

When the new option `compatibility.validate-enum-values` is set to `true` code like below is generated for the following specification:

```yaml
status:
  type: string
  enum: [ success, failed ]
```

```go
func (v *Status) UnmarshalJSON(bs []byte) error {
    var s string

    if err := json.Unmarshal(bs, &s); err != nil {
        return err
    }

    switch Status(s) {
    case Success, Failed:
        *v = Status(s)

        return nil
    default:
        return fmt.Errorf("invalid enum value: %v", s)
    }
}
```

Closes: #657
