### PR TITLE
Fixes #679: JSON decoding to types.File

### DIFF
--- a/pkg/types/file.go
+++ b/pkg/types/file.go
@@ -34,7 +34,12 @@ func (file *File) MarshalJSON() ([]byte, error) {
 }
 
 func (file *File) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &file.data)
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	file.data = []byte(s)
+	return nil
 }
 
 func (file File) Bytes() ([]byte, error) {


### PR DESCRIPTION
Fixes #679. Because both the source and the destination are of type []byte, Go expects the
source to be base64 encoded. However, the OpenAPI string format "binary" designates
"any sequence of octets".

Because "binary" is matched with types.File, a special processing is required
to avoid the base64 decoding of json.