### PR TITLE
Get security scopes from context

### DIFF
--- a/examples/authenticated-api/echo/api/api.gen.go
+++ b/examples/authenticated-api/echo/api/api.gen.go
@@ -25,6 +25,15 @@ const (
 	BearerAuthScopes = "BearerAuth.Scopes"
 )
 
+func BearerAuthScopesFromContext(ctx context.Context) []string {
+	value := ctx.Value(BearerAuthScopes)
+	if value == nil {
+		return nil
+	}
+
+	return value.([]string)
+}
+
 // Error defines model for Error.
 type Error struct {
 	// Error code

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -25,6 +25,15 @@ const (
 	OpenIdScopes = "OpenId.Scopes"
 )
 
+func OpenIdScopesFromContext(ctx context.Context) []string {
+	value := ctx.Value(OpenIdScopes)
+	if value == nil {
+		return nil
+	}
+
+	return value.([]string)
+}
+
 // SchemaObject defines model for SchemaObject.
 type SchemaObject struct {
 	FirstName string `json:"firstName"`

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -29,6 +29,15 @@ const (
 	Access_tokenScopes = "access_token.Scopes"
 )
 
+func Access_tokenScopesFromContext(ctx context.Context) []string {
+	value := ctx.Value(Access_tokenScopes)
+	if value == nil {
+		return nil
+	}
+
+	return value.([]string)
+}
+
 // Defines values for EnumInObjInArrayVal.
 const (
 	First  EnumInObjInArrayVal = "first"

--- a/pkg/codegen/templates/constants.tmpl
+++ b/pkg/codegen/templates/constants.tmpl
@@ -4,6 +4,18 @@ const (
     {{- $ProviderName | ucFirst}}Scopes = "{{$ProviderName}}.Scopes"
 {{end}}
 )
+
+{{range $ProviderName := .SecuritySchemeProviderNames}}
+func {{$ProviderName | ucFirst}}ScopesFromContext(ctx context.Context) []string {
+    value := ctx.Value({{- $ProviderName | ucFirst}}Scopes)
+    if value == nil {
+        return nil
+    }
+
+    return value.([]string)
+}
+
+{{end}}
 {{end}}
 {{range $Enum := .EnumDefinitions}}
 // Defines values for {{$Enum.TypeName}}.


### PR DESCRIPTION
In my project I'm using a sidecar that handles authentication and
injects a header into the request containing the scopes for which the
user is authorized.

In the application itself I annotate the different endpoints with the
required scopes and match these via a middleware function with the
scopes from the user request.

I found myself repeating the code to get the security scopes from the
context in multiple places. This change generates a simple getter for
this that handles the type cast.

Usage:
```yaml
paths:
  /public/resource:
    get:
  /private/resource:
    get:
      security:
        - AuthInfo: ["read"]
    post:
      security:
        - AuthInfo: ["write"]
components:
  securitySchemes:
    AuthInfo:
      type: apiKey
      in: header
      name: X-Authinfo
```

```go
apiScopes := openapi3.AuthInfoScopesFromContext(req.Context())

if scopes == nil {
    // no authorization needed
} else {
    // match apiScopes with request scopes
}
```
