### PR TITLE
Order request body definitions by content type

### DIFF
--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -615,7 +615,8 @@ func GenerateBodyDefinitions(operationID string, bodyOrRef *openapi3.RequestBody
 	var bodyDefinitions []RequestBodyDefinition
 	var typeDefinitions []TypeDefinition
 
-	for contentType, content := range body.Content {
+	for _, contentType := range SortedContentKeys(body.Content) {
+		content := body.Content[contentType]
 		var tag string
 		var defaultBody bool
 


### PR DESCRIPTION
Since `body.Content` is a `map`, the order of iteration is unspecified. Using `SortedContentKeys` ensures consistency across repeated code generation.