### PR TITLE
Chi-server wrapping middleware logic fix.

### DIFF
--- a/pkg/codegen/templates/chi/chi-middleware.tmpl
+++ b/pkg/codegen/templates/chi/chi-middleware.tmpl
@@ -172,8 +172,11 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
     siw.Handler.{{.OperationId}}(w, r{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
   })
 
-  for _, middleware := range siw.HandlerMiddlewares {
-    handler = middleware(handler)
+  for i := len(siw.HandlerMiddlewares) - 1; i >= 0; i--  {
+	h := siw.HandlerMiddlewares[i]
+        if h != nil {
+          handler = h(handler)
+        }
   }
 
   handler.ServeHTTP(w, r.WithContext(ctx))


### PR DESCRIPTION
Current implementation server middlewares to a handler goes like this:

```go
var handler = func(w http.ResponseWriter, r *http.Request) {
	siw.Handler.YourRouteHandler(w, r)
}

for _, middleware := range siw.HandlerMiddlewares {
	handler = middleware(handler)
}
```
The snippet above tends to execute beginning middlewares at the later than the last ones.

The looping is supposed to be like this:
```go
var handler = func(w http.ResponseWriter, r *http.Request) {
	siw.Handler.YourRouteHandler(w, r)
}

for i := len(siw.HandlerMiddlewares) - 1; i >= 0; i--  {
	h := siw.HandlerMiddlewares[i]
        if h != nil {
          handler = h(handler)
        }
}
```
The solution is referenced from [Ardan Lab's Service repository on wrapping middlewares](https://github.com/ardanlabs/service/blob/master/foundation/web/middleware.go)