### PR TITLE
Support `x-enum-varnames` extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,6 +628,35 @@ which help you to use the various OpenAPI 3 Authentication mechanism.
   }
   ```
 
+- `x-enum-varnames`: supplies other enum names for the corresponding values.
+
+    ```yaml
+    components:
+      schemas:
+        Object:
+          properties:
+            category:
+              type: integer
+              enum: [0, 1, 2]
+              x-enum-varnames:
+                - notice
+                - warning
+                - urgent
+    ```
+
+    After code generation you will get this result:
+
+    ```go
+    // Defines values for ObjectCategory.
+    const (
+    	Notice  ObjectCategory = 0
+    	Urgent  ObjectCategory = 2
+    	Warning ObjectCategory = 1
+    )
+
+    // ObjectCategory defines model for Object.Category.
+    type ObjectCategory int
+    ```
 
 ## Using `oapi-codegen`
 

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -184,8 +184,9 @@ type GetTestByNameResponse struct {
 	assert.Contains(t, code, "Top *int `form:\"$top,omitempty\" json:\"$top,omitempty\"`")
 	assert.Contains(t, code, "func (c *Client) GetTestByName(ctx context.Context, name string, params *GetTestByNameParams, reqEditors ...RequestEditorFn) (*http.Response, error) {")
 	assert.Contains(t, code, "func (c *ClientWithResponses) GetTestByNameWithResponse(ctx context.Context, name string, params *GetTestByNameParams, reqEditors ...RequestEditorFn) (*GetTestByNameResponse, error) {")
-	assert.Contains(t, code, "DeadSince *time.Time    `json:\"dead_since,omitempty\" tag1:\"value1\" tag2:\"value2\"`")
-
+	assert.Contains(t, code, "DeadSince   *time.Time       `json:\"dead_since,omitempty\" tag1:\"value1\" tag2:\"value2\"`")
+	assert.Contains(t, code, "Geriatric CatDeadAgeCategory = 5")
+	assert.Contains(t, code, "N2 CatDeadArea = 2")
 	// Make sure the generated code is valid:
 	checkLint(t, "test.gen.go", []byte(code))
 }

--- a/pkg/codegen/extension.go
+++ b/pkg/codegen/extension.go
@@ -10,6 +10,7 @@ const (
 	extGoName        = "x-go-name"
 	extPropOmitEmpty = "x-omitempty"
 	extPropExtraTags = "x-oapi-codegen-extra-tags"
+	extEnumVarNames  = "x-enum-varnames"
 )
 
 func extString(extPropValue interface{}) (string, error) {
@@ -56,4 +57,16 @@ func extExtraTags(extPropValue interface{}) (map[string]string, error) {
 		return nil, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 	return tags, nil
+}
+
+func extParseEnumVarNames(extPropValue interface{}) ([]string, error) {
+	raw, ok := extPropValue.(json.RawMessage)
+	if !ok {
+		return nil, fmt.Errorf("failed to convert type: %T", extPropValue)
+	}
+	var names []string
+	if err := json.Unmarshal(raw, &names); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json: %w", err)
+	}
+	return names, nil
 }

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -401,8 +401,18 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 		for i, enumValue := range schema.Enum {
 			enumValues[i] = fmt.Sprintf("%v", enumValue)
 		}
+		if 0 < len(schema.ExtensionProps.Extensions) {
+			//fmt.Fprintf(os.Stderr, "%#v\n\n", schema)
+		}
 
-		sanitizedValues := SanitizeEnumNames(enumValues)
+		enumNames := enumValues
+		if _, ok := schema.ExtensionProps.Extensions[extEnumVarNames]; ok {
+			if extEnumNames, err := extParseEnumVarNames(schema.ExtensionProps.Extensions[extEnumVarNames]); err == nil {
+				enumNames = extEnumNames
+			}
+		}
+
+		sanitizedValues := SanitizeEnumNames(enumNames, enumValues)
 		outSchema.EnumValues = make(map[string]string, len(sanitizedValues))
 
 		for k, v := range sanitizedValues {

--- a/pkg/codegen/test_spec.yaml
+++ b/pkg/codegen/test_spec.yaml
@@ -136,3 +136,16 @@ components:
         cause:
           type: string
           enum: [car, dog, oldage]
+        area:
+          type: integer
+          enum: [0, 1, 2]
+        age_category:
+          type: integer
+          enum: [0, 1, 2, 3, 4, 5, 6]
+          x-enum-varnames:
+            - kitten
+            - junior
+            - prime
+            - mature
+            - senior
+            - geriatric

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -546,13 +546,17 @@ func SanitizeGoIdentity(str string) string {
 
 // SanitizeEnumNames fixes illegal chars in the enum names
 // and removes duplicates
-func SanitizeEnumNames(enumNames []string) map[string]string {
-	dupCheck := make(map[string]int, len(enumNames))
-	deDup := make([]string, 0, len(enumNames))
+func SanitizeEnumNames(enumNames, enumValues []string) map[string]string {
+	dupCheck := make(map[string]int, len(enumValues))
+	deDup := make([][]string, 0, len(enumValues))
 
-	for _, n := range enumNames {
+	for i, v := range enumValues {
+		n := v
+		if i < len(enumNames) {
+			n = enumNames[i]
+		}
 		if _, dup := dupCheck[n]; !dup {
-			deDup = append(deDup, n)
+			deDup = append(deDup, []string{n, v})
 		}
 		dupCheck[n] = 0
 	}
@@ -560,13 +564,14 @@ func SanitizeEnumNames(enumNames []string) map[string]string {
 	dupCheck = make(map[string]int, len(deDup))
 	sanitizedDeDup := make(map[string]string, len(deDup))
 
-	for _, n := range deDup {
+	for _, p := range deDup {
+		n, v := p[0], p[1]
 		sanitized := SanitizeGoIdentity(SchemaNameToTypeName(n))
 
 		if _, dup := dupCheck[sanitized]; !dup {
-			sanitizedDeDup[sanitized] = n
+			sanitizedDeDup[sanitized] = v
 		} else {
-			sanitizedDeDup[sanitized+strconv.Itoa(dupCheck[sanitized])] = n
+			sanitizedDeDup[sanitized+strconv.Itoa(dupCheck[sanitized])] = v
 		}
 		dupCheck[sanitized]++
 	}


### PR DESCRIPTION
Summary:

Support `x-enum-varnames` extension, derived from [openapi-generator](https://openapi-generator.tech/docs/templating/#enum).

With it, we can supply other enum names for the corresponding values.

```yaml
components:
  schemas:
    Object:
      properties:
        category:
          type: integer
          enum: [0, 1, 2]
          x-enum-varnames:
            - notice
            - warning
            - urgent
```

After code generation you will get this result:


```go
// Defines values for ObjectCategory.
const (
	Notice  ObjectCategory = 0
	Urgent  ObjectCategory = 2
	Warning ObjectCategory = 1
)

// ObjectCategory defines model for Object.Category.
type ObjectCategory int
```
