### PR TITLE
Add fallback for old configuration style

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,12 @@ output-options:
 Have a look at [`cmd/oapi-codegen/oapi-codegen.go`](https://github.com/deepmap/oapi-codegen/blob/master/cmd/oapi-codegen/oapi-codegen.go#L48) 
 to see all the fields on the configuration structure.
 
+**Note:** the old configuration options, present in pre-1.11.0 releases will work again:
+
+```sh
+oapi-codegen --package=petshop --generate="types,client,server,spec" -alias-types petshop-expanded.yaml
+```
+
 ### Import Mappings
 
 OpenAPI specifications may contain references to other OpenAPI specifications,

--- a/internal/test/client/doc.go
+++ b/internal/test/client/doc.go
@@ -1,3 +1,3 @@
 package client
 
-//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen --old-config-style --package=client -o client.gen.go client.yaml
+//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen --package=client -o client.gen.go client.yaml

--- a/internal/test/issues/issue-579/gen.go
+++ b/internal/test/issues/issue-579/gen.go
@@ -1,3 +1,3 @@
 package issue_579
 
-//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen --old-config-style --package=issue_579 --generate=types,skip-prune --alias-types -o issue.gen.go spec.yaml
+//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen --package=issue_579 --generate=types,skip-prune --alias-types -o issue.gen.go spec.yaml


### PR DESCRIPTION
As a means to avoid the breaking changes we introduced in v1.11.0, where
the new-style configuration was made the default, we can tweak our
heuristic for how we work out what configuration is in use by only using
the new-style config if the new `--config` flag is used.

This change in itself is non-breaking, and makes it possible to continue
using the old configuration arguments, as long as you don't provide the
new `--config` flag.

Similar to thoughts in #629, but does not require a revert.

Closes #629.
