### PR TITLE
Strongly typed responses for strict server

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,17 +271,16 @@ function to bind the form to a struct. All other content types are represented b
 
 To form a response simply return one of the generated structs with corresponding status code and content type. For example,
 to return a status code 200 JSON response for a AddPet use the `AddPet200JSONResponse` struct which will set the correct
-Content-Type header, status code and will marshal the response data. You can also return an `error` interface, that will be
-cause an `Internal Server Error` response. If you return a response that is not supported by this method, you will get an error.
-Unfortunately go does not support union types outside generic code, so we can't type check in compile time.
+Content-Type header, status code and will marshal the response data. You can also return an error, that will
+cause an `Internal Server Error` response.
 
 Short example:
 ```go
 type PetStoreImpl struct {}
-func (*PetStoreImpl) GetPets(ctx context.Context, request GetPetsRequestObject) interface{} {
+func (*PetStoreImpl) GetPets(ctx context.Context, request GetPetsRequestObject) (GetPetsResponseObject, error) {
     var result []Pet
 	// Implement me
-    return GetPets200JSONResponse(result)
+    return GetPets200JSONResponse(result), nil
 }
 ```
 For a complete example see `/examples/petstore-expanded/strict`.

--- a/examples/petstore-expanded/strict/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/strict/api/petstore-server.gen.go
@@ -281,10 +281,17 @@ type FindPetsRequestObject struct {
 	Params FindPetsParams
 }
 
+type FindPetsResponseObject interface {
+	VisitFindPetsResponse(w http.ResponseWriter) error
+}
+
 type FindPets200JSONResponse []Pet
 
-func (t FindPets200JSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal(([]Pet)(t))
+func (response FindPets200JSONResponse) VisitFindPetsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
 }
 
 type FindPetsdefaultJSONResponse struct {
@@ -292,18 +299,28 @@ type FindPetsdefaultJSONResponse struct {
 	StatusCode int
 }
 
-func (t FindPetsdefaultJSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Body)
+func (response FindPetsdefaultJSONResponse) VisitFindPetsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.StatusCode)
+
+	return json.NewEncoder(w).Encode(response.Body)
 }
 
 type AddPetRequestObject struct {
 	Body *AddPetJSONRequestBody
 }
 
+type AddPetResponseObject interface {
+	VisitAddPetResponse(w http.ResponseWriter) error
+}
+
 type AddPet200JSONResponse Pet
 
-func (t AddPet200JSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal((Pet)(t))
+func (response AddPet200JSONResponse) VisitAddPetResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
 }
 
 type AddPetdefaultJSONResponse struct {
@@ -311,15 +328,27 @@ type AddPetdefaultJSONResponse struct {
 	StatusCode int
 }
 
-func (t AddPetdefaultJSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Body)
+func (response AddPetdefaultJSONResponse) VisitAddPetResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.StatusCode)
+
+	return json.NewEncoder(w).Encode(response.Body)
 }
 
 type DeletePetRequestObject struct {
 	Id int64 `json:"id"`
 }
 
+type DeletePetResponseObject interface {
+	VisitDeletePetResponse(w http.ResponseWriter) error
+}
+
 type DeletePet204Response struct {
+}
+
+func (response DeletePet204Response) VisitDeletePetResponse(w http.ResponseWriter) error {
+	w.WriteHeader(204)
+	return nil
 }
 
 type DeletePetdefaultJSONResponse struct {
@@ -327,18 +356,28 @@ type DeletePetdefaultJSONResponse struct {
 	StatusCode int
 }
 
-func (t DeletePetdefaultJSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Body)
+func (response DeletePetdefaultJSONResponse) VisitDeletePetResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.StatusCode)
+
+	return json.NewEncoder(w).Encode(response.Body)
 }
 
 type FindPetByIDRequestObject struct {
 	Id int64 `json:"id"`
 }
 
+type FindPetByIDResponseObject interface {
+	VisitFindPetByIDResponse(w http.ResponseWriter) error
+}
+
 type FindPetByID200JSONResponse Pet
 
-func (t FindPetByID200JSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal((Pet)(t))
+func (response FindPetByID200JSONResponse) VisitFindPetByIDResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
 }
 
 type FindPetByIDdefaultJSONResponse struct {
@@ -346,27 +385,30 @@ type FindPetByIDdefaultJSONResponse struct {
 	StatusCode int
 }
 
-func (t FindPetByIDdefaultJSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Body)
+func (response FindPetByIDdefaultJSONResponse) VisitFindPetByIDResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.StatusCode)
+
+	return json.NewEncoder(w).Encode(response.Body)
 }
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
 	// Returns all pets
 	// (GET /pets)
-	FindPets(ctx context.Context, request FindPetsRequestObject) interface{}
+	FindPets(ctx context.Context, request FindPetsRequestObject) (FindPetsResponseObject, error)
 	// Creates a new pet
 	// (POST /pets)
-	AddPet(ctx context.Context, request AddPetRequestObject) interface{}
+	AddPet(ctx context.Context, request AddPetRequestObject) (AddPetResponseObject, error)
 	// Deletes a pet by ID
 	// (DELETE /pets/{id})
-	DeletePet(ctx context.Context, request DeletePetRequestObject) interface{}
+	DeletePet(ctx context.Context, request DeletePetRequestObject) (DeletePetResponseObject, error)
 	// Returns a pet by ID
 	// (GET /pets/{id})
-	FindPetByID(ctx context.Context, request FindPetByIDRequestObject) interface{}
+	FindPetByID(ctx context.Context, request FindPetByIDRequestObject) (FindPetByIDResponseObject, error)
 }
 
-type StrictHandlerFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, args interface{}) interface{}
+type StrictHandlerFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, args interface{}) (interface{}, error)
 
 type StrictMiddlewareFunc func(f StrictHandlerFunc, operationID string) StrictHandlerFunc
 
@@ -402,29 +444,21 @@ func (sh *strictHandler) FindPets(w http.ResponseWriter, r *http.Request, params
 
 	request.Params = params
 
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) interface{} {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.FindPets(ctx, request.(FindPetsRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "FindPets")
 	}
 
-	response := handler(r.Context(), w, r, request)
+	response, err := handler(r.Context(), w, r, request)
 
-	switch v := response.(type) {
-	case FindPets200JSONResponse:
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		writeJSON(w, v)
-	case FindPetsdefaultJSONResponse:
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(v.StatusCode)
-		writeJSON(w, v)
-	case error:
-		sh.options.ResponseErrorHandlerFunc(w, r, v)
-	case nil:
-	default:
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", v))
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(FindPetsResponseObject); ok {
+		if err := validResponse.VisitFindPetsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
 	}
 }
 
@@ -439,29 +473,21 @@ func (sh *strictHandler) AddPet(w http.ResponseWriter, r *http.Request) {
 	}
 	request.Body = &body
 
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) interface{} {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.AddPet(ctx, request.(AddPetRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "AddPet")
 	}
 
-	response := handler(r.Context(), w, r, request)
+	response, err := handler(r.Context(), w, r, request)
 
-	switch v := response.(type) {
-	case AddPet200JSONResponse:
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		writeJSON(w, v)
-	case AddPetdefaultJSONResponse:
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(v.StatusCode)
-		writeJSON(w, v)
-	case error:
-		sh.options.ResponseErrorHandlerFunc(w, r, v)
-	case nil:
-	default:
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", v))
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(AddPetResponseObject); ok {
+		if err := validResponse.VisitAddPetResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
 	}
 }
 
@@ -471,27 +497,21 @@ func (sh *strictHandler) DeletePet(w http.ResponseWriter, r *http.Request, id in
 
 	request.Id = id
 
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) interface{} {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.DeletePet(ctx, request.(DeletePetRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "DeletePet")
 	}
 
-	response := handler(r.Context(), w, r, request)
+	response, err := handler(r.Context(), w, r, request)
 
-	switch v := response.(type) {
-	case DeletePet204Response:
-		w.WriteHeader(204)
-	case DeletePetdefaultJSONResponse:
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(v.StatusCode)
-		writeJSON(w, v)
-	case error:
-		sh.options.ResponseErrorHandlerFunc(w, r, v)
-	case nil:
-	default:
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", v))
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DeletePetResponseObject); ok {
+		if err := validResponse.VisitDeletePetResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
 	}
 }
 
@@ -501,41 +521,21 @@ func (sh *strictHandler) FindPetByID(w http.ResponseWriter, r *http.Request, id 
 
 	request.Id = id
 
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) interface{} {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.FindPetByID(ctx, request.(FindPetByIDRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "FindPetByID")
 	}
 
-	response := handler(r.Context(), w, r, request)
+	response, err := handler(r.Context(), w, r, request)
 
-	switch v := response.(type) {
-	case FindPetByID200JSONResponse:
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		writeJSON(w, v)
-	case FindPetByIDdefaultJSONResponse:
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(v.StatusCode)
-		writeJSON(w, v)
-	case error:
-		sh.options.ResponseErrorHandlerFunc(w, r, v)
-	case nil:
-	default:
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", v))
-	}
-}
-
-func writeJSON(w http.ResponseWriter, v interface{}) {
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		fmt.Fprintln(w, err)
-	}
-}
-
-func writeRaw(w http.ResponseWriter, b []byte) {
-	if _, err := w.Write(b); err != nil {
-		fmt.Fprintln(w, err)
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(FindPetByIDResponseObject); ok {
+		if err := validResponse.VisitFindPetByIDResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
 	}
 }
 

--- a/examples/petstore-expanded/strict/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/strict/api/petstore-server.gen.go
@@ -459,6 +459,8 @@ func (sh *strictHandler) FindPets(w http.ResponseWriter, r *http.Request, params
 		if err := validResponse.VisitFindPetsResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -488,6 +490,8 @@ func (sh *strictHandler) AddPet(w http.ResponseWriter, r *http.Request) {
 		if err := validResponse.VisitAddPetResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -512,6 +516,8 @@ func (sh *strictHandler) DeletePet(w http.ResponseWriter, r *http.Request, id in
 		if err := validResponse.VisitDeletePetResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -536,6 +542,8 @@ func (sh *strictHandler) FindPetByID(w http.ResponseWriter, r *http.Request, id 
 		if err := validResponse.VisitFindPetByIDResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 

--- a/examples/petstore-expanded/strict/api/petstore.go
+++ b/examples/petstore-expanded/strict/api/petstore.go
@@ -28,7 +28,7 @@ func NewPetStore() *PetStore {
 }
 
 // Here, we implement all of the handlers in the ServerInterface
-func (p *PetStore) FindPets(ctx context.Context, request FindPetsRequestObject) interface{} {
+func (p *PetStore) FindPets(ctx context.Context, request FindPetsRequestObject) (FindPetsResponseObject, error) {
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
@@ -56,10 +56,10 @@ func (p *PetStore) FindPets(ctx context.Context, request FindPetsRequestObject) 
 		}
 	}
 
-	return FindPets200JSONResponse(result)
+	return FindPets200JSONResponse(result), nil
 }
 
-func (p *PetStore) AddPet(ctx context.Context, request AddPetRequestObject) interface{} {
+func (p *PetStore) AddPet(ctx context.Context, request AddPetRequestObject) (AddPetResponseObject, error) {
 	// We now have a pet, let's add it to our "database".
 	// We're always asynchronous, so lock unsafe operations below
 	p.Lock.Lock()
@@ -76,30 +76,30 @@ func (p *PetStore) AddPet(ctx context.Context, request AddPetRequestObject) inte
 	p.Pets[pet.Id] = pet
 
 	// Now, we have to return the NewPet
-	return AddPet200JSONResponse(pet)
+	return AddPet200JSONResponse(pet), nil
 }
 
-func (p *PetStore) FindPetByID(ctx context.Context, request FindPetByIDRequestObject) interface{} {
+func (p *PetStore) FindPetByID(ctx context.Context, request FindPetByIDRequestObject) (FindPetByIDResponseObject, error) {
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
 	pet, found := p.Pets[request.Id]
 	if !found {
-		return FindPetByIDdefaultJSONResponse{StatusCode: http.StatusNotFound, Body: Error{Code: http.StatusNotFound, Message: fmt.Sprintf("Could not find pet with ID %d", request.Id)}}
+		return FindPetByIDdefaultJSONResponse{StatusCode: http.StatusNotFound, Body: Error{Code: http.StatusNotFound, Message: fmt.Sprintf("Could not find pet with ID %d", request.Id)}}, nil
 	}
 
-	return FindPetByID200JSONResponse(pet)
+	return FindPetByID200JSONResponse(pet), nil
 }
 
-func (p *PetStore) DeletePet(ctx context.Context, request DeletePetRequestObject) interface{} {
+func (p *PetStore) DeletePet(ctx context.Context, request DeletePetRequestObject) (DeletePetResponseObject, error) {
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
 	_, found := p.Pets[request.Id]
 	if !found {
-		return DeletePetdefaultJSONResponse{StatusCode: http.StatusNotFound, Body: Error{Code: http.StatusNotFound, Message: fmt.Sprintf("Could not find pet with ID %d", request.Id)}}
+		return DeletePetdefaultJSONResponse{StatusCode: http.StatusNotFound, Body: Error{Code: http.StatusNotFound, Message: fmt.Sprintf("Could not find pet with ID %d", request.Id)}}, nil
 	}
 	delete(p.Pets, request.Id)
 
-	return DeletePet204Response{}
+	return DeletePet204Response{}, nil
 }

--- a/internal/test/strict-server/chi/server.gen.go
+++ b/internal/test/strict-server/chi/server.gen.go
@@ -404,36 +404,72 @@ type ReusableresponseJSONResponse struct {
 	Headers ReusableresponseResponseHeaders
 }
 
-func (t ReusableresponseJSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Body)
-}
-
 type JSONExampleRequestObject struct {
 	Body *JSONExampleJSONRequestBody
 }
 
+type JSONExampleResponseObject interface {
+	VisitJSONExampleResponse(w http.ResponseWriter) error
+}
+
 type JSONExample200JSONResponse Example
 
-func (t JSONExample200JSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal((Example)(t))
+func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
 }
 
 type JSONExample400Response = BadrequestResponse
 
+func (response JSONExample400Response) VisitJSONExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
+
 type JSONExampledefaultResponse struct {
 	StatusCode int
+}
+
+func (response JSONExampledefaultResponse) VisitJSONExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
 }
 
 type MultipartExampleRequestObject struct {
 	Body *multipart.Reader
 }
 
+type MultipartExampleResponseObject interface {
+	VisitMultipartExampleResponse(w http.ResponseWriter) error
+}
+
 type MultipartExample200MultipartResponse func(writer *multipart.Writer) error
+
+func (response MultipartExample200MultipartResponse) VisitMultipartExampleResponse(w http.ResponseWriter) error {
+	writer := multipart.NewWriter(w)
+	w.Header().Set("Content-Type", writer.FormDataContentType())
+	w.WriteHeader(200)
+
+	defer writer.Close()
+	return response(writer)
+}
 
 type MultipartExample400Response = BadrequestResponse
 
+func (response MultipartExample400Response) VisitMultipartExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
+
 type MultipartExampledefaultResponse struct {
 	StatusCode int
+}
+
+func (response MultipartExampledefaultResponse) VisitMultipartExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
 }
 
 type MultipleRequestAndResponseTypesRequestObject struct {
@@ -444,51 +480,155 @@ type MultipleRequestAndResponseTypesRequestObject struct {
 	TextBody      *MultipleRequestAndResponseTypesTextRequestBody
 }
 
+type MultipleRequestAndResponseTypesResponseObject interface {
+	VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error
+}
+
 type MultipleRequestAndResponseTypes200JSONResponse Example
 
-func (t MultipleRequestAndResponseTypes200JSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal((Example)(t))
+func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
 }
 
 type MultipleRequestAndResponseTypes200FormdataResponse Example
+
+func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+	w.WriteHeader(200)
+
+	if form, err := runtime.MarshalForm(response, nil); err != nil {
+		return err
+	} else {
+		_, err := w.Write([]byte(form.Encode()))
+		return err
+	}
+}
 
 type MultipleRequestAndResponseTypes200ImagepngResponse struct {
 	Body          io.Reader
 	ContentLength int64
 }
 
+func (response MultipleRequestAndResponseTypes200ImagepngResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "image/png")
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
 type MultipleRequestAndResponseTypes200MultipartResponse func(writer *multipart.Writer) error
+
+func (response MultipleRequestAndResponseTypes200MultipartResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	writer := multipart.NewWriter(w)
+	w.Header().Set("Content-Type", writer.FormDataContentType())
+	w.WriteHeader(200)
+
+	defer writer.Close()
+	return response(writer)
+}
 
 type MultipleRequestAndResponseTypes200TextResponse string
 
+func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(200)
+
+	_, err := w.Write([]byte(response))
+	return err
+}
+
 type MultipleRequestAndResponseTypes400Response = BadrequestResponse
+
+func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type ReusableResponsesRequestObject struct {
 	Body *ReusableResponsesJSONRequestBody
 }
 
+type ReusableResponsesResponseObject interface {
+	VisitReusableResponsesResponse(w http.ResponseWriter) error
+}
+
 type ReusableResponses200JSONResponse = ReusableresponseJSONResponse
+
+func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(w http.ResponseWriter) error {
+	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
+	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response.Body)
+}
 
 type ReusableResponses400Response = BadrequestResponse
 
+func (response ReusableResponses400Response) VisitReusableResponsesResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
+
 type ReusableResponsesdefaultResponse struct {
 	StatusCode int
+}
+
+func (response ReusableResponsesdefaultResponse) VisitReusableResponsesResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
 }
 
 type TextExampleRequestObject struct {
 	Body *TextExampleTextRequestBody
 }
 
+type TextExampleResponseObject interface {
+	VisitTextExampleResponse(w http.ResponseWriter) error
+}
+
 type TextExample200TextResponse string
 
+func (response TextExample200TextResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(200)
+
+	_, err := w.Write([]byte(response))
+	return err
+}
+
 type TextExample400Response = BadrequestResponse
+
+func (response TextExample400Response) VisitTextExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type TextExampledefaultResponse struct {
 	StatusCode int
 }
 
+func (response TextExampledefaultResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
+}
+
 type UnknownExampleRequestObject struct {
 	Body io.Reader
+}
+
+type UnknownExampleResponseObject interface {
+	VisitUnknownExampleResponse(w http.ResponseWriter) error
 }
 
 type UnknownExample200Videomp4Response struct {
@@ -496,15 +636,43 @@ type UnknownExample200Videomp4Response struct {
 	ContentLength int64
 }
 
+func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "video/mp4")
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
 type UnknownExample400Response = BadrequestResponse
+
+func (response UnknownExample400Response) VisitUnknownExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type UnknownExampledefaultResponse struct {
 	StatusCode int
 }
 
+func (response UnknownExampledefaultResponse) VisitUnknownExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
+}
+
 type UnspecifiedContentTypeRequestObject struct {
 	ContentType string
 	Body        io.Reader
+}
+
+type UnspecifiedContentTypeResponseObject interface {
+	VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error
 }
 
 type UnspecifiedContentType200VideoResponse struct {
@@ -513,33 +681,97 @@ type UnspecifiedContentType200VideoResponse struct {
 	ContentLength int64
 }
 
+func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", response.ContentType)
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
 type UnspecifiedContentType400Response = BadrequestResponse
+
+func (response UnspecifiedContentType400Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type UnspecifiedContentType401Response struct {
 }
 
+func (response UnspecifiedContentType401Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.WriteHeader(401)
+	return nil
+}
+
 type UnspecifiedContentType403Response struct {
+}
+
+func (response UnspecifiedContentType403Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.WriteHeader(403)
+	return nil
 }
 
 type UnspecifiedContentTypedefaultResponse struct {
 	StatusCode int
 }
 
+func (response UnspecifiedContentTypedefaultResponse) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
+}
+
 type URLEncodedExampleRequestObject struct {
 	Body *URLEncodedExampleFormdataRequestBody
 }
 
+type URLEncodedExampleResponseObject interface {
+	VisitURLEncodedExampleResponse(w http.ResponseWriter) error
+}
+
 type URLEncodedExample200FormdataResponse Example
 
+func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+	w.WriteHeader(200)
+
+	if form, err := runtime.MarshalForm(response, nil); err != nil {
+		return err
+	} else {
+		_, err := w.Write([]byte(form.Encode()))
+		return err
+	}
+}
+
 type URLEncodedExample400Response = BadrequestResponse
+
+func (response URLEncodedExample400Response) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type URLEncodedExampledefaultResponse struct {
 	StatusCode int
 }
 
+func (response URLEncodedExampledefaultResponse) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
+}
+
 type HeadersExampleRequestObject struct {
 	Params HeadersExampleParams
 	Body   *HeadersExampleJSONRequestBody
+}
+
+type HeadersExampleResponseObject interface {
+	VisitHeadersExampleResponse(w http.ResponseWriter) error
 }
 
 type HeadersExample200ResponseHeaders struct {
@@ -552,48 +784,63 @@ type HeadersExample200JSONResponse struct {
 	Headers HeadersExample200ResponseHeaders
 }
 
-func (t HeadersExample200JSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Body)
+func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
+	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response.Body)
 }
 
 type HeadersExample400Response = BadrequestResponse
 
+func (response HeadersExample400Response) VisitHeadersExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
+
 type HeadersExampledefaultResponse struct {
 	StatusCode int
+}
+
+func (response HeadersExampledefaultResponse) VisitHeadersExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
 }
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
 
 	// (POST /json)
-	JSONExample(ctx context.Context, request JSONExampleRequestObject) interface{}
+	JSONExample(ctx context.Context, request JSONExampleRequestObject) (JSONExampleResponseObject, error)
 
 	// (POST /multipart)
-	MultipartExample(ctx context.Context, request MultipartExampleRequestObject) interface{}
+	MultipartExample(ctx context.Context, request MultipartExampleRequestObject) (MultipartExampleResponseObject, error)
 
 	// (POST /multiple)
-	MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) interface{}
+	MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) (MultipleRequestAndResponseTypesResponseObject, error)
 
 	// (POST /reusable-responses)
-	ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) interface{}
+	ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) (ReusableResponsesResponseObject, error)
 
 	// (POST /text)
-	TextExample(ctx context.Context, request TextExampleRequestObject) interface{}
+	TextExample(ctx context.Context, request TextExampleRequestObject) (TextExampleResponseObject, error)
 
 	// (POST /unknown)
-	UnknownExample(ctx context.Context, request UnknownExampleRequestObject) interface{}
+	UnknownExample(ctx context.Context, request UnknownExampleRequestObject) (UnknownExampleResponseObject, error)
 
 	// (POST /unspecified-content-type)
-	UnspecifiedContentType(ctx context.Context, request UnspecifiedContentTypeRequestObject) interface{}
+	UnspecifiedContentType(ctx context.Context, request UnspecifiedContentTypeRequestObject) (UnspecifiedContentTypeResponseObject, error)
 
 	// (POST /urlencoded)
-	URLEncodedExample(ctx context.Context, request URLEncodedExampleRequestObject) interface{}
+	URLEncodedExample(ctx context.Context, request URLEncodedExampleRequestObject) (URLEncodedExampleResponseObject, error)
 
 	// (POST /with-headers)
-	HeadersExample(ctx context.Context, request HeadersExampleRequestObject) interface{}
+	HeadersExample(ctx context.Context, request HeadersExampleRequestObject) (HeadersExampleResponseObject, error)
 }
 
-type StrictHandlerFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, args interface{}) interface{}
+type StrictHandlerFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, args interface{}) (interface{}, error)
 
 type StrictMiddlewareFunc func(f StrictHandlerFunc, operationID string) StrictHandlerFunc
 
@@ -634,29 +881,21 @@ func (sh *strictHandler) JSONExample(w http.ResponseWriter, r *http.Request) {
 	}
 	request.Body = &body
 
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) interface{} {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.JSONExample(ctx, request.(JSONExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "JSONExample")
 	}
 
-	response := handler(r.Context(), w, r, request)
+	response, err := handler(r.Context(), w, r, request)
 
-	switch v := response.(type) {
-	case JSONExample200JSONResponse:
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		writeJSON(w, v)
-	case JSONExample400Response:
-		w.WriteHeader(400)
-	case JSONExampledefaultResponse:
-		w.WriteHeader(v.StatusCode)
-	case error:
-		sh.options.ResponseErrorHandlerFunc(w, r, v)
-	case nil:
-	default:
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", v))
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(JSONExampleResponseObject); ok {
+		if err := validResponse.VisitJSONExampleResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
 	}
 }
 
@@ -671,33 +910,21 @@ func (sh *strictHandler) MultipartExample(w http.ResponseWriter, r *http.Request
 		request.Body = reader
 	}
 
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) interface{} {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.MultipartExample(ctx, request.(MultipartExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "MultipartExample")
 	}
 
-	response := handler(r.Context(), w, r, request)
+	response, err := handler(r.Context(), w, r, request)
 
-	switch v := response.(type) {
-	case MultipartExample200MultipartResponse:
-		writer := multipart.NewWriter(w)
-		w.Header().Set("Content-Type", writer.FormDataContentType())
-		w.WriteHeader(200)
-		defer writer.Close()
-		if err := v(writer); err != nil {
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(MultipartExampleResponseObject); ok {
+		if err := validResponse.VisitMultipartExampleResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
-	case MultipartExample400Response:
-		w.WriteHeader(400)
-	case MultipartExampledefaultResponse:
-		w.WriteHeader(v.StatusCode)
-	case error:
-		sh.options.ResponseErrorHandlerFunc(w, r, v)
-	case nil:
-	default:
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", v))
 	}
 }
 
@@ -746,57 +973,21 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(w http.ResponseWriter, 
 		request.TextBody = &body
 	}
 
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) interface{} {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.MultipleRequestAndResponseTypes(ctx, request.(MultipleRequestAndResponseTypesRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "MultipleRequestAndResponseTypes")
 	}
 
-	response := handler(r.Context(), w, r, request)
+	response, err := handler(r.Context(), w, r, request)
 
-	switch v := response.(type) {
-	case MultipleRequestAndResponseTypes200JSONResponse:
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		writeJSON(w, v)
-	case MultipleRequestAndResponseTypes200FormdataResponse:
-		w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-		w.WriteHeader(200)
-		if form, err := runtime.MarshalForm(v, nil); err != nil {
-			fmt.Fprintln(w, err)
-		} else {
-			writeRaw(w, []byte(form.Encode()))
-		}
-	case MultipleRequestAndResponseTypes200ImagepngResponse:
-		w.Header().Set("Content-Type", "image/png")
-		if v.ContentLength != 0 {
-			w.Header().Set("Content-Length", fmt.Sprint(v.ContentLength))
-		}
-		w.WriteHeader(200)
-		if closer, ok := v.Body.(io.ReadCloser); ok {
-			defer closer.Close()
-		}
-		_, _ = io.Copy(w, v.Body)
-	case MultipleRequestAndResponseTypes200MultipartResponse:
-		writer := multipart.NewWriter(w)
-		w.Header().Set("Content-Type", writer.FormDataContentType())
-		w.WriteHeader(200)
-		defer writer.Close()
-		if err := v(writer); err != nil {
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(MultipleRequestAndResponseTypesResponseObject); ok {
+		if err := validResponse.VisitMultipleRequestAndResponseTypesResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
-	case MultipleRequestAndResponseTypes200TextResponse:
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(200)
-		writeRaw(w, ([]byte)(v))
-	case MultipleRequestAndResponseTypes400Response:
-		w.WriteHeader(400)
-	case error:
-		sh.options.ResponseErrorHandlerFunc(w, r, v)
-	case nil:
-	default:
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", v))
 	}
 }
 
@@ -811,31 +1002,21 @@ func (sh *strictHandler) ReusableResponses(w http.ResponseWriter, r *http.Reques
 	}
 	request.Body = &body
 
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) interface{} {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.ReusableResponses(ctx, request.(ReusableResponsesRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "ReusableResponses")
 	}
 
-	response := handler(r.Context(), w, r, request)
+	response, err := handler(r.Context(), w, r, request)
 
-	switch v := response.(type) {
-	case ReusableResponses200JSONResponse:
-		w.Header().Set("header1", fmt.Sprint(v.Headers.Header1))
-		w.Header().Set("header2", fmt.Sprint(v.Headers.Header2))
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		writeJSON(w, v)
-	case ReusableResponses400Response:
-		w.WriteHeader(400)
-	case ReusableResponsesdefaultResponse:
-		w.WriteHeader(v.StatusCode)
-	case error:
-		sh.options.ResponseErrorHandlerFunc(w, r, v)
-	case nil:
-	default:
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", v))
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ReusableResponsesResponseObject); ok {
+		if err := validResponse.VisitReusableResponsesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
 	}
 }
 
@@ -851,29 +1032,21 @@ func (sh *strictHandler) TextExample(w http.ResponseWriter, r *http.Request) {
 	body := TextExampleTextRequestBody(data)
 	request.Body = &body
 
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) interface{} {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.TextExample(ctx, request.(TextExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "TextExample")
 	}
 
-	response := handler(r.Context(), w, r, request)
+	response, err := handler(r.Context(), w, r, request)
 
-	switch v := response.(type) {
-	case TextExample200TextResponse:
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(200)
-		writeRaw(w, ([]byte)(v))
-	case TextExample400Response:
-		w.WriteHeader(400)
-	case TextExampledefaultResponse:
-		w.WriteHeader(v.StatusCode)
-	case error:
-		sh.options.ResponseErrorHandlerFunc(w, r, v)
-	case nil:
-	default:
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", v))
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(TextExampleResponseObject); ok {
+		if err := validResponse.VisitTextExampleResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
 	}
 }
 
@@ -883,35 +1056,21 @@ func (sh *strictHandler) UnknownExample(w http.ResponseWriter, r *http.Request) 
 
 	request.Body = r.Body
 
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) interface{} {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.UnknownExample(ctx, request.(UnknownExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "UnknownExample")
 	}
 
-	response := handler(r.Context(), w, r, request)
+	response, err := handler(r.Context(), w, r, request)
 
-	switch v := response.(type) {
-	case UnknownExample200Videomp4Response:
-		w.Header().Set("Content-Type", "video/mp4")
-		if v.ContentLength != 0 {
-			w.Header().Set("Content-Length", fmt.Sprint(v.ContentLength))
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(UnknownExampleResponseObject); ok {
+		if err := validResponse.VisitUnknownExampleResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
-		w.WriteHeader(200)
-		if closer, ok := v.Body.(io.ReadCloser); ok {
-			defer closer.Close()
-		}
-		_, _ = io.Copy(w, v.Body)
-	case UnknownExample400Response:
-		w.WriteHeader(400)
-	case UnknownExampledefaultResponse:
-		w.WriteHeader(v.StatusCode)
-	case error:
-		sh.options.ResponseErrorHandlerFunc(w, r, v)
-	case nil:
-	default:
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", v))
 	}
 }
 
@@ -923,39 +1082,21 @@ func (sh *strictHandler) UnspecifiedContentType(w http.ResponseWriter, r *http.R
 
 	request.Body = r.Body
 
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) interface{} {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.UnspecifiedContentType(ctx, request.(UnspecifiedContentTypeRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "UnspecifiedContentType")
 	}
 
-	response := handler(r.Context(), w, r, request)
+	response, err := handler(r.Context(), w, r, request)
 
-	switch v := response.(type) {
-	case UnspecifiedContentType200VideoResponse:
-		w.Header().Set("Content-Type", v.ContentType)
-		if v.ContentLength != 0 {
-			w.Header().Set("Content-Length", fmt.Sprint(v.ContentLength))
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(UnspecifiedContentTypeResponseObject); ok {
+		if err := validResponse.VisitUnspecifiedContentTypeResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
-		w.WriteHeader(200)
-		if closer, ok := v.Body.(io.ReadCloser); ok {
-			defer closer.Close()
-		}
-		_, _ = io.Copy(w, v.Body)
-	case UnspecifiedContentType400Response:
-		w.WriteHeader(400)
-	case UnspecifiedContentType401Response:
-		w.WriteHeader(401)
-	case UnspecifiedContentType403Response:
-		w.WriteHeader(403)
-	case UnspecifiedContentTypedefaultResponse:
-		w.WriteHeader(v.StatusCode)
-	case error:
-		sh.options.ResponseErrorHandlerFunc(w, r, v)
-	case nil:
-	default:
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", v))
 	}
 }
 
@@ -974,33 +1115,21 @@ func (sh *strictHandler) URLEncodedExample(w http.ResponseWriter, r *http.Reques
 	}
 	request.Body = &body
 
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) interface{} {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.URLEncodedExample(ctx, request.(URLEncodedExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "URLEncodedExample")
 	}
 
-	response := handler(r.Context(), w, r, request)
+	response, err := handler(r.Context(), w, r, request)
 
-	switch v := response.(type) {
-	case URLEncodedExample200FormdataResponse:
-		w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
-		w.WriteHeader(200)
-		if form, err := runtime.MarshalForm(v, nil); err != nil {
-			fmt.Fprintln(w, err)
-		} else {
-			writeRaw(w, []byte(form.Encode()))
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(URLEncodedExampleResponseObject); ok {
+		if err := validResponse.VisitURLEncodedExampleResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
-	case URLEncodedExample400Response:
-		w.WriteHeader(400)
-	case URLEncodedExampledefaultResponse:
-		w.WriteHeader(v.StatusCode)
-	case error:
-		sh.options.ResponseErrorHandlerFunc(w, r, v)
-	case nil:
-	default:
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", v))
 	}
 }
 
@@ -1017,43 +1146,21 @@ func (sh *strictHandler) HeadersExample(w http.ResponseWriter, r *http.Request, 
 	}
 	request.Body = &body
 
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) interface{} {
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.HeadersExample(ctx, request.(HeadersExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "HeadersExample")
 	}
 
-	response := handler(r.Context(), w, r, request)
+	response, err := handler(r.Context(), w, r, request)
 
-	switch v := response.(type) {
-	case HeadersExample200JSONResponse:
-		w.Header().Set("header1", fmt.Sprint(v.Headers.Header1))
-		w.Header().Set("header2", fmt.Sprint(v.Headers.Header2))
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		writeJSON(w, v)
-	case HeadersExample400Response:
-		w.WriteHeader(400)
-	case HeadersExampledefaultResponse:
-		w.WriteHeader(v.StatusCode)
-	case error:
-		sh.options.ResponseErrorHandlerFunc(w, r, v)
-	case nil:
-	default:
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", v))
-	}
-}
-
-func writeJSON(w http.ResponseWriter, v interface{}) {
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		fmt.Fprintln(w, err)
-	}
-}
-
-func writeRaw(w http.ResponseWriter, b []byte) {
-	if _, err := w.Write(b); err != nil {
-		fmt.Fprintln(w, err)
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(HeadersExampleResponseObject); ok {
+		if err := validResponse.VisitHeadersExampleResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
 	}
 }
 

--- a/internal/test/strict-server/chi/server.gen.go
+++ b/internal/test/strict-server/chi/server.gen.go
@@ -896,6 +896,8 @@ func (sh *strictHandler) JSONExample(w http.ResponseWriter, r *http.Request) {
 		if err := validResponse.VisitJSONExampleResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -925,6 +927,8 @@ func (sh *strictHandler) MultipartExample(w http.ResponseWriter, r *http.Request
 		if err := validResponse.VisitMultipartExampleResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -988,6 +992,8 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(w http.ResponseWriter, 
 		if err := validResponse.VisitMultipleRequestAndResponseTypesResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -1017,6 +1023,8 @@ func (sh *strictHandler) ReusableResponses(w http.ResponseWriter, r *http.Reques
 		if err := validResponse.VisitReusableResponsesResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -1047,6 +1055,8 @@ func (sh *strictHandler) TextExample(w http.ResponseWriter, r *http.Request) {
 		if err := validResponse.VisitTextExampleResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -1071,6 +1081,8 @@ func (sh *strictHandler) UnknownExample(w http.ResponseWriter, r *http.Request) 
 		if err := validResponse.VisitUnknownExampleResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -1097,6 +1109,8 @@ func (sh *strictHandler) UnspecifiedContentType(w http.ResponseWriter, r *http.R
 		if err := validResponse.VisitUnspecifiedContentTypeResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -1130,6 +1144,8 @@ func (sh *strictHandler) URLEncodedExample(w http.ResponseWriter, r *http.Reques
 		if err := validResponse.VisitURLEncodedExampleResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -1161,6 +1177,8 @@ func (sh *strictHandler) HeadersExample(w http.ResponseWriter, r *http.Request, 
 		if err := validResponse.VisitHeadersExampleResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 

--- a/internal/test/strict-server/chi/server.go
+++ b/internal/test/strict-server/chi/server.go
@@ -12,11 +12,11 @@ import (
 type StrictServer struct {
 }
 
-func (s StrictServer) JSONExample(ctx context.Context, request JSONExampleRequestObject) interface{} {
-	return JSONExample200JSONResponse(*request.Body)
+func (s StrictServer) JSONExample(ctx context.Context, request JSONExampleRequestObject) (JSONExampleResponseObject, error) {
+	return JSONExample200JSONResponse(*request.Body), nil
 }
 
-func (s StrictServer) MultipartExample(ctx context.Context, request MultipartExampleRequestObject) interface{} {
+func (s StrictServer) MultipartExample(ctx context.Context, request MultipartExampleRequestObject) (MultipartExampleResponseObject, error) {
 	return MultipartExample200MultipartResponse(func(writer *multipart.Writer) error {
 		for {
 			part, err := request.Body.NextPart()
@@ -37,19 +37,19 @@ func (s StrictServer) MultipartExample(ctx context.Context, request MultipartExa
 				return err
 			}
 		}
-	})
+	}), nil
 }
 
-func (s StrictServer) MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) interface{} {
+func (s StrictServer) MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) (MultipleRequestAndResponseTypesResponseObject, error) {
 	switch {
 	case request.Body != nil:
-		return MultipleRequestAndResponseTypes200ImagepngResponse{Body: request.Body}
+		return MultipleRequestAndResponseTypes200ImagepngResponse{Body: request.Body}, nil
 	case request.JSONBody != nil:
-		return MultipleRequestAndResponseTypes200JSONResponse(*request.JSONBody)
+		return MultipleRequestAndResponseTypes200JSONResponse(*request.JSONBody), nil
 	case request.FormdataBody != nil:
-		return MultipleRequestAndResponseTypes200FormdataResponse(*request.FormdataBody)
+		return MultipleRequestAndResponseTypes200FormdataResponse(*request.FormdataBody), nil
 	case request.TextBody != nil:
-		return MultipleRequestAndResponseTypes200TextResponse(*request.TextBody)
+		return MultipleRequestAndResponseTypes200TextResponse(*request.TextBody), nil
 	case request.MultipartBody != nil:
 		return MultipleRequestAndResponseTypes200MultipartResponse(func(writer *multipart.Writer) error {
 			for {
@@ -71,32 +71,32 @@ func (s StrictServer) MultipleRequestAndResponseTypes(ctx context.Context, reque
 					return err
 				}
 			}
-		})
+		}), nil
 	default:
-		return MultipleRequestAndResponseTypes400Response{}
+		return MultipleRequestAndResponseTypes400Response{}, nil
 	}
 }
 
-func (s StrictServer) TextExample(ctx context.Context, request TextExampleRequestObject) interface{} {
-	return TextExample200TextResponse(*request.Body)
+func (s StrictServer) TextExample(ctx context.Context, request TextExampleRequestObject) (TextExampleResponseObject, error) {
+	return TextExample200TextResponse(*request.Body), nil
 }
 
-func (s StrictServer) UnknownExample(ctx context.Context, request UnknownExampleRequestObject) interface{} {
-	return UnknownExample200Videomp4Response{Body: request.Body}
+func (s StrictServer) UnknownExample(ctx context.Context, request UnknownExampleRequestObject) (UnknownExampleResponseObject, error) {
+	return UnknownExample200Videomp4Response{Body: request.Body}, nil
 }
 
-func (s StrictServer) UnspecifiedContentType(ctx context.Context, request UnspecifiedContentTypeRequestObject) interface{} {
-	return UnspecifiedContentType200VideoResponse{Body: request.Body, ContentType: request.ContentType}
+func (s StrictServer) UnspecifiedContentType(ctx context.Context, request UnspecifiedContentTypeRequestObject) (UnspecifiedContentTypeResponseObject, error) {
+	return UnspecifiedContentType200VideoResponse{Body: request.Body, ContentType: request.ContentType}, nil
 }
 
-func (s StrictServer) URLEncodedExample(ctx context.Context, request URLEncodedExampleRequestObject) interface{} {
-	return URLEncodedExample200FormdataResponse(*request.Body)
+func (s StrictServer) URLEncodedExample(ctx context.Context, request URLEncodedExampleRequestObject) (URLEncodedExampleResponseObject, error) {
+	return URLEncodedExample200FormdataResponse(*request.Body), nil
 }
 
-func (s StrictServer) HeadersExample(ctx context.Context, request HeadersExampleRequestObject) interface{} {
-	return HeadersExample200JSONResponse{Body: Example(*request.Body), Headers: HeadersExample200ResponseHeaders{Header1: request.Params.Header1, Header2: *request.Params.Header2}}
+func (s StrictServer) HeadersExample(ctx context.Context, request HeadersExampleRequestObject) (HeadersExampleResponseObject, error) {
+	return HeadersExample200JSONResponse{Body: Example(*request.Body), Headers: HeadersExample200ResponseHeaders{Header1: request.Params.Header1, Header2: *request.Params.Header2}}, nil
 }
 
-func (s StrictServer) ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) interface{} {
-	return ReusableResponses200JSONResponse{Body: *request.Body}
+func (s StrictServer) ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) (ReusableResponsesResponseObject, error) {
+	return ReusableResponses200JSONResponse{Body: *request.Body}, nil
 }

--- a/internal/test/strict-server/echo/server.gen.go
+++ b/internal/test/strict-server/echo/server.gen.go
@@ -701,9 +701,9 @@ func (sh *strictHandler) JSONExample(ctx echo.Context) error {
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(JSONExampleResponseObject); ok {
-		if err := validResponse.VisitJSONExampleResponse(ctx.Response()); err != nil {
-			return err
-		}
+		return validResponse.VisitJSONExampleResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("Unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -730,9 +730,9 @@ func (sh *strictHandler) MultipartExample(ctx echo.Context) error {
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(MultipartExampleResponseObject); ok {
-		if err := validResponse.VisitMultipartExampleResponse(ctx.Response()); err != nil {
-			return err
-		}
+		return validResponse.VisitMultipartExampleResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("Unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -790,9 +790,9 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx echo.Context) error
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(MultipleRequestAndResponseTypesResponseObject); ok {
-		if err := validResponse.VisitMultipleRequestAndResponseTypesResponse(ctx.Response()); err != nil {
-			return err
-		}
+		return validResponse.VisitMultipleRequestAndResponseTypesResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("Unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -819,9 +819,9 @@ func (sh *strictHandler) ReusableResponses(ctx echo.Context) error {
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(ReusableResponsesResponseObject); ok {
-		if err := validResponse.VisitReusableResponsesResponse(ctx.Response()); err != nil {
-			return err
-		}
+		return validResponse.VisitReusableResponsesResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("Unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -849,9 +849,9 @@ func (sh *strictHandler) TextExample(ctx echo.Context) error {
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(TextExampleResponseObject); ok {
-		if err := validResponse.VisitTextExampleResponse(ctx.Response()); err != nil {
-			return err
-		}
+		return validResponse.VisitTextExampleResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("Unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -874,9 +874,9 @@ func (sh *strictHandler) UnknownExample(ctx echo.Context) error {
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(UnknownExampleResponseObject); ok {
-		if err := validResponse.VisitUnknownExampleResponse(ctx.Response()); err != nil {
-			return err
-		}
+		return validResponse.VisitUnknownExampleResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("Unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -901,9 +901,9 @@ func (sh *strictHandler) UnspecifiedContentType(ctx echo.Context) error {
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(UnspecifiedContentTypeResponseObject); ok {
-		if err := validResponse.VisitUnspecifiedContentTypeResponse(ctx.Response()); err != nil {
-			return err
-		}
+		return validResponse.VisitUnspecifiedContentTypeResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("Unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -934,9 +934,9 @@ func (sh *strictHandler) URLEncodedExample(ctx echo.Context) error {
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(URLEncodedExampleResponseObject); ok {
-		if err := validResponse.VisitURLEncodedExampleResponse(ctx.Response()); err != nil {
-			return err
-		}
+		return validResponse.VisitURLEncodedExampleResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("Unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -965,9 +965,9 @@ func (sh *strictHandler) HeadersExample(ctx echo.Context, params HeadersExampleP
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(HeadersExampleResponseObject); ok {
-		if err := validResponse.VisitHeadersExampleResponse(ctx.Response()); err != nil {
-			return err
-		}
+		return validResponse.VisitHeadersExampleResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("Unexpected response type: %T", response)
 	}
 	return nil
 }

--- a/internal/test/strict-server/echo/server.gen.go
+++ b/internal/test/strict-server/echo/server.gen.go
@@ -230,36 +230,72 @@ type ReusableresponseJSONResponse struct {
 	Headers ReusableresponseResponseHeaders
 }
 
-func (t ReusableresponseJSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Body)
-}
-
 type JSONExampleRequestObject struct {
 	Body *JSONExampleJSONRequestBody
 }
 
+type JSONExampleResponseObject interface {
+	VisitJSONExampleResponse(w http.ResponseWriter) error
+}
+
 type JSONExample200JSONResponse Example
 
-func (t JSONExample200JSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal((Example)(t))
+func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
 }
 
 type JSONExample400Response = BadrequestResponse
 
+func (response JSONExample400Response) VisitJSONExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
+
 type JSONExampledefaultResponse struct {
 	StatusCode int
+}
+
+func (response JSONExampledefaultResponse) VisitJSONExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
 }
 
 type MultipartExampleRequestObject struct {
 	Body *multipart.Reader
 }
 
+type MultipartExampleResponseObject interface {
+	VisitMultipartExampleResponse(w http.ResponseWriter) error
+}
+
 type MultipartExample200MultipartResponse func(writer *multipart.Writer) error
+
+func (response MultipartExample200MultipartResponse) VisitMultipartExampleResponse(w http.ResponseWriter) error {
+	writer := multipart.NewWriter(w)
+	w.Header().Set("Content-Type", writer.FormDataContentType())
+	w.WriteHeader(200)
+
+	defer writer.Close()
+	return response(writer)
+}
 
 type MultipartExample400Response = BadrequestResponse
 
+func (response MultipartExample400Response) VisitMultipartExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
+
 type MultipartExampledefaultResponse struct {
 	StatusCode int
+}
+
+func (response MultipartExampledefaultResponse) VisitMultipartExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
 }
 
 type MultipleRequestAndResponseTypesRequestObject struct {
@@ -270,51 +306,155 @@ type MultipleRequestAndResponseTypesRequestObject struct {
 	TextBody      *MultipleRequestAndResponseTypesTextRequestBody
 }
 
+type MultipleRequestAndResponseTypesResponseObject interface {
+	VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error
+}
+
 type MultipleRequestAndResponseTypes200JSONResponse Example
 
-func (t MultipleRequestAndResponseTypes200JSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal((Example)(t))
+func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
 }
 
 type MultipleRequestAndResponseTypes200FormdataResponse Example
+
+func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+	w.WriteHeader(200)
+
+	if form, err := runtime.MarshalForm(response, nil); err != nil {
+		return err
+	} else {
+		_, err := w.Write([]byte(form.Encode()))
+		return err
+	}
+}
 
 type MultipleRequestAndResponseTypes200ImagepngResponse struct {
 	Body          io.Reader
 	ContentLength int64
 }
 
+func (response MultipleRequestAndResponseTypes200ImagepngResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "image/png")
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
 type MultipleRequestAndResponseTypes200MultipartResponse func(writer *multipart.Writer) error
+
+func (response MultipleRequestAndResponseTypes200MultipartResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	writer := multipart.NewWriter(w)
+	w.Header().Set("Content-Type", writer.FormDataContentType())
+	w.WriteHeader(200)
+
+	defer writer.Close()
+	return response(writer)
+}
 
 type MultipleRequestAndResponseTypes200TextResponse string
 
+func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(200)
+
+	_, err := w.Write([]byte(response))
+	return err
+}
+
 type MultipleRequestAndResponseTypes400Response = BadrequestResponse
+
+func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type ReusableResponsesRequestObject struct {
 	Body *ReusableResponsesJSONRequestBody
 }
 
+type ReusableResponsesResponseObject interface {
+	VisitReusableResponsesResponse(w http.ResponseWriter) error
+}
+
 type ReusableResponses200JSONResponse = ReusableresponseJSONResponse
+
+func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(w http.ResponseWriter) error {
+	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
+	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response.Body)
+}
 
 type ReusableResponses400Response = BadrequestResponse
 
+func (response ReusableResponses400Response) VisitReusableResponsesResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
+
 type ReusableResponsesdefaultResponse struct {
 	StatusCode int
+}
+
+func (response ReusableResponsesdefaultResponse) VisitReusableResponsesResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
 }
 
 type TextExampleRequestObject struct {
 	Body *TextExampleTextRequestBody
 }
 
+type TextExampleResponseObject interface {
+	VisitTextExampleResponse(w http.ResponseWriter) error
+}
+
 type TextExample200TextResponse string
 
+func (response TextExample200TextResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(200)
+
+	_, err := w.Write([]byte(response))
+	return err
+}
+
 type TextExample400Response = BadrequestResponse
+
+func (response TextExample400Response) VisitTextExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type TextExampledefaultResponse struct {
 	StatusCode int
 }
 
+func (response TextExampledefaultResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
+}
+
 type UnknownExampleRequestObject struct {
 	Body io.Reader
+}
+
+type UnknownExampleResponseObject interface {
+	VisitUnknownExampleResponse(w http.ResponseWriter) error
 }
 
 type UnknownExample200Videomp4Response struct {
@@ -322,15 +462,43 @@ type UnknownExample200Videomp4Response struct {
 	ContentLength int64
 }
 
+func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "video/mp4")
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
 type UnknownExample400Response = BadrequestResponse
+
+func (response UnknownExample400Response) VisitUnknownExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type UnknownExampledefaultResponse struct {
 	StatusCode int
 }
 
+func (response UnknownExampledefaultResponse) VisitUnknownExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
+}
+
 type UnspecifiedContentTypeRequestObject struct {
 	ContentType string
 	Body        io.Reader
+}
+
+type UnspecifiedContentTypeResponseObject interface {
+	VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error
 }
 
 type UnspecifiedContentType200VideoResponse struct {
@@ -339,33 +507,97 @@ type UnspecifiedContentType200VideoResponse struct {
 	ContentLength int64
 }
 
+func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", response.ContentType)
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
 type UnspecifiedContentType400Response = BadrequestResponse
+
+func (response UnspecifiedContentType400Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type UnspecifiedContentType401Response struct {
 }
 
+func (response UnspecifiedContentType401Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.WriteHeader(401)
+	return nil
+}
+
 type UnspecifiedContentType403Response struct {
+}
+
+func (response UnspecifiedContentType403Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.WriteHeader(403)
+	return nil
 }
 
 type UnspecifiedContentTypedefaultResponse struct {
 	StatusCode int
 }
 
+func (response UnspecifiedContentTypedefaultResponse) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
+}
+
 type URLEncodedExampleRequestObject struct {
 	Body *URLEncodedExampleFormdataRequestBody
 }
 
+type URLEncodedExampleResponseObject interface {
+	VisitURLEncodedExampleResponse(w http.ResponseWriter) error
+}
+
 type URLEncodedExample200FormdataResponse Example
 
+func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+	w.WriteHeader(200)
+
+	if form, err := runtime.MarshalForm(response, nil); err != nil {
+		return err
+	} else {
+		_, err := w.Write([]byte(form.Encode()))
+		return err
+	}
+}
+
 type URLEncodedExample400Response = BadrequestResponse
+
+func (response URLEncodedExample400Response) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type URLEncodedExampledefaultResponse struct {
 	StatusCode int
 }
 
+func (response URLEncodedExampledefaultResponse) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
+}
+
 type HeadersExampleRequestObject struct {
 	Params HeadersExampleParams
 	Body   *HeadersExampleJSONRequestBody
+}
+
+type HeadersExampleResponseObject interface {
+	VisitHeadersExampleResponse(w http.ResponseWriter) error
 }
 
 type HeadersExample200ResponseHeaders struct {
@@ -378,48 +610,63 @@ type HeadersExample200JSONResponse struct {
 	Headers HeadersExample200ResponseHeaders
 }
 
-func (t HeadersExample200JSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Body)
+func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
+	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response.Body)
 }
 
 type HeadersExample400Response = BadrequestResponse
 
+func (response HeadersExample400Response) VisitHeadersExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
+
 type HeadersExampledefaultResponse struct {
 	StatusCode int
+}
+
+func (response HeadersExampledefaultResponse) VisitHeadersExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
 }
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
 
 	// (POST /json)
-	JSONExample(ctx context.Context, request JSONExampleRequestObject) interface{}
+	JSONExample(ctx context.Context, request JSONExampleRequestObject) (JSONExampleResponseObject, error)
 
 	// (POST /multipart)
-	MultipartExample(ctx context.Context, request MultipartExampleRequestObject) interface{}
+	MultipartExample(ctx context.Context, request MultipartExampleRequestObject) (MultipartExampleResponseObject, error)
 
 	// (POST /multiple)
-	MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) interface{}
+	MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) (MultipleRequestAndResponseTypesResponseObject, error)
 
 	// (POST /reusable-responses)
-	ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) interface{}
+	ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) (ReusableResponsesResponseObject, error)
 
 	// (POST /text)
-	TextExample(ctx context.Context, request TextExampleRequestObject) interface{}
+	TextExample(ctx context.Context, request TextExampleRequestObject) (TextExampleResponseObject, error)
 
 	// (POST /unknown)
-	UnknownExample(ctx context.Context, request UnknownExampleRequestObject) interface{}
+	UnknownExample(ctx context.Context, request UnknownExampleRequestObject) (UnknownExampleResponseObject, error)
 
 	// (POST /unspecified-content-type)
-	UnspecifiedContentType(ctx context.Context, request UnspecifiedContentTypeRequestObject) interface{}
+	UnspecifiedContentType(ctx context.Context, request UnspecifiedContentTypeRequestObject) (UnspecifiedContentTypeResponseObject, error)
 
 	// (POST /urlencoded)
-	URLEncodedExample(ctx context.Context, request URLEncodedExampleRequestObject) interface{}
+	URLEncodedExample(ctx context.Context, request URLEncodedExampleRequestObject) (URLEncodedExampleResponseObject, error)
 
 	// (POST /with-headers)
-	HeadersExample(ctx context.Context, request HeadersExampleRequestObject) interface{}
+	HeadersExample(ctx context.Context, request HeadersExampleRequestObject) (HeadersExampleResponseObject, error)
 }
 
-type StrictHandlerFunc func(ctx echo.Context, args interface{}) interface{}
+type StrictHandlerFunc func(ctx echo.Context, args interface{}) (interface{}, error)
 
 type StrictMiddlewareFunc func(f StrictHandlerFunc, operationID string) StrictHandlerFunc
 
@@ -442,27 +689,21 @@ func (sh *strictHandler) JSONExample(ctx echo.Context) error {
 	}
 	request.Body = &body
 
-	handler := func(ctx echo.Context, request interface{}) interface{} {
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.JSONExample(ctx.Request().Context(), request.(JSONExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "JSONExample")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case JSONExample200JSONResponse:
-		return ctx.JSON(200, v)
-	case JSONExample400Response:
-		return ctx.NoContent(400)
-	case JSONExampledefaultResponse:
-		return ctx.NoContent(v.StatusCode)
-	case error:
-		return v
-	case nil:
-	default:
-		return fmt.Errorf("Unexpected response type: %T", v)
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(JSONExampleResponseObject); ok {
+		if err := validResponse.VisitJSONExampleResponse(ctx.Response()); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -477,32 +718,21 @@ func (sh *strictHandler) MultipartExample(ctx echo.Context) error {
 		request.Body = reader
 	}
 
-	handler := func(ctx echo.Context, request interface{}) interface{} {
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.MultipartExample(ctx.Request().Context(), request.(MultipartExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "MultipartExample")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case MultipartExample200MultipartResponse:
-		writer := multipart.NewWriter(ctx.Response())
-		ctx.Response().Header().Set("Content-Type", writer.FormDataContentType())
-		defer writer.Close()
-		if err := v(writer); err != nil {
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(MultipartExampleResponseObject); ok {
+		if err := validResponse.VisitMultipartExampleResponse(ctx.Response()); err != nil {
 			return err
 		}
-	case MultipartExample400Response:
-		return ctx.NoContent(400)
-	case MultipartExampledefaultResponse:
-		return ctx.NoContent(v.StatusCode)
-	case error:
-		return v
-	case nil:
-	default:
-		return fmt.Errorf("Unexpected response type: %T", v)
 	}
 	return nil
 }
@@ -548,48 +778,21 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx echo.Context) error
 		request.TextBody = &body
 	}
 
-	handler := func(ctx echo.Context, request interface{}) interface{} {
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.MultipleRequestAndResponseTypes(ctx.Request().Context(), request.(MultipleRequestAndResponseTypesRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "MultipleRequestAndResponseTypes")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case MultipleRequestAndResponseTypes200JSONResponse:
-		return ctx.JSON(200, v)
-	case MultipleRequestAndResponseTypes200FormdataResponse:
-		if form, err := runtime.MarshalForm(v, nil); err != nil {
-			return err
-		} else {
-			return ctx.Blob(200, "application/x-www-form-urlencoded", []byte(form.Encode()))
-		}
-	case MultipleRequestAndResponseTypes200ImagepngResponse:
-		if v.ContentLength != 0 {
-			ctx.Response().Header().Set("Content-Length", fmt.Sprint(v.ContentLength))
-		}
-		if closer, ok := v.Body.(io.ReadCloser); ok {
-			defer closer.Close()
-		}
-		return ctx.Stream(200, "image/png", v.Body)
-	case MultipleRequestAndResponseTypes200MultipartResponse:
-		writer := multipart.NewWriter(ctx.Response())
-		ctx.Response().Header().Set("Content-Type", writer.FormDataContentType())
-		defer writer.Close()
-		if err := v(writer); err != nil {
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(MultipleRequestAndResponseTypesResponseObject); ok {
+		if err := validResponse.VisitMultipleRequestAndResponseTypesResponse(ctx.Response()); err != nil {
 			return err
 		}
-	case MultipleRequestAndResponseTypes200TextResponse:
-		return ctx.Blob(200, "text/plain", []byte(v))
-	case MultipleRequestAndResponseTypes400Response:
-		return ctx.NoContent(400)
-	case error:
-		return v
-	case nil:
-	default:
-		return fmt.Errorf("Unexpected response type: %T", v)
 	}
 	return nil
 }
@@ -604,29 +807,21 @@ func (sh *strictHandler) ReusableResponses(ctx echo.Context) error {
 	}
 	request.Body = &body
 
-	handler := func(ctx echo.Context, request interface{}) interface{} {
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.ReusableResponses(ctx.Request().Context(), request.(ReusableResponsesRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "ReusableResponses")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case ReusableResponses200JSONResponse:
-		ctx.Response().Header().Set("header1", fmt.Sprint(v.Headers.Header1))
-		ctx.Response().Header().Set("header2", fmt.Sprint(v.Headers.Header2))
-		return ctx.JSON(200, v)
-	case ReusableResponses400Response:
-		return ctx.NoContent(400)
-	case ReusableResponsesdefaultResponse:
-		return ctx.NoContent(v.StatusCode)
-	case error:
-		return v
-	case nil:
-	default:
-		return fmt.Errorf("Unexpected response type: %T", v)
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(ReusableResponsesResponseObject); ok {
+		if err := validResponse.VisitReusableResponsesResponse(ctx.Response()); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -642,27 +837,21 @@ func (sh *strictHandler) TextExample(ctx echo.Context) error {
 	body := TextExampleTextRequestBody(data)
 	request.Body = &body
 
-	handler := func(ctx echo.Context, request interface{}) interface{} {
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TextExample(ctx.Request().Context(), request.(TextExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "TextExample")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case TextExample200TextResponse:
-		return ctx.Blob(200, "text/plain", []byte(v))
-	case TextExample400Response:
-		return ctx.NoContent(400)
-	case TextExampledefaultResponse:
-		return ctx.NoContent(v.StatusCode)
-	case error:
-		return v
-	case nil:
-	default:
-		return fmt.Errorf("Unexpected response type: %T", v)
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(TextExampleResponseObject); ok {
+		if err := validResponse.VisitTextExampleResponse(ctx.Response()); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -673,33 +862,21 @@ func (sh *strictHandler) UnknownExample(ctx echo.Context) error {
 
 	request.Body = ctx.Request().Body
 
-	handler := func(ctx echo.Context, request interface{}) interface{} {
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UnknownExample(ctx.Request().Context(), request.(UnknownExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "UnknownExample")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case UnknownExample200Videomp4Response:
-		if v.ContentLength != 0 {
-			ctx.Response().Header().Set("Content-Length", fmt.Sprint(v.ContentLength))
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(UnknownExampleResponseObject); ok {
+		if err := validResponse.VisitUnknownExampleResponse(ctx.Response()); err != nil {
+			return err
 		}
-		if closer, ok := v.Body.(io.ReadCloser); ok {
-			defer closer.Close()
-		}
-		return ctx.Stream(200, "video/mp4", v.Body)
-	case UnknownExample400Response:
-		return ctx.NoContent(400)
-	case UnknownExampledefaultResponse:
-		return ctx.NoContent(v.StatusCode)
-	case error:
-		return v
-	case nil:
-	default:
-		return fmt.Errorf("Unexpected response type: %T", v)
 	}
 	return nil
 }
@@ -712,37 +889,21 @@ func (sh *strictHandler) UnspecifiedContentType(ctx echo.Context) error {
 
 	request.Body = ctx.Request().Body
 
-	handler := func(ctx echo.Context, request interface{}) interface{} {
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UnspecifiedContentType(ctx.Request().Context(), request.(UnspecifiedContentTypeRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "UnspecifiedContentType")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case UnspecifiedContentType200VideoResponse:
-		if v.ContentLength != 0 {
-			ctx.Response().Header().Set("Content-Length", fmt.Sprint(v.ContentLength))
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(UnspecifiedContentTypeResponseObject); ok {
+		if err := validResponse.VisitUnspecifiedContentTypeResponse(ctx.Response()); err != nil {
+			return err
 		}
-		if closer, ok := v.Body.(io.ReadCloser); ok {
-			defer closer.Close()
-		}
-		return ctx.Stream(200, v.ContentType, v.Body)
-	case UnspecifiedContentType400Response:
-		return ctx.NoContent(400)
-	case UnspecifiedContentType401Response:
-		return ctx.NoContent(401)
-	case UnspecifiedContentType403Response:
-		return ctx.NoContent(403)
-	case UnspecifiedContentTypedefaultResponse:
-		return ctx.NoContent(v.StatusCode)
-	case error:
-		return v
-	case nil:
-	default:
-		return fmt.Errorf("Unexpected response type: %T", v)
 	}
 	return nil
 }
@@ -761,31 +922,21 @@ func (sh *strictHandler) URLEncodedExample(ctx echo.Context) error {
 		return err
 	}
 
-	handler := func(ctx echo.Context, request interface{}) interface{} {
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.URLEncodedExample(ctx.Request().Context(), request.(URLEncodedExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "URLEncodedExample")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case URLEncodedExample200FormdataResponse:
-		if form, err := runtime.MarshalForm(v, nil); err != nil {
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(URLEncodedExampleResponseObject); ok {
+		if err := validResponse.VisitURLEncodedExampleResponse(ctx.Response()); err != nil {
 			return err
-		} else {
-			return ctx.Blob(200, "application/x-www-form-urlencoded", []byte(form.Encode()))
 		}
-	case URLEncodedExample400Response:
-		return ctx.NoContent(400)
-	case URLEncodedExampledefaultResponse:
-		return ctx.NoContent(v.StatusCode)
-	case error:
-		return v
-	case nil:
-	default:
-		return fmt.Errorf("Unexpected response type: %T", v)
 	}
 	return nil
 }
@@ -802,29 +953,21 @@ func (sh *strictHandler) HeadersExample(ctx echo.Context, params HeadersExampleP
 	}
 	request.Body = &body
 
-	handler := func(ctx echo.Context, request interface{}) interface{} {
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.HeadersExample(ctx.Request().Context(), request.(HeadersExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "HeadersExample")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case HeadersExample200JSONResponse:
-		ctx.Response().Header().Set("header1", fmt.Sprint(v.Headers.Header1))
-		ctx.Response().Header().Set("header2", fmt.Sprint(v.Headers.Header2))
-		return ctx.JSON(200, v)
-	case HeadersExample400Response:
-		return ctx.NoContent(400)
-	case HeadersExampledefaultResponse:
-		return ctx.NoContent(v.StatusCode)
-	case error:
-		return v
-	case nil:
-	default:
-		return fmt.Errorf("Unexpected response type: %T", v)
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(HeadersExampleResponseObject); ok {
+		if err := validResponse.VisitHeadersExampleResponse(ctx.Response()); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/test/strict-server/echo/server.go
+++ b/internal/test/strict-server/echo/server.go
@@ -12,11 +12,11 @@ import (
 type StrictServer struct {
 }
 
-func (s StrictServer) JSONExample(ctx context.Context, request JSONExampleRequestObject) interface{} {
-	return JSONExample200JSONResponse(*request.Body)
+func (s StrictServer) JSONExample(ctx context.Context, request JSONExampleRequestObject) (JSONExampleResponseObject, error) {
+	return JSONExample200JSONResponse(*request.Body), nil
 }
 
-func (s StrictServer) MultipartExample(ctx context.Context, request MultipartExampleRequestObject) interface{} {
+func (s StrictServer) MultipartExample(ctx context.Context, request MultipartExampleRequestObject) (MultipartExampleResponseObject, error) {
 	return MultipartExample200MultipartResponse(func(writer *multipart.Writer) error {
 		for {
 			part, err := request.Body.NextPart()
@@ -37,19 +37,19 @@ func (s StrictServer) MultipartExample(ctx context.Context, request MultipartExa
 				return err
 			}
 		}
-	})
+	}), nil
 }
 
-func (s StrictServer) MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) interface{} {
+func (s StrictServer) MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) (MultipleRequestAndResponseTypesResponseObject, error) {
 	switch {
 	case request.Body != nil:
-		return MultipleRequestAndResponseTypes200ImagepngResponse{Body: request.Body}
+		return MultipleRequestAndResponseTypes200ImagepngResponse{Body: request.Body}, nil
 	case request.JSONBody != nil:
-		return MultipleRequestAndResponseTypes200JSONResponse(*request.JSONBody)
+		return MultipleRequestAndResponseTypes200JSONResponse(*request.JSONBody), nil
 	case request.FormdataBody != nil:
-		return MultipleRequestAndResponseTypes200FormdataResponse(*request.FormdataBody)
+		return MultipleRequestAndResponseTypes200FormdataResponse(*request.FormdataBody), nil
 	case request.TextBody != nil:
-		return MultipleRequestAndResponseTypes200TextResponse(*request.TextBody)
+		return MultipleRequestAndResponseTypes200TextResponse(*request.TextBody), nil
 	case request.MultipartBody != nil:
 		return MultipleRequestAndResponseTypes200MultipartResponse(func(writer *multipart.Writer) error {
 			for {
@@ -71,32 +71,32 @@ func (s StrictServer) MultipleRequestAndResponseTypes(ctx context.Context, reque
 					return err
 				}
 			}
-		})
+		}), nil
 	default:
-		return MultipleRequestAndResponseTypes400Response{}
+		return MultipleRequestAndResponseTypes400Response{}, nil
 	}
 }
 
-func (s StrictServer) TextExample(ctx context.Context, request TextExampleRequestObject) interface{} {
-	return TextExample200TextResponse(*request.Body)
+func (s StrictServer) TextExample(ctx context.Context, request TextExampleRequestObject) (TextExampleResponseObject, error) {
+	return TextExample200TextResponse(*request.Body), nil
 }
 
-func (s StrictServer) UnknownExample(ctx context.Context, request UnknownExampleRequestObject) interface{} {
-	return UnknownExample200Videomp4Response{Body: request.Body}
+func (s StrictServer) UnknownExample(ctx context.Context, request UnknownExampleRequestObject) (UnknownExampleResponseObject, error) {
+	return UnknownExample200Videomp4Response{Body: request.Body}, nil
 }
 
-func (s StrictServer) UnspecifiedContentType(ctx context.Context, request UnspecifiedContentTypeRequestObject) interface{} {
-	return UnspecifiedContentType200VideoResponse{Body: request.Body, ContentType: request.ContentType}
+func (s StrictServer) UnspecifiedContentType(ctx context.Context, request UnspecifiedContentTypeRequestObject) (UnspecifiedContentTypeResponseObject, error) {
+	return UnspecifiedContentType200VideoResponse{Body: request.Body, ContentType: request.ContentType}, nil
 }
 
-func (s StrictServer) URLEncodedExample(ctx context.Context, request URLEncodedExampleRequestObject) interface{} {
-	return URLEncodedExample200FormdataResponse(*request.Body)
+func (s StrictServer) URLEncodedExample(ctx context.Context, request URLEncodedExampleRequestObject) (URLEncodedExampleResponseObject, error) {
+	return URLEncodedExample200FormdataResponse(*request.Body), nil
 }
 
-func (s StrictServer) HeadersExample(ctx context.Context, request HeadersExampleRequestObject) interface{} {
-	return HeadersExample200JSONResponse{Body: Example(*request.Body), Headers: HeadersExample200ResponseHeaders{Header1: request.Params.Header1, Header2: *request.Params.Header2}}
+func (s StrictServer) HeadersExample(ctx context.Context, request HeadersExampleRequestObject) (HeadersExampleResponseObject, error) {
+	return HeadersExample200JSONResponse{Body: Example(*request.Body), Headers: HeadersExample200ResponseHeaders{Header1: request.Params.Header1, Header2: *request.Params.Header2}}, nil
 }
 
-func (s StrictServer) ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) interface{} {
-	return ReusableResponses200JSONResponse{Body: *request.Body}
+func (s StrictServer) ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) (ReusableResponsesResponseObject, error) {
+	return ReusableResponses200JSONResponse{Body: *request.Body}, nil
 }

--- a/internal/test/strict-server/gin/server.gen.go
+++ b/internal/test/strict-server/gin/server.gen.go
@@ -727,6 +727,8 @@ func (sh *strictHandler) JSONExample(ctx *gin.Context) {
 		if err := validResponse.VisitJSONExampleResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -756,6 +758,8 @@ func (sh *strictHandler) MultipartExample(ctx *gin.Context) {
 		if err := validResponse.VisitMultipartExampleResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -819,6 +823,8 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx *gin.Context) {
 		if err := validResponse.VisitMultipleRequestAndResponseTypesResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -848,6 +854,8 @@ func (sh *strictHandler) ReusableResponses(ctx *gin.Context) {
 		if err := validResponse.VisitReusableResponsesResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -878,6 +886,8 @@ func (sh *strictHandler) TextExample(ctx *gin.Context) {
 		if err := validResponse.VisitTextExampleResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -902,6 +912,8 @@ func (sh *strictHandler) UnknownExample(ctx *gin.Context) {
 		if err := validResponse.VisitUnknownExampleResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -928,6 +940,8 @@ func (sh *strictHandler) UnspecifiedContentType(ctx *gin.Context) {
 		if err := validResponse.VisitUnspecifiedContentTypeResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -961,6 +975,8 @@ func (sh *strictHandler) URLEncodedExample(ctx *gin.Context) {
 		if err := validResponse.VisitURLEncodedExampleResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 
@@ -992,6 +1008,8 @@ func (sh *strictHandler) HeadersExample(ctx *gin.Context, params HeadersExampleP
 		if err := validResponse.VisitHeadersExampleResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
 	}
 }
 

--- a/internal/test/strict-server/gin/server.gen.go
+++ b/internal/test/strict-server/gin/server.gen.go
@@ -252,36 +252,72 @@ type ReusableresponseJSONResponse struct {
 	Headers ReusableresponseResponseHeaders
 }
 
-func (t ReusableresponseJSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Body)
-}
-
 type JSONExampleRequestObject struct {
 	Body *JSONExampleJSONRequestBody
 }
 
+type JSONExampleResponseObject interface {
+	VisitJSONExampleResponse(w http.ResponseWriter) error
+}
+
 type JSONExample200JSONResponse Example
 
-func (t JSONExample200JSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal((Example)(t))
+func (response JSONExample200JSONResponse) VisitJSONExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
 }
 
 type JSONExample400Response = BadrequestResponse
 
+func (response JSONExample400Response) VisitJSONExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
+
 type JSONExampledefaultResponse struct {
 	StatusCode int
+}
+
+func (response JSONExampledefaultResponse) VisitJSONExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
 }
 
 type MultipartExampleRequestObject struct {
 	Body *multipart.Reader
 }
 
+type MultipartExampleResponseObject interface {
+	VisitMultipartExampleResponse(w http.ResponseWriter) error
+}
+
 type MultipartExample200MultipartResponse func(writer *multipart.Writer) error
+
+func (response MultipartExample200MultipartResponse) VisitMultipartExampleResponse(w http.ResponseWriter) error {
+	writer := multipart.NewWriter(w)
+	w.Header().Set("Content-Type", writer.FormDataContentType())
+	w.WriteHeader(200)
+
+	defer writer.Close()
+	return response(writer)
+}
 
 type MultipartExample400Response = BadrequestResponse
 
+func (response MultipartExample400Response) VisitMultipartExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
+
 type MultipartExampledefaultResponse struct {
 	StatusCode int
+}
+
+func (response MultipartExampledefaultResponse) VisitMultipartExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
 }
 
 type MultipleRequestAndResponseTypesRequestObject struct {
@@ -292,51 +328,155 @@ type MultipleRequestAndResponseTypesRequestObject struct {
 	TextBody      *MultipleRequestAndResponseTypesTextRequestBody
 }
 
+type MultipleRequestAndResponseTypesResponseObject interface {
+	VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error
+}
+
 type MultipleRequestAndResponseTypes200JSONResponse Example
 
-func (t MultipleRequestAndResponseTypes200JSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal((Example)(t))
+func (response MultipleRequestAndResponseTypes200JSONResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
 }
 
 type MultipleRequestAndResponseTypes200FormdataResponse Example
+
+func (response MultipleRequestAndResponseTypes200FormdataResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+	w.WriteHeader(200)
+
+	if form, err := runtime.MarshalForm(response, nil); err != nil {
+		return err
+	} else {
+		_, err := w.Write([]byte(form.Encode()))
+		return err
+	}
+}
 
 type MultipleRequestAndResponseTypes200ImagepngResponse struct {
 	Body          io.Reader
 	ContentLength int64
 }
 
+func (response MultipleRequestAndResponseTypes200ImagepngResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "image/png")
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
 type MultipleRequestAndResponseTypes200MultipartResponse func(writer *multipart.Writer) error
+
+func (response MultipleRequestAndResponseTypes200MultipartResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	writer := multipart.NewWriter(w)
+	w.Header().Set("Content-Type", writer.FormDataContentType())
+	w.WriteHeader(200)
+
+	defer writer.Close()
+	return response(writer)
+}
 
 type MultipleRequestAndResponseTypes200TextResponse string
 
+func (response MultipleRequestAndResponseTypes200TextResponse) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(200)
+
+	_, err := w.Write([]byte(response))
+	return err
+}
+
 type MultipleRequestAndResponseTypes400Response = BadrequestResponse
+
+func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestAndResponseTypesResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type ReusableResponsesRequestObject struct {
 	Body *ReusableResponsesJSONRequestBody
 }
 
+type ReusableResponsesResponseObject interface {
+	VisitReusableResponsesResponse(w http.ResponseWriter) error
+}
+
 type ReusableResponses200JSONResponse = ReusableresponseJSONResponse
+
+func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(w http.ResponseWriter) error {
+	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
+	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response.Body)
+}
 
 type ReusableResponses400Response = BadrequestResponse
 
+func (response ReusableResponses400Response) VisitReusableResponsesResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
+
 type ReusableResponsesdefaultResponse struct {
 	StatusCode int
+}
+
+func (response ReusableResponsesdefaultResponse) VisitReusableResponsesResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
 }
 
 type TextExampleRequestObject struct {
 	Body *TextExampleTextRequestBody
 }
 
+type TextExampleResponseObject interface {
+	VisitTextExampleResponse(w http.ResponseWriter) error
+}
+
 type TextExample200TextResponse string
 
+func (response TextExample200TextResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(200)
+
+	_, err := w.Write([]byte(response))
+	return err
+}
+
 type TextExample400Response = BadrequestResponse
+
+func (response TextExample400Response) VisitTextExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type TextExampledefaultResponse struct {
 	StatusCode int
 }
 
+func (response TextExampledefaultResponse) VisitTextExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
+}
+
 type UnknownExampleRequestObject struct {
 	Body io.Reader
+}
+
+type UnknownExampleResponseObject interface {
+	VisitUnknownExampleResponse(w http.ResponseWriter) error
 }
 
 type UnknownExample200Videomp4Response struct {
@@ -344,15 +484,43 @@ type UnknownExample200Videomp4Response struct {
 	ContentLength int64
 }
 
+func (response UnknownExample200Videomp4Response) VisitUnknownExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "video/mp4")
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
 type UnknownExample400Response = BadrequestResponse
+
+func (response UnknownExample400Response) VisitUnknownExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type UnknownExampledefaultResponse struct {
 	StatusCode int
 }
 
+func (response UnknownExampledefaultResponse) VisitUnknownExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
+}
+
 type UnspecifiedContentTypeRequestObject struct {
 	ContentType string
 	Body        io.Reader
+}
+
+type UnspecifiedContentTypeResponseObject interface {
+	VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error
 }
 
 type UnspecifiedContentType200VideoResponse struct {
@@ -361,33 +529,97 @@ type UnspecifiedContentType200VideoResponse struct {
 	ContentLength int64
 }
 
+func (response UnspecifiedContentType200VideoResponse) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", response.ContentType)
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
 type UnspecifiedContentType400Response = BadrequestResponse
+
+func (response UnspecifiedContentType400Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type UnspecifiedContentType401Response struct {
 }
 
+func (response UnspecifiedContentType401Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.WriteHeader(401)
+	return nil
+}
+
 type UnspecifiedContentType403Response struct {
+}
+
+func (response UnspecifiedContentType403Response) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.WriteHeader(403)
+	return nil
 }
 
 type UnspecifiedContentTypedefaultResponse struct {
 	StatusCode int
 }
 
+func (response UnspecifiedContentTypedefaultResponse) VisitUnspecifiedContentTypeResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
+}
+
 type URLEncodedExampleRequestObject struct {
 	Body *URLEncodedExampleFormdataRequestBody
 }
 
+type URLEncodedExampleResponseObject interface {
+	VisitURLEncodedExampleResponse(w http.ResponseWriter) error
+}
+
 type URLEncodedExample200FormdataResponse Example
 
+func (response URLEncodedExample200FormdataResponse) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+	w.WriteHeader(200)
+
+	if form, err := runtime.MarshalForm(response, nil); err != nil {
+		return err
+	} else {
+		_, err := w.Write([]byte(form.Encode()))
+		return err
+	}
+}
+
 type URLEncodedExample400Response = BadrequestResponse
+
+func (response URLEncodedExample400Response) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
 
 type URLEncodedExampledefaultResponse struct {
 	StatusCode int
 }
 
+func (response URLEncodedExampledefaultResponse) VisitURLEncodedExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
+}
+
 type HeadersExampleRequestObject struct {
 	Params HeadersExampleParams
 	Body   *HeadersExampleJSONRequestBody
+}
+
+type HeadersExampleResponseObject interface {
+	VisitHeadersExampleResponse(w http.ResponseWriter) error
 }
 
 type HeadersExample200ResponseHeaders struct {
@@ -400,48 +632,63 @@ type HeadersExample200JSONResponse struct {
 	Headers HeadersExample200ResponseHeaders
 }
 
-func (t HeadersExample200JSONResponse) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Body)
+func (response HeadersExample200JSONResponse) VisitHeadersExampleResponse(w http.ResponseWriter) error {
+	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))
+	w.Header().Set("header2", fmt.Sprint(response.Headers.Header2))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response.Body)
 }
 
 type HeadersExample400Response = BadrequestResponse
 
+func (response HeadersExample400Response) VisitHeadersExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(400)
+	return nil
+}
+
 type HeadersExampledefaultResponse struct {
 	StatusCode int
+}
+
+func (response HeadersExampledefaultResponse) VisitHeadersExampleResponse(w http.ResponseWriter) error {
+	w.WriteHeader(response.StatusCode)
+	return nil
 }
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
 
 	// (POST /json)
-	JSONExample(ctx context.Context, request JSONExampleRequestObject) interface{}
+	JSONExample(ctx context.Context, request JSONExampleRequestObject) (JSONExampleResponseObject, error)
 
 	// (POST /multipart)
-	MultipartExample(ctx context.Context, request MultipartExampleRequestObject) interface{}
+	MultipartExample(ctx context.Context, request MultipartExampleRequestObject) (MultipartExampleResponseObject, error)
 
 	// (POST /multiple)
-	MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) interface{}
+	MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) (MultipleRequestAndResponseTypesResponseObject, error)
 
 	// (POST /reusable-responses)
-	ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) interface{}
+	ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) (ReusableResponsesResponseObject, error)
 
 	// (POST /text)
-	TextExample(ctx context.Context, request TextExampleRequestObject) interface{}
+	TextExample(ctx context.Context, request TextExampleRequestObject) (TextExampleResponseObject, error)
 
 	// (POST /unknown)
-	UnknownExample(ctx context.Context, request UnknownExampleRequestObject) interface{}
+	UnknownExample(ctx context.Context, request UnknownExampleRequestObject) (UnknownExampleResponseObject, error)
 
 	// (POST /unspecified-content-type)
-	UnspecifiedContentType(ctx context.Context, request UnspecifiedContentTypeRequestObject) interface{}
+	UnspecifiedContentType(ctx context.Context, request UnspecifiedContentTypeRequestObject) (UnspecifiedContentTypeResponseObject, error)
 
 	// (POST /urlencoded)
-	URLEncodedExample(ctx context.Context, request URLEncodedExampleRequestObject) interface{}
+	URLEncodedExample(ctx context.Context, request URLEncodedExampleRequestObject) (URLEncodedExampleResponseObject, error)
 
 	// (POST /with-headers)
-	HeadersExample(ctx context.Context, request HeadersExampleRequestObject) interface{}
+	HeadersExample(ctx context.Context, request HeadersExampleRequestObject) (HeadersExampleResponseObject, error)
 }
 
-type StrictHandlerFunc func(ctx *gin.Context, args interface{}) interface{}
+type StrictHandlerFunc func(ctx *gin.Context, args interface{}) (interface{}, error)
 
 type StrictMiddlewareFunc func(f StrictHandlerFunc, operationID string) StrictHandlerFunc
 
@@ -465,27 +712,21 @@ func (sh *strictHandler) JSONExample(ctx *gin.Context) {
 	}
 	request.Body = &body
 
-	handler := func(ctx *gin.Context, request interface{}) interface{} {
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.JSONExample(ctx, request.(JSONExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "JSONExample")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case JSONExample200JSONResponse:
-		ctx.JSON(200, v)
-	case JSONExample400Response:
-		ctx.Status(400)
-	case JSONExampledefaultResponse:
-		ctx.Status(v.StatusCode)
-	case error:
-		ctx.Error(v)
-	case nil:
-	default:
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", v))
+	if err != nil {
+		ctx.Error(err)
+	} else if validResponse, ok := response.(JSONExampleResponseObject); ok {
+		if err := validResponse.VisitJSONExampleResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
 	}
 }
 
@@ -500,32 +741,21 @@ func (sh *strictHandler) MultipartExample(ctx *gin.Context) {
 		return
 	}
 
-	handler := func(ctx *gin.Context, request interface{}) interface{} {
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.MultipartExample(ctx, request.(MultipartExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "MultipartExample")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case MultipartExample200MultipartResponse:
-		writer := multipart.NewWriter(ctx.Writer)
-		ctx.Writer.Header().Set("Content-Type", writer.FormDataContentType())
-		defer writer.Close()
-		if err := v(writer); err != nil {
+	if err != nil {
+		ctx.Error(err)
+	} else if validResponse, ok := response.(MultipartExampleResponseObject); ok {
+		if err := validResponse.VisitMultipartExampleResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
-	case MultipartExample400Response:
-		ctx.Status(400)
-	case MultipartExampledefaultResponse:
-		ctx.Status(v.StatusCode)
-	case error:
-		ctx.Error(v)
-	case nil:
-	default:
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", v))
 	}
 }
 
@@ -574,45 +804,21 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx *gin.Context) {
 		request.TextBody = &body
 	}
 
-	handler := func(ctx *gin.Context, request interface{}) interface{} {
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.MultipleRequestAndResponseTypes(ctx, request.(MultipleRequestAndResponseTypesRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "MultipleRequestAndResponseTypes")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case MultipleRequestAndResponseTypes200JSONResponse:
-		ctx.JSON(200, v)
-	case MultipleRequestAndResponseTypes200FormdataResponse:
-		if form, err := runtime.MarshalForm(v, nil); err != nil {
-			ctx.Error(err)
-		} else {
-			ctx.Data(200, "application/x-www-form-urlencoded", []byte(form.Encode()))
-		}
-	case MultipleRequestAndResponseTypes200ImagepngResponse:
-		if closer, ok := v.Body.(io.ReadCloser); ok {
-			defer closer.Close()
-		}
-		ctx.DataFromReader(200, v.ContentLength, "image/png", v.Body, nil)
-	case MultipleRequestAndResponseTypes200MultipartResponse:
-		writer := multipart.NewWriter(ctx.Writer)
-		ctx.Writer.Header().Set("Content-Type", writer.FormDataContentType())
-		defer writer.Close()
-		if err := v(writer); err != nil {
+	if err != nil {
+		ctx.Error(err)
+	} else if validResponse, ok := response.(MultipleRequestAndResponseTypesResponseObject); ok {
+		if err := validResponse.VisitMultipleRequestAndResponseTypesResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
-	case MultipleRequestAndResponseTypes200TextResponse:
-		ctx.Data(200, "text/plain", []byte(v))
-	case MultipleRequestAndResponseTypes400Response:
-		ctx.Status(400)
-	case error:
-		ctx.Error(v)
-	case nil:
-	default:
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", v))
 	}
 }
 
@@ -627,29 +833,21 @@ func (sh *strictHandler) ReusableResponses(ctx *gin.Context) {
 	}
 	request.Body = &body
 
-	handler := func(ctx *gin.Context, request interface{}) interface{} {
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.ReusableResponses(ctx, request.(ReusableResponsesRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "ReusableResponses")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case ReusableResponses200JSONResponse:
-		ctx.Header("header1", fmt.Sprint(v.Headers.Header1))
-		ctx.Header("header2", fmt.Sprint(v.Headers.Header2))
-		ctx.JSON(200, v)
-	case ReusableResponses400Response:
-		ctx.Status(400)
-	case ReusableResponsesdefaultResponse:
-		ctx.Status(v.StatusCode)
-	case error:
-		ctx.Error(v)
-	case nil:
-	default:
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", v))
+	if err != nil {
+		ctx.Error(err)
+	} else if validResponse, ok := response.(ReusableResponsesResponseObject); ok {
+		if err := validResponse.VisitReusableResponsesResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
 	}
 }
 
@@ -665,27 +863,21 @@ func (sh *strictHandler) TextExample(ctx *gin.Context) {
 	body := TextExampleTextRequestBody(data)
 	request.Body = &body
 
-	handler := func(ctx *gin.Context, request interface{}) interface{} {
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.TextExample(ctx, request.(TextExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "TextExample")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case TextExample200TextResponse:
-		ctx.Data(200, "text/plain", []byte(v))
-	case TextExample400Response:
-		ctx.Status(400)
-	case TextExampledefaultResponse:
-		ctx.Status(v.StatusCode)
-	case error:
-		ctx.Error(v)
-	case nil:
-	default:
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", v))
+	if err != nil {
+		ctx.Error(err)
+	} else if validResponse, ok := response.(TextExampleResponseObject); ok {
+		if err := validResponse.VisitTextExampleResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
 	}
 }
 
@@ -695,30 +887,21 @@ func (sh *strictHandler) UnknownExample(ctx *gin.Context) {
 
 	request.Body = ctx.Request.Body
 
-	handler := func(ctx *gin.Context, request interface{}) interface{} {
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UnknownExample(ctx, request.(UnknownExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "UnknownExample")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case UnknownExample200Videomp4Response:
-		if closer, ok := v.Body.(io.ReadCloser); ok {
-			defer closer.Close()
+	if err != nil {
+		ctx.Error(err)
+	} else if validResponse, ok := response.(UnknownExampleResponseObject); ok {
+		if err := validResponse.VisitUnknownExampleResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
 		}
-		ctx.DataFromReader(200, v.ContentLength, "video/mp4", v.Body, nil)
-	case UnknownExample400Response:
-		ctx.Status(400)
-	case UnknownExampledefaultResponse:
-		ctx.Status(v.StatusCode)
-	case error:
-		ctx.Error(v)
-	case nil:
-	default:
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", v))
 	}
 }
 
@@ -730,34 +913,21 @@ func (sh *strictHandler) UnspecifiedContentType(ctx *gin.Context) {
 
 	request.Body = ctx.Request.Body
 
-	handler := func(ctx *gin.Context, request interface{}) interface{} {
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.UnspecifiedContentType(ctx, request.(UnspecifiedContentTypeRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "UnspecifiedContentType")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case UnspecifiedContentType200VideoResponse:
-		if closer, ok := v.Body.(io.ReadCloser); ok {
-			defer closer.Close()
+	if err != nil {
+		ctx.Error(err)
+	} else if validResponse, ok := response.(UnspecifiedContentTypeResponseObject); ok {
+		if err := validResponse.VisitUnspecifiedContentTypeResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
 		}
-		ctx.DataFromReader(200, v.ContentLength, v.ContentType, v.Body, nil)
-	case UnspecifiedContentType400Response:
-		ctx.Status(400)
-	case UnspecifiedContentType401Response:
-		ctx.Status(401)
-	case UnspecifiedContentType403Response:
-		ctx.Status(403)
-	case UnspecifiedContentTypedefaultResponse:
-		ctx.Status(v.StatusCode)
-	case error:
-		ctx.Error(v)
-	case nil:
-	default:
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", v))
 	}
 }
 
@@ -776,31 +946,21 @@ func (sh *strictHandler) URLEncodedExample(ctx *gin.Context) {
 	}
 	request.Body = &body
 
-	handler := func(ctx *gin.Context, request interface{}) interface{} {
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.URLEncodedExample(ctx, request.(URLEncodedExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "URLEncodedExample")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case URLEncodedExample200FormdataResponse:
-		if form, err := runtime.MarshalForm(v, nil); err != nil {
+	if err != nil {
+		ctx.Error(err)
+	} else if validResponse, ok := response.(URLEncodedExampleResponseObject); ok {
+		if err := validResponse.VisitURLEncodedExampleResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
-		} else {
-			ctx.Data(200, "application/x-www-form-urlencoded", []byte(form.Encode()))
 		}
-	case URLEncodedExample400Response:
-		ctx.Status(400)
-	case URLEncodedExampledefaultResponse:
-		ctx.Status(v.StatusCode)
-	case error:
-		ctx.Error(v)
-	case nil:
-	default:
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", v))
 	}
 }
 
@@ -817,29 +977,21 @@ func (sh *strictHandler) HeadersExample(ctx *gin.Context, params HeadersExampleP
 	}
 	request.Body = &body
 
-	handler := func(ctx *gin.Context, request interface{}) interface{} {
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
 		return sh.ssi.HeadersExample(ctx, request.(HeadersExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "HeadersExample")
 	}
 
-	response := handler(ctx, request)
+	response, err := handler(ctx, request)
 
-	switch v := response.(type) {
-	case HeadersExample200JSONResponse:
-		ctx.Header("header1", fmt.Sprint(v.Headers.Header1))
-		ctx.Header("header2", fmt.Sprint(v.Headers.Header2))
-		ctx.JSON(200, v)
-	case HeadersExample400Response:
-		ctx.Status(400)
-	case HeadersExampledefaultResponse:
-		ctx.Status(v.StatusCode)
-	case error:
-		ctx.Error(v)
-	case nil:
-	default:
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", v))
+	if err != nil {
+		ctx.Error(err)
+	} else if validResponse, ok := response.(HeadersExampleResponseObject); ok {
+		if err := validResponse.VisitHeadersExampleResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
 	}
 }
 

--- a/internal/test/strict-server/gin/server.go
+++ b/internal/test/strict-server/gin/server.go
@@ -12,11 +12,11 @@ import (
 type StrictServer struct {
 }
 
-func (s StrictServer) JSONExample(ctx context.Context, request JSONExampleRequestObject) interface{} {
-	return JSONExample200JSONResponse(*request.Body)
+func (s StrictServer) JSONExample(ctx context.Context, request JSONExampleRequestObject) (JSONExampleResponseObject, error) {
+	return JSONExample200JSONResponse(*request.Body), nil
 }
 
-func (s StrictServer) MultipartExample(ctx context.Context, request MultipartExampleRequestObject) interface{} {
+func (s StrictServer) MultipartExample(ctx context.Context, request MultipartExampleRequestObject) (MultipartExampleResponseObject, error) {
 	return MultipartExample200MultipartResponse(func(writer *multipart.Writer) error {
 		for {
 			part, err := request.Body.NextPart()
@@ -37,19 +37,19 @@ func (s StrictServer) MultipartExample(ctx context.Context, request MultipartExa
 				return err
 			}
 		}
-	})
+	}), nil
 }
 
-func (s StrictServer) MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) interface{} {
+func (s StrictServer) MultipleRequestAndResponseTypes(ctx context.Context, request MultipleRequestAndResponseTypesRequestObject) (MultipleRequestAndResponseTypesResponseObject, error) {
 	switch {
 	case request.Body != nil:
-		return MultipleRequestAndResponseTypes200ImagepngResponse{Body: request.Body}
+		return MultipleRequestAndResponseTypes200ImagepngResponse{Body: request.Body}, nil
 	case request.JSONBody != nil:
-		return MultipleRequestAndResponseTypes200JSONResponse(*request.JSONBody)
+		return MultipleRequestAndResponseTypes200JSONResponse(*request.JSONBody), nil
 	case request.FormdataBody != nil:
-		return MultipleRequestAndResponseTypes200FormdataResponse(*request.FormdataBody)
+		return MultipleRequestAndResponseTypes200FormdataResponse(*request.FormdataBody), nil
 	case request.TextBody != nil:
-		return MultipleRequestAndResponseTypes200TextResponse(*request.TextBody)
+		return MultipleRequestAndResponseTypes200TextResponse(*request.TextBody), nil
 	case request.MultipartBody != nil:
 		return MultipleRequestAndResponseTypes200MultipartResponse(func(writer *multipart.Writer) error {
 			for {
@@ -71,32 +71,32 @@ func (s StrictServer) MultipleRequestAndResponseTypes(ctx context.Context, reque
 					return err
 				}
 			}
-		})
+		}), nil
 	default:
-		return MultipleRequestAndResponseTypes400Response{}
+		return MultipleRequestAndResponseTypes400Response{}, nil
 	}
 }
 
-func (s StrictServer) TextExample(ctx context.Context, request TextExampleRequestObject) interface{} {
-	return TextExample200TextResponse(*request.Body)
+func (s StrictServer) TextExample(ctx context.Context, request TextExampleRequestObject) (TextExampleResponseObject, error) {
+	return TextExample200TextResponse(*request.Body), nil
 }
 
-func (s StrictServer) UnknownExample(ctx context.Context, request UnknownExampleRequestObject) interface{} {
-	return UnknownExample200Videomp4Response{Body: request.Body}
+func (s StrictServer) UnknownExample(ctx context.Context, request UnknownExampleRequestObject) (UnknownExampleResponseObject, error) {
+	return UnknownExample200Videomp4Response{Body: request.Body}, nil
 }
 
-func (s StrictServer) UnspecifiedContentType(ctx context.Context, request UnspecifiedContentTypeRequestObject) interface{} {
-	return UnspecifiedContentType200VideoResponse{Body: request.Body, ContentType: request.ContentType}
+func (s StrictServer) UnspecifiedContentType(ctx context.Context, request UnspecifiedContentTypeRequestObject) (UnspecifiedContentTypeResponseObject, error) {
+	return UnspecifiedContentType200VideoResponse{Body: request.Body, ContentType: request.ContentType}, nil
 }
 
-func (s StrictServer) URLEncodedExample(ctx context.Context, request URLEncodedExampleRequestObject) interface{} {
-	return URLEncodedExample200FormdataResponse(*request.Body)
+func (s StrictServer) URLEncodedExample(ctx context.Context, request URLEncodedExampleRequestObject) (URLEncodedExampleResponseObject, error) {
+	return URLEncodedExample200FormdataResponse(*request.Body), nil
 }
 
-func (s StrictServer) HeadersExample(ctx context.Context, request HeadersExampleRequestObject) interface{} {
-	return HeadersExample200JSONResponse{Body: Example(*request.Body), Headers: HeadersExample200ResponseHeaders{Header1: request.Params.Header1, Header2: *request.Params.Header2}}
+func (s StrictServer) HeadersExample(ctx context.Context, request HeadersExampleRequestObject) (HeadersExampleResponseObject, error) {
+	return HeadersExample200JSONResponse{Body: Example(*request.Body), Headers: HeadersExample200ResponseHeaders{Header1: request.Params.Header1, Header2: *request.Params.Header2}}, nil
 }
 
-func (s StrictServer) ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) interface{} {
-	return ReusableResponses200JSONResponse{Body: *request.Body}
+func (s StrictServer) ReusableResponses(ctx context.Context, request ReusableResponsesRequestObject) (ReusableResponsesResponseObject, error) {
+	return ReusableResponses200JSONResponse{Body: *request.Body}, nil
 }

--- a/pkg/codegen/templates/strict/strict-chi.tmpl
+++ b/pkg/codegen/templates/strict/strict-chi.tmpl
@@ -1,4 +1,4 @@
-type StrictHandlerFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, args interface{}) interface{}
+type StrictHandlerFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, args interface{}) (interface{}, error)
 
 type StrictMiddlewareFunc func(f StrictHandlerFunc, operationID string) StrictHandlerFunc
 
@@ -89,82 +89,21 @@ type strictHandler struct {
             {{if $multipleBodies}}}{{end}}
         {{end}}{{/* range .Bodies */}}
 
-        handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) interface{}{
+        handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
             return sh.ssi.{{.OperationId}}(ctx, request.({{$opid | ucFirst}}RequestObject))
         }
         for _, middleware := range sh.middlewares {
             handler = middleware(handler, "{{.OperationId}}")
         }
 
-        response := handler(r.Context(), w, r, request)
+        response, err := handler(r.Context(), w, r, request)
 
-        switch v := response.(type) {
-            {{range .Responses -}}
-                {{$statusCode := .StatusCode -}}
-                {{$fixedStatusCode := .HasFixedStatusCode -}}
-                {{$headers := .Headers -}}
-                {{range .Contents -}}
-                    case {{$opid}}{{$statusCode}}{{.NameTagOrContentType}}Response:
-                    {{range $headers -}}
-                        w.Header().Set("{{.Name}}", fmt.Sprint(v.Headers.{{.GoName}}))
-                    {{end -}}
-                    {{if eq .NameTag "Multipart" -}}
-                        writer := multipart.NewWriter(w)
-                    {{end -}}
-                    w.Header().Set("Content-Type", {{if eq .NameTag "Multipart"}}writer.FormDataContentType(){{else if .HasFixedContentType }}"{{.ContentType}}"{{else}}v.ContentType{{end}})
-                    {{if not .IsSupported -}}
-                        if v.ContentLength != 0 {
-                            w.Header().Set("Content-Length", fmt.Sprint(v.ContentLength))
-                        }
-                    {{end -}}
-                    w.WriteHeader({{if $fixedStatusCode}}{{$statusCode}}{{else}}v.StatusCode{{end}})
-                    {{if eq .NameTag "JSON" -}}
-                        writeJSON(w, v)
-                    {{else if eq .NameTag "Text" -}}
-                        writeRaw(w, ([]byte)(v))
-                    {{else if eq .NameTag "Formdata" -}}
-                        if form, err := runtime.MarshalForm(v, nil); err != nil {
-                            fmt.Fprintln(w, err)
-                        } else {
-                            writeRaw(w, []byte(form.Encode()))
-                        }
-                    {{else if eq .NameTag "Multipart" -}}
-                        defer writer.Close()
-                        if err := v(writer); err != nil {
-                            sh.options.ResponseErrorHandlerFunc(w, r, err)
-                        }
-                    {{else -}}
-                        if closer, ok := v.Body.(io.ReadCloser); ok {
-                            defer closer.Close()
-                        }
-                        _, _ = io.Copy(w, v.Body)
-                    {{end}}{{/* if eq .NameTag "JSON" */ -}}
-                {{end}}{{/* range .Contents */ -}}
-                {{if eq 0 (len .Contents) -}}
-                    case {{$opid}}{{$statusCode}}Response:
-                    {{range $headers -}}
-                        w.Header().Set("{{.Name}}", fmt.Sprint(v.Headers.{{.GoName}}))
-                    {{end -}}
-                    w.WriteHeader({{if $fixedStatusCode}}{{$statusCode}}{{else}}v.StatusCode{{end}})
-                {{end}}{{/* if eq 0 (len .Contents) */ -}}
-            {{end}}{{/* range .Responses */ -}}
-            case error:
-                sh.options.ResponseErrorHandlerFunc(w, r, v)
-            case nil:
-            default:
-                sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", v))
+        if err != nil {
+            sh.options.ResponseErrorHandlerFunc(w, r, err)
+        } else if validResponse, ok := response.({{$opid | ucFirst}}ResponseObject); ok {
+            if err := validResponse.Visit{{$opid}}Response(w); err != nil {
+                sh.options.ResponseErrorHandlerFunc(w, r, err)
+            }
         }
     }
 {{end}}
-
-func writeJSON(w http.ResponseWriter, v interface{}) {
-    if err := json.NewEncoder(w).Encode(v); err != nil {
-        fmt.Fprintln(w, err)
-    }
-}
-
-func writeRaw(w http.ResponseWriter, b []byte) {
-    if _, err := w.Write(b); err != nil {
-        fmt.Fprintln(w, err)
-    }
-}

--- a/pkg/codegen/templates/strict/strict-chi.tmpl
+++ b/pkg/codegen/templates/strict/strict-chi.tmpl
@@ -104,6 +104,8 @@ type strictHandler struct {
             if err := validResponse.Visit{{$opid}}Response(w); err != nil {
                 sh.options.ResponseErrorHandlerFunc(w, r, err)
             }
+        } else if response != nil {
+            sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
         }
     }
 {{end}}

--- a/pkg/codegen/templates/strict/strict-echo.tmpl
+++ b/pkg/codegen/templates/strict/strict-echo.tmpl
@@ -1,4 +1,4 @@
-type StrictHandlerFunc func(ctx echo.Context, args interface{}) interface{}
+type StrictHandlerFunc func(ctx echo.Context, args interface{}) (interface{}, error)
 
 type StrictMiddlewareFunc func(f StrictHandlerFunc, operationID string) StrictHandlerFunc
 
@@ -68,65 +68,21 @@ type strictHandler struct {
             {{if $multipleBodies}}}{{end}}
         {{end}}{{/* range .Bodies */}}
 
-        handler := func(ctx echo.Context, request interface{}) interface{}{
+        handler := func(ctx echo.Context, request interface{}) (interface{}, error){
             return sh.ssi.{{.OperationId}}(ctx.Request().Context(), request.({{$opid | ucFirst}}RequestObject))
         }
         for _, middleware := range sh.middlewares {
             handler = middleware(handler, "{{.OperationId}}")
         }
 
-        response := handler(ctx, request)
+        response, err := handler(ctx, request)
 
-        switch v := response.(type) {
-            {{range .Responses -}}
-                {{$statusCode := .StatusCode -}}
-                {{$fixedStatusCode := .HasFixedStatusCode -}}
-                {{$headers := .Headers -}}
-                {{range .Contents -}}
-                    case {{$opid}}{{$statusCode}}{{.NameTagOrContentType}}Response:
-                    {{range $headers -}}
-                        ctx.Response().Header().Set("{{.Name}}", fmt.Sprint(v.Headers.{{.GoName}}))
-                    {{end -}}
-                    {{if eq .NameTag "JSON" -}}
-                        return ctx.JSON({{if $fixedStatusCode}}{{$statusCode}}{{else}}v.StatusCode{{end}}, v)
-                    {{else if eq .NameTag "Text" -}}
-                        return ctx.Blob({{if $fixedStatusCode}}{{$statusCode}}{{else}}v.StatusCode{{end}}, "{{.ContentType}}", []byte(v))
-                    {{else if eq .NameTag "Formdata" -}}
-                        if form, err := runtime.MarshalForm(v, nil); err != nil {
-                            return err
-                        } else {
-                            return ctx.Blob({{if $fixedStatusCode}}{{$statusCode}}{{else}}v.StatusCode{{end}}, "{{.ContentType}}", []byte(form.Encode()))
-                        }
-                    {{else if eq .NameTag "Multipart" -}}
-                        writer := multipart.NewWriter(ctx.Response())
-                        ctx.Response().Header().Set("Content-Type", writer.FormDataContentType())
-                        defer writer.Close()
-                        if err := v(writer); err != nil {
-                            return err
-                        }
-                    {{else -}}
-                        if v.ContentLength != 0 {
-                            ctx.Response().Header().Set("Content-Length", fmt.Sprint(v.ContentLength))
-                        }
-                        if closer, ok := v.Body.(io.ReadCloser); ok {
-                            defer closer.Close()
-                        }
-                        return ctx.Stream({{if $fixedStatusCode}}{{$statusCode}}{{else}}v.StatusCode{{end}}, {{if .HasFixedContentType }}"{{.ContentType}}"{{else}}v.ContentType{{end}}, v.Body)
-                    {{end}}{{/* if eq .NameTag "JSON" */ -}}
-                {{end}}{{/* range .Contents */ -}}
-                {{if eq 0 (len .Contents) -}}
-                    case {{$opid}}{{$statusCode}}Response:
-                    {{range $headers -}}
-                        ctx.Response().Header().Set("{{.Name}}", fmt.Sprint(v.Headers.{{.GoName}}))
-                    {{end -}}
-                    return ctx.NoContent({{if $fixedStatusCode}}{{$statusCode}}{{else}}v.StatusCode{{end}})
-                {{end}}{{/* if eq 0 (len .Contents) */ -}}
-            {{end}}{{/* range .Responses */ -}}
-            case error:
-                return v
-            case nil:
-            default:
-                return fmt.Errorf("Unexpected response type: %T", v)
+        if err != nil {
+            return err
+        } else if validResponse, ok := response.({{$opid | ucFirst}}ResponseObject); ok {
+            if err := validResponse.Visit{{$opid}}Response(ctx.Response()); err != nil {
+                return err
+            }
         }
         return nil
     }

--- a/pkg/codegen/templates/strict/strict-echo.tmpl
+++ b/pkg/codegen/templates/strict/strict-echo.tmpl
@@ -80,9 +80,9 @@ type strictHandler struct {
         if err != nil {
             return err
         } else if validResponse, ok := response.({{$opid | ucFirst}}ResponseObject); ok {
-            if err := validResponse.Visit{{$opid}}Response(ctx.Response()); err != nil {
-                return err
-            }
+            return validResponse.Visit{{$opid}}Response(ctx.Response())
+        } else if response != nil {
+            return fmt.Errorf("Unexpected response type: %T", response)
         }
         return nil
     }

--- a/pkg/codegen/templates/strict/strict-gin.tmpl
+++ b/pkg/codegen/templates/strict/strict-gin.tmpl
@@ -87,6 +87,8 @@ type strictHandler struct {
             if err := validResponse.Visit{{$opid}}Response(ctx.Writer); err != nil {
                 ctx.Error(err)
             }
+        } else if response != nil {
+            ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
         }
     }
 {{end}}

--- a/pkg/codegen/templates/strict/strict-gin.tmpl
+++ b/pkg/codegen/templates/strict/strict-gin.tmpl
@@ -1,4 +1,4 @@
-type StrictHandlerFunc func(ctx *gin.Context, args interface{}) interface{}
+type StrictHandlerFunc func(ctx *gin.Context, args interface{}) (interface{}, error)
 
 type StrictMiddlewareFunc func(f StrictHandlerFunc, operationID string) StrictHandlerFunc
 
@@ -72,62 +72,21 @@ type strictHandler struct {
             {{if $multipleBodies}}}{{end}}
         {{end}}{{/* range .Bodies */}}
 
-        handler := func(ctx *gin.Context, request interface{}) interface{}{
+        handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
             return sh.ssi.{{.OperationId}}(ctx, request.({{$opid | ucFirst}}RequestObject))
         }
         for _, middleware := range sh.middlewares {
             handler = middleware(handler, "{{.OperationId}}")
         }
 
-        response := handler(ctx, request)
+        response, err := handler(ctx, request)
 
-        switch v := response.(type) {
-            {{range .Responses -}}
-                {{$statusCode := .StatusCode -}}
-                {{$fixedStatusCode := .HasFixedStatusCode -}}
-                {{$headers := .Headers -}}
-                {{range .Contents -}}
-                    case {{$opid}}{{$statusCode}}{{.NameTagOrContentType}}Response:
-                    {{range $headers -}}
-                        ctx.Header("{{.Name}}", fmt.Sprint(v.Headers.{{.GoName}}))
-                    {{end -}}
-                    {{if eq .NameTag "JSON" -}}
-                        ctx.JSON({{if $fixedStatusCode}}{{$statusCode}}{{else}}v.StatusCode{{end}}, v)
-                    {{else if eq .NameTag "Text" -}}
-                        ctx.Data({{if $fixedStatusCode}}{{$statusCode}}{{else}}v.StatusCode{{end}}, "{{.ContentType}}", []byte(v))
-                    {{else if eq .NameTag "Formdata" -}}
-                        if form, err := runtime.MarshalForm(v, nil); err != nil {
-                            ctx.Error(err)
-                        } else {
-                            ctx.Data({{if $fixedStatusCode}}{{$statusCode}}{{else}}v.StatusCode{{end}}, "{{.ContentType}}", []byte(form.Encode()))
-                        }
-                    {{else if eq .NameTag "Multipart" -}}
-                        writer := multipart.NewWriter(ctx.Writer)
-                        ctx.Writer.Header().Set("Content-Type", writer.FormDataContentType())
-                        defer writer.Close()
-                        if err := v(writer); err != nil {
-                            ctx.Error(err)
-                        }
-                    {{else -}}
-                        if closer, ok := v.Body.(io.ReadCloser); ok {
-                            defer closer.Close()
-                        }
-                        ctx.DataFromReader({{if $fixedStatusCode}}{{$statusCode}}{{else}}v.StatusCode{{end}}, v.ContentLength, {{if .HasFixedContentType }}"{{.ContentType}}"{{else}}v.ContentType{{end}}, v.Body, nil)
-                    {{end}}{{/* if eq .NameTag "JSON" */ -}}
-                {{end}}{{/* range .Contents */ -}}
-                {{if eq 0 (len .Contents) -}}
-                    case {{$opid}}{{$statusCode}}Response:
-                    {{range $headers -}}
-                        ctx.Header("{{.Name}}", fmt.Sprint(v.Headers.{{.GoName}}))
-                    {{end -}}
-                    ctx.Status({{if $fixedStatusCode}}{{$statusCode}}{{else}}v.StatusCode{{end}})
-                {{end}}{{/* if eq 0 (len .Contents) */ -}}
-            {{end}}{{/* range .Responses */ -}}
-            case error:
-                ctx.Error(v)
-            case nil:
-            default:
-                ctx.Error(fmt.Errorf("Unexpected response type: %T", v))
+        if err != nil {
+            ctx.Error(err)
+        } else if validResponse, ok := response.({{$opid | ucFirst}}ResponseObject); ok {
+            if err := validResponse.Visit{{$opid}}Response(ctx.Writer); err != nil {
+                ctx.Error(err)
+            }
         }
     }
 {{end}}

--- a/pkg/codegen/templates/strict/strict-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-interface.tmpl
@@ -16,12 +16,17 @@
         {{end -}}
     }
 
+    type {{$opid | ucFirst}}ResponseObject interface {
+        Visit{{$opid}}Response(w http.ResponseWriter) error
+    }
+
     {{range .Responses}}
         {{$statusCode := .StatusCode -}}
         {{$hasHeaders := ne 0 (len .Headers) -}}
         {{$fixedStatusCode := .HasFixedStatusCode -}}
         {{$isRef := .IsRef -}}
         {{$ref := .Ref  | ucFirst -}}
+        {{$headers := .Headers -}}
 
         {{if (and $hasHeaders (not $isRef)) -}}
             type {{$opid}}{{$statusCode}}ResponseHeaders struct {
@@ -36,12 +41,6 @@
                 type {{$opid}}{{$statusCode}}{{.NameTagOrContentType}}Response = {{$ref}}{{.NameTagOrContentType}}Response
             {{else if and (not $hasHeaders) ($fixedStatusCode) (.IsSupported) -}}
                 type {{$opid}}{{$statusCode}}{{.NameTagOrContentType}}Response {{if eq .NameTag "Multipart"}}func(writer *multipart.Writer)error{{else if .IsSupported}}{{if .Schema.IsRef}}={{end}} {{.Schema.TypeDecl}}{{else}}io.Reader{{end}}
-
-                {{if and (not .Schema.IsRef) (eq .NameTag "JSON")}}
-                    func (t {{$opid}}{{$statusCode}}{{.NameTagOrContentType}}Response) MarshalJSON() ([]byte, error) {
-                        return json.Marshal(({{.Schema.GoType}})(t))
-                    }
-                {{end}}
             {{else -}}
                 type {{$opid}}{{$statusCode}}{{.NameTagOrContentType}}Response struct {
                     Body {{if eq .NameTag "Multipart"}}func(writer *multipart.Writer)error{{else if .IsSupported}}{{.Schema.TypeDecl}}{{else}}io.Reader{{end}}
@@ -61,12 +60,46 @@
                         ContentLength int64
                     {{end -}}
                 }
-                {{if eq .NameTag "JSON"}}
-                    func (t {{$opid}}{{$statusCode}}{{.NameTagOrContentType}}Response) MarshalJSON() ([]byte, error) {
-                        return json.Marshal(t.Body)
-                    }
-                {{end}}
             {{end}}
+
+            func (response {{$opid}}{{$statusCode}}{{.NameTagOrContentType}}Response) Visit{{$opid}}Response(w http.ResponseWriter) error {
+                {{range $headers -}}
+                    w.Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
+                {{end -}}
+                {{if eq .NameTag "Multipart" -}}
+                    writer := multipart.NewWriter(w)
+                {{end -}}
+                w.Header().Set("Content-Type", {{if eq .NameTag "Multipart"}}writer.FormDataContentType(){{else if .HasFixedContentType }}"{{.ContentType}}"{{else}}response.ContentType{{end}})
+                {{if not .IsSupported -}}
+                    if response.ContentLength != 0 {
+                        w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+                    }
+                {{end -}}
+                w.WriteHeader({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
+                {{$hasBodyVar := or ($hasHeaders) (not $fixedStatusCode) (not .IsSupported)}}
+                {{if eq .NameTag "JSON" -}}
+                    return json.NewEncoder(w).Encode({{if $hasBodyVar}}response.Body{{else}}response{{end}})
+                {{else if eq .NameTag "Text" -}}
+                    _, err := w.Write([]byte({{if $hasBodyVar}}response.Body{{else}}response{{end}}))
+                    return err
+                {{else if eq .NameTag "Formdata" -}}
+                    if form, err := runtime.MarshalForm({{if $hasBodyVar}}response.Body{{else}}response{{end}}, nil); err != nil {
+                        return err
+                    } else {
+                        _, err := w.Write([]byte(form.Encode()))
+                        return err
+                    }
+                {{else if eq .NameTag "Multipart" -}}
+                    defer writer.Close()
+                    return {{if $hasBodyVar}}response.Body{{else}}response{{end}}(writer);
+                {{else -}}
+                    if closer, ok := response.Body.(io.ReadCloser); ok {
+                        defer closer.Close()
+                    }
+                    _, err := io.Copy(w, response.Body)
+                    return err
+                {{end}}{{/* if eq .NameTag "JSON" */ -}}
+            }
         {{end}}
 
         {{if eq 0 (len .Contents) -}}
@@ -82,6 +115,13 @@
                     {{end -}}
                 }
             {{end -}}
+            func (response {{$opid}}{{$statusCode}}Response) Visit{{$opid}}Response(w http.ResponseWriter) error {
+                {{range $headers -}}
+                    w.Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
+                {{end -}}
+                w.WriteHeader({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
+                return nil
+            }
         {{end}}
     {{end}}
 {{end}}
@@ -91,6 +131,6 @@ type StrictServerInterface interface {
 {{range .}}{{.SummaryAsComment }}
 // ({{.Method}} {{.Path}})
 {{$opid := .OperationId -}}
-{{$opid}}(ctx context.Context, request {{$opid | ucFirst}}RequestObject) interface{}
+{{$opid}}(ctx context.Context, request {{$opid | ucFirst}}RequestObject) ({{$opid | ucFirst}}ResponseObject, error)
 {{end}}{{/* range . */ -}}
 }

--- a/pkg/codegen/templates/strict/strict-responses.tmpl
+++ b/pkg/codegen/templates/strict/strict-responses.tmpl
@@ -12,12 +12,6 @@
     {{range .Contents -}}
         {{if and (not $hasHeaders) (.IsSupported) -}}
             type {{$name}}{{.NameTagOrContentType}}Response {{if eq .NameTag "Multipart"}}func(writer *multipart.Writer)error{{else if .IsSupported}}{{if .Schema.IsRef}}={{end}} {{.Schema.TypeDecl}}{{else}}io.Reader{{end}}
-
-            {{if and (not (and .Schema.IsRef)) (eq .NameTag "JSON")}}
-                func (t {{$name}}{{.NameTagOrContentType}}Response) MarshalJSON() ([]byte, error) {
-                    return json.Marshal(({{.Schema.GoType}})(t))
-                }
-            {{end}}
         {{else -}}
             type {{$name}}{{.NameTagOrContentType}}Response struct {
                 Body {{if eq .NameTag "Multipart"}}func(writer *multipart.Writer)error{{else if .IsSupported}}{{.Schema.TypeDecl}}{{else}}io.Reader{{end}}
@@ -34,11 +28,6 @@
                     ContentLength int64
                 {{end -}}
             }
-            {{if eq .NameTag "JSON"}}
-                func (t {{$name}}{{.NameTagOrContentType}}Response) MarshalJSON() ([]byte, error) {
-                    return json.Marshal(t.Body)
-                }
-            {{end}}
         {{end -}}
     {{end -}}
 


### PR DESCRIPTION
Before this, the methods of strict server would return empty interface, like so:
`FindPets(ctx context.Context, request FindPetsRequestObject) interface{}`
With this PR, methods will return an interface unique to each method and an error, like so:
`FindPets(ctx context.Context, request FindPetsRequestObject) (FindPetsResponseObject, error)`

This method-specific interface contains a single method `Visit%METHOD_NAME%Response`, that will marshal the response into `http.ResponseWriter`:
```
type FindPetsResponseObject interface {
	VisitFindPetsResponse(w http.ResponseWriter) error
}
```

This has several advantages:
- Compile-time type checking of response type. Before, you would only get an error in runtime, if you passed an unsupported response object.
- Complicated response marshalling code moved from sever-specific code into common code, making it less error-prone
- Making it clear for user that he can return errors from strict server methods
- It is now simpler to break the strictness by making your own type that satisfies the interface. Before, you would have to use a middleware to access response writer.

The disadvantages are:
- More code is being generated (additional interfaces and methods)
- Breaking change of interface. Not that big of a deal since there was no official release with strict server. Existing user would have to change their code though.
- Harder to do middleware tricks, like redirects. Before you could return anything, catch it in a middleware and execute your own logic. Now, you would have to make separate structs for each method, or use errors (from my expirience most reusable stuff are errors anyway).

@deepmap-marcinr, can you look at this before you make a public release?

This PR is a result of discussion in #669, which this PR should close.