### PR TITLE
Document the README may not be latest tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 OpenAPI Client and Server Code Generator
 ----------------------------------------
 
+⚠️ This README may be for the latest development version, which may contain
+unreleased changes. Please ensure you're looking at the README for the latest
+release version.
+
 This package contains a set of utilities for generating Go boilerplate code for
 services based on
 [OpenAPI 3.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md)


### PR DESCRIPTION
A solution for #660, to avoid confusion about unreleased features.

This will still be present when we're on a tagged release, but that's
probably fine, and I'd prefer we avoid introducing too much overhead for
releases.

Closes #660.
