### PR TITLE
Migrate to `tidied`

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -13,8 +13,8 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Run `make tidy`
-        run: make tidy
+      - name: Install `tidied`
+        run: go install gitlab.com/jamietanna/tidied@latest
 
       - name: Check for no untracked files
-        run: git diff-index --quiet HEAD --
+        run: tidied -verbose


### PR DESCRIPTION
I've recently released this to make it simpler to manage checking
whether `go mod tidy` has been run. This is a slightly better
experience, as it'll lead to a nicer output when things are missing.
