### PR TITLE
add option to generate custom server based on user templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,19 @@ Strict server also has its own middlewares. It can access to both request and re
 as well as raw request\response data. It can be used for logging the parsed request\response objects, transforming go errors into response structs,
 authorization, etc. Note that middlewares are server-specific.
 
+#### Custom server generation
+
+oapi-codegen also supports custom templates as an input to generate server code. This option does not use any of the existing templates, all the templates must be provided by the user.
+The goal of this option is to allow users to experiment with code generation for other frameworks or even avoid frameworks if they want.
+
+The user provided folder with templates can have as many files as desired, they will be parsed and concatenated into a single file.
+
+Example usage:
+
+```bash
+oapi-codegen -generate custom-server -o server.gen.go -old-config-style -package server -templates ./your-template-folder-path examples/petstore-expanded/petstore-expanded.yaml
+```
+
 #### Additional Properties in type definitions
 
 [OpenAPI Schemas](https://swagger.io/specification/#schemaObject) implicitly
@@ -647,6 +660,8 @@ you can specify any combination of those.
  same package to compile.
 - `chi-server`: generate the Chi server boilerplate. This code is dependent on
  that produced by the `types` target.
+- `custom-server`: generate a server file based on user provided templates. This code 
+ is not dependent on the code produced by the `types` target, but could be used it also.
 - `client`: generate the client boilerplate. It, too, requires the types to be
  present in its package.
 - `spec`: embed the OpenAPI spec into the generated code as a gzipped blob.

--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -325,6 +325,8 @@ func newConfigFromOldConfig(c oldConfiguration) configuration {
 			opts.Generate.GorillaServer = true
 		case "strict-server":
 			opts.Generate.Strict = true
+		case "custom-server":
+			opts.Generate.CustomServer = true
 		case "types":
 			opts.Generate.Models = true
 		case "spec":

--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -27,6 +27,7 @@ type GenerateOptions struct {
 	GinServer     bool `yaml:"gin-server,omitempty"`     // GinServer specifies whether to generate gin server boilerplate
 	GorillaServer bool `yaml:"gorilla-server,omitempty"` // GorillaServer specifies whether to generate Gorilla server boilerplate
 	Strict        bool `yaml:"strict-server,omitempty"`  // Strict specifies whether to generate strict server wrapper
+	CustomServer  bool `yaml:"custom-server,omitempty"`  // Strict specifies whether to generate strict server wrapper
 	Client        bool `yaml:"client,omitempty"`         // Client specifies whether to generate client boilerplate
 	Models        bool `yaml:"models,omitempty"`         // Models specifies whether to generate type definitions
 	EmbeddedSpec  bool `yaml:"embedded-spec,omitempty"`  // Whether to embed the swagger spec in the generated code

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -927,6 +927,10 @@ func GenerateStrictResponses(t *template.Template, responses []ResponseDefinitio
 	return GenerateTemplates([]string{"strict/strict-responses.tmpl"}, t, responses)
 }
 
+func GenerateCustomServer(t *template.Template, operations []OperationDefinition, userTemplates []string) (string, error) {
+	return GenerateTemplates(userTemplates, t, operations)
+}
+
 // Uses the template engine to generate the function which registers our wrappers
 // as Echo path handlers.
 func GenerateClient(t *template.Template, ops []OperationDefinition) (string, error) {


### PR DESCRIPTION
The goal of this PR is to add the option to use "user provided" templates without depending on a specific framework, by using the new option `custom-server`.

Objectives:
- when calling oapi-codegen user provides a folder with multiple template files, the number of files or names do not matter
- all the files should get parsed and the result returned as a single file

Non goals
- support multiple file output (I tried this but it changed the current implementation too much) 🥲 

This is useful when you want to create custom/private implementations (in my case, based on httprouter) that are too opinionated to be used by other people.
