### PR TITLE
Be more flexible parsing config files.

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -60,7 +60,7 @@ type configuration struct {
 	OutputFile string `yaml:"output,omitempty"`
 }
 
-// This structure is deprecated. Please add no more flags here. It is here
+// oldConfiguration is deprecated. Please add no more flags here. It is here
 // for backwards compatibility and it will be removed in the future.
 type oldConfiguration struct {
 	PackageName        string                       `yaml:"package"`
@@ -113,8 +113,73 @@ func main() {
 		os.Exit(1)
 	}
 
+	// We will try to infer whether the user has an old-style config, or a new
+	// style. Start with the command line argument. If it's true, we know it's
+	// old config style.
+	var oldConfigStyle *bool
+	if flagOldConfigStyle {
+		oldConfigStyle = &flagOldConfigStyle
+	}
+
+	// We don't know yet, so keep looking. Try to parse the configuration file,
+	// if given.
+	if oldConfigStyle == nil && (flagConfigFile != "") {
+		configFile, err := os.ReadFile(flagConfigFile)
+		if err != nil {
+			errExit("error reading config file '%s': %v", flagConfigFile, err)
+		}
+		var oldConfig oldConfiguration
+		oldErr := yaml.UnmarshalStrict(configFile, &oldConfig)
+
+		var newConfig configuration
+		newErr := yaml.UnmarshalStrict(configFile, &newConfig)
+
+		// If one of the two files parses, but the other fails, we know the
+		// answer.
+		if oldErr != nil && newErr == nil {
+			f := false
+			oldConfigStyle = &f
+		} else if oldErr == nil && newErr != nil {
+			t := true
+			oldConfigStyle = &t
+		} else if oldErr != nil && newErr != nil {
+			errExit("error parsing configuration style as old version or new version: %v", err)
+		}
+		// Else we fall through, and we still don't know, so we need to infer it from flags.
+	}
+
+	if oldConfigStyle == nil {
+		// If any deprecated flag is present, and config file structure is unknown,
+		// the presence of the deprecated flag means we must be using the old
+		// config style. It should work correctly if we go down the old path,
+		// even if we have a simple config file readable as both types.
+		deprecatedFlagNames := map[string]bool{
+			"generate":             true,
+			"include-tags":         true,
+			"exclude-tags":         true,
+			"templates":            true,
+			"import-mapping":       true,
+			"exclude-schemas":      true,
+			"response-type-suffix": true,
+			"alias-types":          true,
+		}
+		hasDeprecatedFlag := false
+		flag.Visit(func(f *flag.Flag) {
+			if deprecatedFlagNames[f.Name] {
+				hasDeprecatedFlag = true
+			}
+		})
+		if hasDeprecatedFlag {
+			t := true
+			oldConfigStyle = &t
+		} else {
+			f := false
+			oldConfigStyle = &f
+		}
+	}
+
 	var opts configuration
-	if !flagOldConfigStyle {
+	if !*oldConfigStyle {
 		// We simply read the configuration from disk.
 		if flagConfigFile != "" {
 			buf, err := ioutil.ReadFile(flagConfigFile)

--- a/internal/test/client/doc.go
+++ b/internal/test/client/doc.go
@@ -1,3 +1,3 @@
 package client
 
-//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen --old-config-style --package=client -o client.gen.go client.yaml
+//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen --package=client -o client.gen.go client.yaml

--- a/internal/test/issues/issue-579/gen.go
+++ b/internal/test/issues/issue-579/gen.go
@@ -1,3 +1,3 @@
 package issue_579
 
-//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen --old-config-style --package=issue_579 --generate=types,skip-prune --alias-types -o issue.gen.go spec.yaml
+//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen --package=issue_579 --generate=types,skip-prune --alias-types -o issue.gen.go spec.yaml


### PR DESCRIPTION
Release v1.11.0 introduced a new config file format, and it's default-on, which breaks existing generation upon update. This change attempts to infer the version of the config file and flags from the the structure of the file, or the presence of deprecated flags.

Closes #629