### PR TITLE
Ft/remove loop

### DIFF
--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -16,6 +16,7 @@ package codegen
 import (
 	"encoding/json"
 	"fmt"
+	"go/token"
 	"net/url"
 	"regexp"
 	"sort"
@@ -444,40 +445,7 @@ func SortParamsByPath(path string, in []ParameterDefinition) ([]ParameterDefinit
 
 // Returns whether the given string is a go keyword
 func IsGoKeyword(str string) bool {
-	keywords := []string{
-		"break",
-		"case",
-		"chan",
-		"const",
-		"continue",
-		"default",
-		"defer",
-		"else",
-		"fallthrough",
-		"for",
-		"func",
-		"go",
-		"goto",
-		"if",
-		"import",
-		"interface",
-		"map",
-		"package",
-		"range",
-		"return",
-		"select",
-		"struct",
-		"switch",
-		"type",
-		"var",
-	}
-
-	for _, k := range keywords {
-		if k == str {
-			return true
-		}
-	}
-	return false
+	return token.IsKeyword(str)
 }
 
 // IsPredeclaredGoIdentifier returns whether the given string

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -27,9 +27,60 @@ import (
 )
 
 var pathParamRE *regexp.Regexp
+var predeclaredSet map[string]struct{}
 
 func init() {
 	pathParamRE = regexp.MustCompile("{[.;?]?([^{}*]+)\\*?}")
+
+	predeclaredIdentifiers := []string{
+		// Types
+		"bool",
+		"byte",
+		"complex64",
+		"complex128",
+		"error",
+		"float32",
+		"float64",
+		"int",
+		"int8",
+		"int16",
+		"int32",
+		"int64",
+		"rune",
+		"string",
+		"uint",
+		"uint8",
+		"uint16",
+		"uint32",
+		"uint64",
+		"uintptr",
+		// Constants
+		"true",
+		"false",
+		"iota",
+		// Zero value
+		"nil",
+		// Functions
+		"append",
+		"cap",
+		"close",
+		"complex",
+		"copy",
+		"delete",
+		"imag",
+		"len",
+		"make",
+		"new",
+		"panic",
+		"print",
+		"println",
+		"real",
+		"recover",
+	}
+	predeclaredSet = map[string]struct{}{}
+	for _, id := range predeclaredIdentifiers {
+		predeclaredSet[id] = struct{}{}
+	}
 }
 
 // Uppercase the first character in a string. This assumes UTF-8, so we have
@@ -431,59 +482,8 @@ func IsGoKeyword(str string) bool {
 //
 // See https://golang.org/ref/spec#Predeclared_identifiers
 func IsPredeclaredGoIdentifier(str string) bool {
-	predeclaredIdentifiers := []string{
-		// Types
-		"bool",
-		"byte",
-		"complex64",
-		"complex128",
-		"error",
-		"float32",
-		"float64",
-		"int",
-		"int8",
-		"int16",
-		"int32",
-		"int64",
-		"rune",
-		"string",
-		"uint",
-		"uint8",
-		"uint16",
-		"uint32",
-		"uint64",
-		"uintptr",
-		// Constants
-		"true",
-		"false",
-		"iota",
-		// Zero value
-		"nil",
-		// Functions
-		"append",
-		"cap",
-		"close",
-		"complex",
-		"copy",
-		"delete",
-		"imag",
-		"len",
-		"make",
-		"new",
-		"panic",
-		"print",
-		"println",
-		"real",
-		"recover",
-	}
-
-	for _, k := range predeclaredIdentifiers {
-		if k == str {
-			return true
-		}
-	}
-
-	return false
+	_, exists := predeclaredSet[str]
+	return exists
 }
 
 // IsGoIdentity checks if the given string can be used as an identity

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -26,8 +26,11 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-var pathParamRE *regexp.Regexp
-var predeclaredSet map[string]struct{}
+var (
+	pathParamRE    *regexp.Regexp
+	predeclaredSet map[string]struct{}
+	separatorSet   map[rune]struct{}
+)
 
 func init() {
 	pathParamRE = regexp.MustCompile("{[.;?]?([^{}*]+)\\*?}")
@@ -81,6 +84,12 @@ func init() {
 	for _, id := range predeclaredIdentifiers {
 		predeclaredSet[id] = struct{}{}
 	}
+
+	separators := "-#@!$&=.+:;_~ (){}[]"
+	separatorSet = map[rune]struct{}{}
+	for _, r := range separators {
+		separatorSet[r] = struct{}{}
+	}
 }
 
 // Uppercase the first character in a string. This assumes UTF-8, so we have
@@ -109,7 +118,6 @@ func LowercaseFirstCharacter(str string) string {
 // So, "word.word-word+word:word;word_word~word word(word)word{word}[word]"
 // would be converted to WordWordWordWordWordWordWordWordWordWordWordWordWord
 func ToCamelCase(str string) string {
-	separators := "-#@!$&=.+:;_~ (){}[]"
 	s := strings.Trim(str, " ")
 
 	n := ""
@@ -128,12 +136,7 @@ func ToCamelCase(str string) string {
 				n += string(v)
 			}
 		}
-
-		if strings.ContainsRune(separators, v) {
-			capNext = true
-		} else {
-			capNext = false
-		}
+		_, capNext = separatorSet[v]
 	}
 	return n
 }


### PR DESCRIPTION
# Overview
I've removed useless loops from generating code.

## Changes

* use dict to confirm that predeclaredIdentifiers exit in an identifier.
* use dict to confirm separator exist in an identifier instead of `strings.ContainsRune()`
* use official function (`token.IsKeyword()`) instead of self made function.