### PR TITLE
feat: add config to emit `required:"true"` field tag

### DIFF
--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -76,6 +76,7 @@ type OutputOptions struct {
 
 	ExcludeSchemas     []string `yaml:"exclude-schemas,omitempty"`      // Exclude from generation schemas with given names. Ignored when empty.
 	ResponseTypeSuffix string   `yaml:"response-type-suffix,omitempty"` // The suffix used for responses types
+	RequiredFieldTag   bool     `yaml:"required-field-tag"`             // Emit `required:"true"` tag for required fields
 }
 
 // UpdateDefaults sets reasonable default values for unset fields in Configuration

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -146,12 +146,13 @@ type Constants struct {
 //
 // Let's use this example schema:
 // components:
-//  schemas:
-//    Person:
-//      type: object
-//      properties:
-//      name:
-//        type: string
+//
+//	schemas:
+//	  Person:
+//	    type: object
+//	    properties:
+//	    name:
+//	      type: string
 type TypeDefinition struct {
 	// The name of the type, eg, type <...> Person
 	TypeName string
@@ -617,6 +618,11 @@ func GenFieldsFromProperties(props []Property) []string {
 				}
 			}
 		}
+
+		if p.Required && globalState.options.OutputOptions.RequiredFieldTag {
+			fieldTags["required"] = "true"
+		}
+
 		// Convert the fieldTags map into Go field annotations.
 		keys := SortedStringKeys(fieldTags)
 		tags := make([]string, len(keys))


### PR DESCRIPTION
It is handy for cases when openapi spec is generated from sources and source's types reuses types generated from other openapi spec.