### PR TITLE
Migrate deprecated io/ioutil package to io and os packages

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -16,7 +16,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime/debug"
@@ -182,7 +181,7 @@ func main() {
 	if !*oldConfigStyle {
 		// We simply read the configuration from disk.
 		if flagConfigFile != "" {
-			buf, err := ioutil.ReadFile(flagConfigFile)
+			buf, err := os.ReadFile(flagConfigFile)
 			if err != nil {
 				errExit("error reading config file '%s': %v", flagConfigFile, err)
 			}
@@ -199,7 +198,7 @@ func main() {
 	} else {
 		var oldConfig oldConfiguration
 		if flagConfigFile != "" {
-			buf, err := ioutil.ReadFile(flagConfigFile)
+			buf, err := os.ReadFile(flagConfigFile)
 			if err != nil {
 				errExit("error reading config file '%s': %v", flagConfigFile, err)
 			}
@@ -241,7 +240,7 @@ func main() {
 	}
 
 	if opts.OutputFile != "" {
-		err = ioutil.WriteFile(opts.OutputFile, []byte(code), 0644)
+		err = os.WriteFile(opts.OutputFile, []byte(code), 0644)
 		if err != nil {
 			errExit("error writing generated code to file: %s", err)
 		}
@@ -257,7 +256,7 @@ func loadTemplateOverrides(templatesDir string) (map[string]string, error) {
 		return templates, nil
 	}
 
-	files, err := ioutil.ReadDir(templatesDir)
+	files, err := os.ReadDir(templatesDir)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +275,7 @@ func loadTemplateOverrides(templatesDir string) (map[string]string, error) {
 			}
 			continue
 		}
-		data, err := ioutil.ReadFile(path.Join(templatesDir, f.Name()))
+		data, err := os.ReadFile(path.Join(templatesDir, f.Name()))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/test/issues/issue-grab_import_names/issue.gen.go
+++ b/internal/test/issues/issue-grab_import_names/issue.gen.go
@@ -23,7 +23,7 @@ import (
 
 // GetFooParams defines parameters for GetFoo.
 type GetFooParams struct {
-	// Foo base64. bytes. chi. context. echo. errors. fmt. gzip. http. io. ioutil. json. openapi3.
+	// Foo base64. bytes. chi. context. echo. errors. fmt. gzip. http. io. json. openapi3.
 	Foo *string `json:"Foo,omitempty"`
 
 	// Bar openapi_types. path. runtime. strings. time.Duration time.Time url. xml. yaml.

--- a/internal/test/issues/issue-grab_import_names/issue.gen.go
+++ b/internal/test/issues/issue-grab_import_names/issue.gen.go
@@ -363,12 +363,12 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/3yRwWojMQyGX0XobJQhWfYwx2XZpffeSinORMm4jC1jaUrSMO9e7MkpNDUYIWF9/vXr",
-	"ioPELImTKfbXxWFIR8H+ihZsYuyRiNDhBxcNkrDHjjrqcHEomZPPAXvcUUdbdJi9jZWCm6M0xomthgPr",
-	"UEK2FbACJXPxtfJ0wB7/s/0TaYjiIxsXxf7lvnPvlX//IthfjJVgGAPBIMn4bAQ8jELApUhRgmM0gtNn",
-	"yASjWSYIUu9sYSJ4V0kEN/27qiZU/Mj+wAUdJh/r5KsiHUaOvjlyybWsVkI64bK4e3034lt9qATVDoIy",
-	"JwuRCdY+JWjp33kdf82eQ2SYy0RwjhPBxcfpoaw/vvwo69VhYc2SlNsytl1XQzMqtX34nKcwtO831Yta",
-	"e8xb3DcLXNr5CgAA//+IR/EuPgIAAA==",
+	"H4sIAAAAAAAC/3yRQWv7MAzFv4rQ2aih/fM/5DjGxu67jTHcVG08YstY6mhX8t2HnZ7KulyERPTz03sX",
+	"HCRmSZxMsb/MDkPaC/YXtGATY49EhA6/uGiQhD121FGHs0PJnHwO2OOGOlqjw+xtrBRc7aUxDmy17FiH",
+	"ErItgAUomYuvk5cd9vjM9iTSEMVHNi6K/dvt5tYr//9HsD0bK8EwBoJBkvHJCHgYhYBLkaIE+2gEh++Q",
+	"CUazTBCE4FMlEVx1b6qKULEj+x0XdJh8rBcvSnQYOfrmxDnXsVoJ6YDz7G51XYkf9UclqDYQlGOyEJlg",
+	"2VOC1j4el7OX7jVEhmOZCE5xIjj7ON2V9eDLn7LeHRbWLEm5hbDuulqaQanl4HOewtCeX1Uv6uw+b3a/",
+	"BDe37ycAAP//wjdd4jYCAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/issues/issue-grab_import_names/spec.yaml
+++ b/internal/test/issues/issue-grab_import_names/spec.yaml
@@ -10,7 +10,7 @@ paths:
       parameters:
         - name: Foo
           in: header
-          description: base64. bytes. chi. context. echo. errors. fmt. gzip. http. io. ioutil. json. openapi3.
+          description: base64. bytes. chi. context. echo. errors. fmt. gzip. http. io. json. openapi3.
           schema:
             type: string
           required: false

--- a/internal/test/server/server_moq.gen.go
+++ b/internal/test/server/server_moq.gen.go
@@ -14,46 +14,46 @@ var _ ServerInterface = &ServerInterfaceMock{}
 
 // ServerInterfaceMock is a mock implementation of ServerInterface.
 //
-// 	func TestSomethingThatUsesServerInterface(t *testing.T) {
+//	func TestSomethingThatUsesServerInterface(t *testing.T) {
 //
-// 		// make and configure a mocked ServerInterface
-// 		mockedServerInterface := &ServerInterfaceMock{
-// 			CreateResourceFunc: func(w http.ResponseWriter, r *http.Request, argument string)  {
-// 				panic("mock out the CreateResource method")
-// 			},
-// 			CreateResource2Func: func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params)  {
-// 				panic("mock out the CreateResource2 method")
-// 			},
-// 			GetEveryTypeOptionalFunc: func(w http.ResponseWriter, r *http.Request)  {
-// 				panic("mock out the GetEveryTypeOptional method")
-// 			},
-// 			GetReservedKeywordFunc: func(w http.ResponseWriter, r *http.Request)  {
-// 				panic("mock out the GetReservedKeyword method")
-// 			},
-// 			GetResponseWithReferenceFunc: func(w http.ResponseWriter, r *http.Request)  {
-// 				panic("mock out the GetResponseWithReference method")
-// 			},
-// 			GetSimpleFunc: func(w http.ResponseWriter, r *http.Request)  {
-// 				panic("mock out the GetSimple method")
-// 			},
-// 			GetWithArgsFunc: func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams)  {
-// 				panic("mock out the GetWithArgs method")
-// 			},
-// 			GetWithContentTypeFunc: func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType)  {
-// 				panic("mock out the GetWithContentType method")
-// 			},
-// 			GetWithReferencesFunc: func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument string)  {
-// 				panic("mock out the GetWithReferences method")
-// 			},
-// 			UpdateResource3Func: func(w http.ResponseWriter, r *http.Request, pFallthrough int)  {
-// 				panic("mock out the UpdateResource3 method")
-// 			},
-// 		}
+//		// make and configure a mocked ServerInterface
+//		mockedServerInterface := &ServerInterfaceMock{
+//			CreateResourceFunc: func(w http.ResponseWriter, r *http.Request, argument string)  {
+//				panic("mock out the CreateResource method")
+//			},
+//			CreateResource2Func: func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params)  {
+//				panic("mock out the CreateResource2 method")
+//			},
+//			GetEveryTypeOptionalFunc: func(w http.ResponseWriter, r *http.Request)  {
+//				panic("mock out the GetEveryTypeOptional method")
+//			},
+//			GetReservedKeywordFunc: func(w http.ResponseWriter, r *http.Request)  {
+//				panic("mock out the GetReservedKeyword method")
+//			},
+//			GetResponseWithReferenceFunc: func(w http.ResponseWriter, r *http.Request)  {
+//				panic("mock out the GetResponseWithReference method")
+//			},
+//			GetSimpleFunc: func(w http.ResponseWriter, r *http.Request)  {
+//				panic("mock out the GetSimple method")
+//			},
+//			GetWithArgsFunc: func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams)  {
+//				panic("mock out the GetWithArgs method")
+//			},
+//			GetWithContentTypeFunc: func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType)  {
+//				panic("mock out the GetWithContentType method")
+//			},
+//			GetWithReferencesFunc: func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument string)  {
+//				panic("mock out the GetWithReferences method")
+//			},
+//			UpdateResource3Func: func(w http.ResponseWriter, r *http.Request, pFallthrough int)  {
+//				panic("mock out the UpdateResource3 method")
+//			},
+//		}
 //
-// 		// use mockedServerInterface in code that requires ServerInterface
-// 		// and then make assertions.
+//		// use mockedServerInterface in code that requires ServerInterface
+//		// and then make assertions.
 //
-// 	}
+//	}
 type ServerInterfaceMock struct {
 	// CreateResourceFunc mocks the CreateResource method.
 	CreateResourceFunc func(w http.ResponseWriter, r *http.Request, argument string)
@@ -208,7 +208,8 @@ func (mock *ServerInterfaceMock) CreateResource(w http.ResponseWriter, r *http.R
 
 // CreateResourceCalls gets all the calls that were made to CreateResource.
 // Check the length with:
-//     len(mockedServerInterface.CreateResourceCalls())
+//
+//	len(mockedServerInterface.CreateResourceCalls())
 func (mock *ServerInterfaceMock) CreateResourceCalls() []struct {
 	W        http.ResponseWriter
 	R        *http.Request
@@ -249,7 +250,8 @@ func (mock *ServerInterfaceMock) CreateResource2(w http.ResponseWriter, r *http.
 
 // CreateResource2Calls gets all the calls that were made to CreateResource2.
 // Check the length with:
-//     len(mockedServerInterface.CreateResource2Calls())
+//
+//	len(mockedServerInterface.CreateResource2Calls())
 func (mock *ServerInterfaceMock) CreateResource2Calls() []struct {
 	W              http.ResponseWriter
 	R              *http.Request
@@ -288,7 +290,8 @@ func (mock *ServerInterfaceMock) GetEveryTypeOptional(w http.ResponseWriter, r *
 
 // GetEveryTypeOptionalCalls gets all the calls that were made to GetEveryTypeOptional.
 // Check the length with:
-//     len(mockedServerInterface.GetEveryTypeOptionalCalls())
+//
+//	len(mockedServerInterface.GetEveryTypeOptionalCalls())
 func (mock *ServerInterfaceMock) GetEveryTypeOptionalCalls() []struct {
 	W http.ResponseWriter
 	R *http.Request
@@ -323,7 +326,8 @@ func (mock *ServerInterfaceMock) GetReservedKeyword(w http.ResponseWriter, r *ht
 
 // GetReservedKeywordCalls gets all the calls that were made to GetReservedKeyword.
 // Check the length with:
-//     len(mockedServerInterface.GetReservedKeywordCalls())
+//
+//	len(mockedServerInterface.GetReservedKeywordCalls())
 func (mock *ServerInterfaceMock) GetReservedKeywordCalls() []struct {
 	W http.ResponseWriter
 	R *http.Request
@@ -358,7 +362,8 @@ func (mock *ServerInterfaceMock) GetResponseWithReference(w http.ResponseWriter,
 
 // GetResponseWithReferenceCalls gets all the calls that were made to GetResponseWithReference.
 // Check the length with:
-//     len(mockedServerInterface.GetResponseWithReferenceCalls())
+//
+//	len(mockedServerInterface.GetResponseWithReferenceCalls())
 func (mock *ServerInterfaceMock) GetResponseWithReferenceCalls() []struct {
 	W http.ResponseWriter
 	R *http.Request
@@ -393,7 +398,8 @@ func (mock *ServerInterfaceMock) GetSimple(w http.ResponseWriter, r *http.Reques
 
 // GetSimpleCalls gets all the calls that were made to GetSimple.
 // Check the length with:
-//     len(mockedServerInterface.GetSimpleCalls())
+//
+//	len(mockedServerInterface.GetSimpleCalls())
 func (mock *ServerInterfaceMock) GetSimpleCalls() []struct {
 	W http.ResponseWriter
 	R *http.Request
@@ -430,7 +436,8 @@ func (mock *ServerInterfaceMock) GetWithArgs(w http.ResponseWriter, r *http.Requ
 
 // GetWithArgsCalls gets all the calls that were made to GetWithArgs.
 // Check the length with:
-//     len(mockedServerInterface.GetWithArgsCalls())
+//
+//	len(mockedServerInterface.GetWithArgsCalls())
 func (mock *ServerInterfaceMock) GetWithArgsCalls() []struct {
 	W      http.ResponseWriter
 	R      *http.Request
@@ -469,7 +476,8 @@ func (mock *ServerInterfaceMock) GetWithContentType(w http.ResponseWriter, r *ht
 
 // GetWithContentTypeCalls gets all the calls that were made to GetWithContentType.
 // Check the length with:
-//     len(mockedServerInterface.GetWithContentTypeCalls())
+//
+//	len(mockedServerInterface.GetWithContentTypeCalls())
 func (mock *ServerInterfaceMock) GetWithContentTypeCalls() []struct {
 	W           http.ResponseWriter
 	R           *http.Request
@@ -510,7 +518,8 @@ func (mock *ServerInterfaceMock) GetWithReferences(w http.ResponseWriter, r *htt
 
 // GetWithReferencesCalls gets all the calls that were made to GetWithReferences.
 // Check the length with:
-//     len(mockedServerInterface.GetWithReferencesCalls())
+//
+//	len(mockedServerInterface.GetWithReferencesCalls())
 func (mock *ServerInterfaceMock) GetWithReferencesCalls() []struct {
 	W              http.ResponseWriter
 	R              *http.Request
@@ -551,7 +560,8 @@ func (mock *ServerInterfaceMock) UpdateResource3(w http.ResponseWriter, r *http.
 
 // UpdateResource3Calls gets all the calls that were made to UpdateResource3.
 // Check the length with:
-//     len(mockedServerInterface.UpdateResource3Calls())
+//
+//	len(mockedServerInterface.UpdateResource3Calls())
 func (mock *ServerInterfaceMock) UpdateResource3Calls() []struct {
 	W            http.ResponseWriter
 	R            *http.Request

--- a/internal/test/server/server_moq.gen.go
+++ b/internal/test/server/server_moq.gen.go
@@ -14,46 +14,46 @@ var _ ServerInterface = &ServerInterfaceMock{}
 
 // ServerInterfaceMock is a mock implementation of ServerInterface.
 //
-//	func TestSomethingThatUsesServerInterface(t *testing.T) {
+// 	func TestSomethingThatUsesServerInterface(t *testing.T) {
 //
-//		// make and configure a mocked ServerInterface
-//		mockedServerInterface := &ServerInterfaceMock{
-//			CreateResourceFunc: func(w http.ResponseWriter, r *http.Request, argument string)  {
-//				panic("mock out the CreateResource method")
-//			},
-//			CreateResource2Func: func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params)  {
-//				panic("mock out the CreateResource2 method")
-//			},
-//			GetEveryTypeOptionalFunc: func(w http.ResponseWriter, r *http.Request)  {
-//				panic("mock out the GetEveryTypeOptional method")
-//			},
-//			GetReservedKeywordFunc: func(w http.ResponseWriter, r *http.Request)  {
-//				panic("mock out the GetReservedKeyword method")
-//			},
-//			GetResponseWithReferenceFunc: func(w http.ResponseWriter, r *http.Request)  {
-//				panic("mock out the GetResponseWithReference method")
-//			},
-//			GetSimpleFunc: func(w http.ResponseWriter, r *http.Request)  {
-//				panic("mock out the GetSimple method")
-//			},
-//			GetWithArgsFunc: func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams)  {
-//				panic("mock out the GetWithArgs method")
-//			},
-//			GetWithContentTypeFunc: func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType)  {
-//				panic("mock out the GetWithContentType method")
-//			},
-//			GetWithReferencesFunc: func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument string)  {
-//				panic("mock out the GetWithReferences method")
-//			},
-//			UpdateResource3Func: func(w http.ResponseWriter, r *http.Request, pFallthrough int)  {
-//				panic("mock out the UpdateResource3 method")
-//			},
-//		}
+// 		// make and configure a mocked ServerInterface
+// 		mockedServerInterface := &ServerInterfaceMock{
+// 			CreateResourceFunc: func(w http.ResponseWriter, r *http.Request, argument string)  {
+// 				panic("mock out the CreateResource method")
+// 			},
+// 			CreateResource2Func: func(w http.ResponseWriter, r *http.Request, inlineArgument int, params CreateResource2Params)  {
+// 				panic("mock out the CreateResource2 method")
+// 			},
+// 			GetEveryTypeOptionalFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 				panic("mock out the GetEveryTypeOptional method")
+// 			},
+// 			GetReservedKeywordFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 				panic("mock out the GetReservedKeyword method")
+// 			},
+// 			GetResponseWithReferenceFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 				panic("mock out the GetResponseWithReference method")
+// 			},
+// 			GetSimpleFunc: func(w http.ResponseWriter, r *http.Request)  {
+// 				panic("mock out the GetSimple method")
+// 			},
+// 			GetWithArgsFunc: func(w http.ResponseWriter, r *http.Request, params GetWithArgsParams)  {
+// 				panic("mock out the GetWithArgs method")
+// 			},
+// 			GetWithContentTypeFunc: func(w http.ResponseWriter, r *http.Request, contentType GetWithContentTypeParamsContentType)  {
+// 				panic("mock out the GetWithContentType method")
+// 			},
+// 			GetWithReferencesFunc: func(w http.ResponseWriter, r *http.Request, globalArgument int64, argument string)  {
+// 				panic("mock out the GetWithReferences method")
+// 			},
+// 			UpdateResource3Func: func(w http.ResponseWriter, r *http.Request, pFallthrough int)  {
+// 				panic("mock out the UpdateResource3 method")
+// 			},
+// 		}
 //
-//		// use mockedServerInterface in code that requires ServerInterface
-//		// and then make assertions.
+// 		// use mockedServerInterface in code that requires ServerInterface
+// 		// and then make assertions.
 //
-//	}
+// 	}
 type ServerInterfaceMock struct {
 	// CreateResourceFunc mocks the CreateResource method.
 	CreateResourceFunc func(w http.ResponseWriter, r *http.Request, argument string)
@@ -208,8 +208,7 @@ func (mock *ServerInterfaceMock) CreateResource(w http.ResponseWriter, r *http.R
 
 // CreateResourceCalls gets all the calls that were made to CreateResource.
 // Check the length with:
-//
-//	len(mockedServerInterface.CreateResourceCalls())
+//     len(mockedServerInterface.CreateResourceCalls())
 func (mock *ServerInterfaceMock) CreateResourceCalls() []struct {
 	W        http.ResponseWriter
 	R        *http.Request
@@ -250,8 +249,7 @@ func (mock *ServerInterfaceMock) CreateResource2(w http.ResponseWriter, r *http.
 
 // CreateResource2Calls gets all the calls that were made to CreateResource2.
 // Check the length with:
-//
-//	len(mockedServerInterface.CreateResource2Calls())
+//     len(mockedServerInterface.CreateResource2Calls())
 func (mock *ServerInterfaceMock) CreateResource2Calls() []struct {
 	W              http.ResponseWriter
 	R              *http.Request
@@ -290,8 +288,7 @@ func (mock *ServerInterfaceMock) GetEveryTypeOptional(w http.ResponseWriter, r *
 
 // GetEveryTypeOptionalCalls gets all the calls that were made to GetEveryTypeOptional.
 // Check the length with:
-//
-//	len(mockedServerInterface.GetEveryTypeOptionalCalls())
+//     len(mockedServerInterface.GetEveryTypeOptionalCalls())
 func (mock *ServerInterfaceMock) GetEveryTypeOptionalCalls() []struct {
 	W http.ResponseWriter
 	R *http.Request
@@ -326,8 +323,7 @@ func (mock *ServerInterfaceMock) GetReservedKeyword(w http.ResponseWriter, r *ht
 
 // GetReservedKeywordCalls gets all the calls that were made to GetReservedKeyword.
 // Check the length with:
-//
-//	len(mockedServerInterface.GetReservedKeywordCalls())
+//     len(mockedServerInterface.GetReservedKeywordCalls())
 func (mock *ServerInterfaceMock) GetReservedKeywordCalls() []struct {
 	W http.ResponseWriter
 	R *http.Request
@@ -362,8 +358,7 @@ func (mock *ServerInterfaceMock) GetResponseWithReference(w http.ResponseWriter,
 
 // GetResponseWithReferenceCalls gets all the calls that were made to GetResponseWithReference.
 // Check the length with:
-//
-//	len(mockedServerInterface.GetResponseWithReferenceCalls())
+//     len(mockedServerInterface.GetResponseWithReferenceCalls())
 func (mock *ServerInterfaceMock) GetResponseWithReferenceCalls() []struct {
 	W http.ResponseWriter
 	R *http.Request
@@ -398,8 +393,7 @@ func (mock *ServerInterfaceMock) GetSimple(w http.ResponseWriter, r *http.Reques
 
 // GetSimpleCalls gets all the calls that were made to GetSimple.
 // Check the length with:
-//
-//	len(mockedServerInterface.GetSimpleCalls())
+//     len(mockedServerInterface.GetSimpleCalls())
 func (mock *ServerInterfaceMock) GetSimpleCalls() []struct {
 	W http.ResponseWriter
 	R *http.Request
@@ -436,8 +430,7 @@ func (mock *ServerInterfaceMock) GetWithArgs(w http.ResponseWriter, r *http.Requ
 
 // GetWithArgsCalls gets all the calls that were made to GetWithArgs.
 // Check the length with:
-//
-//	len(mockedServerInterface.GetWithArgsCalls())
+//     len(mockedServerInterface.GetWithArgsCalls())
 func (mock *ServerInterfaceMock) GetWithArgsCalls() []struct {
 	W      http.ResponseWriter
 	R      *http.Request
@@ -476,8 +469,7 @@ func (mock *ServerInterfaceMock) GetWithContentType(w http.ResponseWriter, r *ht
 
 // GetWithContentTypeCalls gets all the calls that were made to GetWithContentType.
 // Check the length with:
-//
-//	len(mockedServerInterface.GetWithContentTypeCalls())
+//     len(mockedServerInterface.GetWithContentTypeCalls())
 func (mock *ServerInterfaceMock) GetWithContentTypeCalls() []struct {
 	W           http.ResponseWriter
 	R           *http.Request
@@ -518,8 +510,7 @@ func (mock *ServerInterfaceMock) GetWithReferences(w http.ResponseWriter, r *htt
 
 // GetWithReferencesCalls gets all the calls that were made to GetWithReferences.
 // Check the length with:
-//
-//	len(mockedServerInterface.GetWithReferencesCalls())
+//     len(mockedServerInterface.GetWithReferencesCalls())
 func (mock *ServerInterfaceMock) GetWithReferencesCalls() []struct {
 	W              http.ResponseWriter
 	R              *http.Request
@@ -560,8 +551,7 @@ func (mock *ServerInterfaceMock) UpdateResource3(w http.ResponseWriter, r *http.
 
 // UpdateResource3Calls gets all the calls that were made to UpdateResource3.
 // Check the length with:
-//
-//	len(mockedServerInterface.UpdateResource3Calls())
+//     len(mockedServerInterface.UpdateResource3Calls())
 func (mock *ServerInterfaceMock) UpdateResource3Calls() []struct {
 	W            http.ResponseWriter
 	R            *http.Request

--- a/internal/test/server/server_test.go
+++ b/internal/test/server/server_test.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -55,7 +55,7 @@ func TestErrorHandlerFuncBackwardsCompatible(t *testing.T) {
 	defer s.Close()
 
 	req, err := http.DefaultClient.Get(s.URL + "/get-with-args")
-	b, _ := ioutil.ReadAll(req.Body)
+	b, _ := io.ReadAll(req.Body)
 	assert.Nil(t, err)
 	assert.Equal(t, "text/plain; charset=utf-8", req.Header.Get("Content-Type"))
 	assert.Equal(t, "Query argument required_argument is required, but not found\n", string(b))

--- a/pkg/chi-middleware/oapi_validate_test.go
+++ b/pkg/chi-middleware/oapi_validate_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -96,7 +96,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	{
 		rec := doGet(t, r, "http://deepmap.ai/multiparamresource?id=50")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \"id2\"")
 			assert.Contains(t, string(body), "value is required but missing")
@@ -110,7 +110,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	{
 		rec := doGet(t, r, "http://deepmap.ai/multiparamresource")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \"id\"")
 			assert.Contains(t, string(body), "value is required but missing")
@@ -126,7 +126,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	{
 		rec := doGet(t, r, "http://deepmap.ai/multiparamresource?id=500")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \"id\"")
 			assert.Contains(t, string(body), "number must be at most 100")
@@ -142,7 +142,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	{
 		rec := doGet(t, r, "http://deepmap.ai/multiparamresource?id=abc&id2=1")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \"id\"")
 			assert.Contains(t, string(body), "parsing \"abc\": invalid syntax")
@@ -198,7 +198,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	{
 		rec := doGet(t, r, "http://deepmap.ai/multiparamresource?id=50")
 		assert.Equal(t, http.StatusTeapot, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \"id2\"")
 			assert.Contains(t, string(body), "value is required but missing")
@@ -212,7 +212,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	{
 		rec := doGet(t, r, "http://deepmap.ai/multiparamresource")
 		assert.Equal(t, http.StatusTeapot, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \"id\"")
 			assert.Contains(t, string(body), "value is required but missing")
@@ -228,7 +228,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	{
 		rec := doGet(t, r, "http://deepmap.ai/multiparamresource?id=500")
 		assert.Equal(t, http.StatusTeapot, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \"id\"")
 			assert.Contains(t, string(body), "number must be at most 100")
@@ -244,7 +244,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	{
 		rec := doGet(t, r, "http://deepmap.ai/multiparamresource?id=abc&id2=1")
 		assert.Equal(t, http.StatusTeapot, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \"id\"")
 			assert.Contains(t, string(body), "parsing \"abc\": invalid syntax")

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	_ "embed"
 	"go/format"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -114,7 +114,7 @@ func TestExamplePetStoreParseFunction(t *testing.T) {
 
 	cannedResponse := &http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewReader(bodyBytes)),
+		Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
 		Header:     http.Header{},
 	}
 	cannedResponse.Header.Add("Content-type", "application/json")

--- a/pkg/gin-middleware/oapi_validate.go
+++ b/pkg/gin-middleware/oapi_validate.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"net/http"
 	"strings"
 
@@ -36,7 +36,7 @@ const (
 
 // Create validator middleware from a YAML file path
 func OapiValidatorFromYamlFile(path string) (gin.HandlerFunc, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %s", path, err)
 	}

--- a/pkg/gin-middleware/oapi_validate_test.go
+++ b/pkg/gin-middleware/oapi_validate_test.go
@@ -19,7 +19,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -246,7 +246,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	{
 		rec := doGet(t, g, "http://deepmap.ai/multiparamresource?id=50")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "multiple errors encountered")
 			assert.Contains(t, string(body), "parameter \\\"id2\\\"")
@@ -261,7 +261,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	{
 		rec := doGet(t, g, "http://deepmap.ai/multiparamresource")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "multiple errors encountered")
 			assert.Contains(t, string(body), "parameter \\\"id\\\"")
@@ -278,7 +278,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	{
 		rec := doGet(t, g, "http://deepmap.ai/multiparamresource?id=500")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "multiple errors encountered")
 			assert.Contains(t, string(body), "parameter \\\"id\\\"")
@@ -295,7 +295,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	{
 		rec := doGet(t, g, "http://deepmap.ai/multiparamresource?id=abc&id2=1")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "multiple errors encountered")
 			assert.Contains(t, string(body), "parameter \\\"id\\\"")
@@ -352,7 +352,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	{
 		rec := doGet(t, g, "http://deepmap.ai/multiparamresource?id=50")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "Bad stuff")
 			assert.Contains(t, string(body), "parameter \\\"id2\\\"")
@@ -367,7 +367,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	{
 		rec := doGet(t, g, "http://deepmap.ai/multiparamresource")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "Bad stuff")
 			assert.Contains(t, string(body), "parameter \\\"id\\\"")
@@ -384,7 +384,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	{
 		rec := doGet(t, g, "http://deepmap.ai/multiparamresource?id=500")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "Bad stuff")
 			assert.Contains(t, string(body), "parameter \\\"id\\\"")
@@ -401,7 +401,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	{
 		rec := doGet(t, g, "http://deepmap.ai/multiparamresource?id=abc&id2=1")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "Bad stuff")
 			assert.Contains(t, string(body), "parameter \\\"id\\\"")

--- a/pkg/middleware/oapi_validate.go
+++ b/pkg/middleware/oapi_validate.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"net/http"
 	"strings"
 
@@ -41,7 +41,7 @@ const (
 
 // Create validator middleware from a YAML file path
 func OapiValidatorFromYamlFile(path string) (echo.MiddlewareFunc, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %s", path, err)
 	}

--- a/pkg/middleware/oapi_validate_test.go
+++ b/pkg/middleware/oapi_validate_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	_ "embed"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -250,7 +250,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	{
 		rec := doGet(t, e, "http://deepmap.ai/multiparamresource?id=50")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \\\"id2\\\"")
 			assert.Contains(t, string(body), "value is required but missing")
@@ -264,7 +264,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	{
 		rec := doGet(t, e, "http://deepmap.ai/multiparamresource")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \\\"id\\\"")
 			assert.Contains(t, string(body), "value is required but missing")
@@ -280,7 +280,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	{
 		rec := doGet(t, e, "http://deepmap.ai/multiparamresource?id=500")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \\\"id\\\"")
 			assert.Contains(t, string(body), "number must be at most 100")
@@ -296,7 +296,7 @@ func TestOapiRequestValidatorWithOptionsMultiError(t *testing.T) {
 	{
 		rec := doGet(t, e, "http://deepmap.ai/multiparamresource?id=abc&id2=1")
 		assert.Equal(t, http.StatusBadRequest, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \\\"id\\\"")
 			assert.Contains(t, string(body), "parsing \\\"abc\\\": invalid syntax")
@@ -358,7 +358,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	{
 		rec := doGet(t, e, "http://deepmap.ai/multiparamresource?id=50")
 		assert.Equal(t, http.StatusTeapot, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \\\"id2\\\"")
 			assert.Contains(t, string(body), "value is required but missing")
@@ -372,7 +372,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	{
 		rec := doGet(t, e, "http://deepmap.ai/multiparamresource")
 		assert.Equal(t, http.StatusTeapot, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \\\"id\\\"")
 			assert.Contains(t, string(body), "value is required but missing")
@@ -388,7 +388,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	{
 		rec := doGet(t, e, "http://deepmap.ai/multiparamresource?id=500")
 		assert.Equal(t, http.StatusTeapot, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \\\"id\\\"")
 			assert.Contains(t, string(body), "number must be at most 100")
@@ -404,7 +404,7 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 	{
 		rec := doGet(t, e, "http://deepmap.ai/multiparamresource?id=abc&id2=1")
 		assert.Equal(t, http.StatusTeapot, rec.Code)
-		body, err := ioutil.ReadAll(rec.Body)
+		body, err := io.ReadAll(rec.Body)
 		if assert.NoError(t, err) {
 			assert.Contains(t, string(body), "parameter \\\"id\\\"")
 			assert.Contains(t, string(body), "parsing \\\"abc\\\": invalid syntax")


### PR DESCRIPTION
Since Go 1.16 it's recommended to migrate away from the deprecated io/ioutil package.

This PR replaces io/ioutil by the replacement functions in the io and os packages, see https://pkg.go.dev/io/ioutil