### PR TITLE
Fix a bug where strict json decoder is not used.

### DIFF
--- a/pkg/testutil/response_handlers.go
+++ b/pkg/testutil/response_handlers.go
@@ -40,5 +40,5 @@ func jsonHandler(_ string, r io.Reader, obj interface{}, strict bool) error {
 	if strict {
 		d.DisallowUnknownFields()
 	}
-	return json.NewDecoder(r).Decode(obj)
+	return d.Decode(obj)
 }


### PR DESCRIPTION
A json decoder is created however it is not used. The Strict value is essentially useless. This PR fixes the problem and uses the created json decoder and Strict value is also used.