### PR TITLE
fix: inconsistency in newline printing on error

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -30,6 +30,7 @@ import (
 
 func errExit(format string, args ...interface{}) {
 	_, _ = fmt.Fprintf(os.Stderr, format, args...)
+	fmt.Println("")
 	os.Exit(1)
 }
 
@@ -237,7 +238,7 @@ func main() {
 
 	code, err := codegen.Generate(swagger, opts.Configuration)
 	if err != nil {
-		errExit("error generating code: %s\n", err)
+		errExit("error generating code: %s", err)
 	}
 
 	if opts.OutputFile != "" {
@@ -353,7 +354,7 @@ func updateOldConfigFromFlags(cfg oldConfiguration) oldConfiguration {
 		var err error
 		cfg.ImportMapping, err = util.ParseCommandlineMap(flagImportMapping)
 		if err != nil {
-			errExit("error parsing import-mapping: %s\n", err)
+			errExit("error parsing import-mapping: %s", err)
 		}
 	}
 	if cfg.ExcludeSchemas == nil {
@@ -411,7 +412,7 @@ func newConfigFromOldConfig(c oldConfiguration) configuration {
 
 	templates, err := loadTemplateOverrides(cfg.TemplatesDir)
 	if err != nil {
-		errExit("error loading template overrides: %s\n", err)
+		errExit("error loading template overrides: %s", err)
 	}
 	opts.OutputOptions.UserTemplates = templates
 

--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -28,9 +28,16 @@ import (
 	"github.com/deepmap/oapi-codegen/pkg/util"
 )
 
+func withNewline(s string) string {
+	if len(s) > 1 && s[len(s) - 1] != '\n' {
+		return s + "\n"
+	}
+	
+	return s
+}
+
 func errExit(format string, args ...interface{}) {
-	_, _ = fmt.Fprintf(os.Stderr, format, args...)
-	fmt.Println("")
+	_, _ = fmt.Fprintf(os.Stderr, withNewline(format), args...)
 	os.Exit(1)
 }
 

--- a/cmd/oapi-codegen/oapi-codegen_test.go
+++ b/cmd/oapi-codegen/oapi-codegen_test.go
@@ -24,3 +24,21 @@ func TestLoader(t *testing.T) {
 		}
 	}
 }
+
+func TestWithNewline(t *testing.T) {
+	testmap := [][2]string {
+		{ "", "" },
+		{ "\n", "\n" },
+		{ "\n\n", "\n\n" },
+		{ "%s", "%s\n" },
+		{ "%s\n", "%s\n" },
+		{ "%s %d", "%s %d\n" },
+		{ "%s %d\n", "%s %d\n" },
+	}
+
+	for i := 0; i < len(testmap); i += 1 {
+		if withNewline(testmap[i][0]) != testmap[i][1] {
+			t.Errorf("withNewline(%q) != %q", testmap[i][0], testmap[i][1])
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/deepmap/oapi-codegen/issues/758
Problematic lines found manually as well as with `grep 'errExit.*\\n\"' oapi-codegen.go`