### PR TITLE
AdditionalProperties and oneOf in one Schema

### DIFF
--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -217,6 +217,13 @@ type OneOfObject120 = string
 // OneOfObject121 defines model for .
 type OneOfObject121 = float32
 
+// OneOfObject13 oneOf with fixed discriminator and other fields allowed
+type OneOfObject13 struct {
+	Type                 string                 `json:"type"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+	union                json.RawMessage
+}
+
 // OneOfObject2 oneOf with inline elements
 type OneOfObject2 struct {
 	union json.RawMessage

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -779,6 +779,23 @@ func (a AdditionalPropertiesObject4_Inner) MarshalJSON() ([]byte, error) {
 	return json.Marshal(object)
 }
 
+// Getter for additional properties for OneOfObject13. Returns the specified
+// element and whether it was found
+func (a OneOfObject13) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for OneOfObject13
+func (a *OneOfObject13) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
 // AsOneOfVariant4 returns the union data inside the AnyOfObject1 as a OneOfVariant4
 func (t AnyOfObject1) AsOneOfVariant4() (OneOfVariant4, error) {
 	var body OneOfVariant4
@@ -1247,6 +1264,89 @@ func (t OneOfObject12) MarshalJSON() ([]byte, error) {
 func (t *OneOfObject12) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
+}
+
+// AsOneOfVariant1 returns the union data inside the OneOfObject13 as a OneOfVariant1
+func (t OneOfObject13) AsOneOfVariant1() (OneOfVariant1, error) {
+	var body OneOfVariant1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromOneOfVariant1 overwrites any union data inside the OneOfObject13 as the provided OneOfVariant1
+func (t *OneOfObject13) FromOneOfVariant1(v OneOfVariant1) error {
+	t.Type = "v1"
+
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeOneOfVariant1 performs a merge with any union data inside the OneOfObject13, using the provided OneOfVariant1
+func (t *OneOfObject13) MergeOneOfVariant1(v OneOfVariant1) error {
+	t.Type = "v1"
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+// AsOneOfVariant6 returns the union data inside the OneOfObject13 as a OneOfVariant6
+func (t OneOfObject13) AsOneOfVariant6() (OneOfVariant6, error) {
+	var body OneOfVariant6
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromOneOfVariant6 overwrites any union data inside the OneOfObject13 as the provided OneOfVariant6
+func (t *OneOfObject13) FromOneOfVariant6(v OneOfVariant6) error {
+	t.Type = "v6"
+
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeOneOfVariant6 performs a merge with any union data inside the OneOfObject13, using the provided OneOfVariant6
+func (t *OneOfObject13) MergeOneOfVariant6(v OneOfVariant6) error {
+	t.Type = "v6"
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(b, t.union)
+	t.union = merged
+	return err
+}
+
+func (t OneOfObject13) Discriminator() (string, error) {
+	var discriminator struct {
+		Discriminator string `json:"type"`
+	}
+	err := json.Unmarshal(t.union, &discriminator)
+	return discriminator.Discriminator, err
+}
+
+func (t OneOfObject13) ValueByDiscriminator() (interface{}, error) {
+	discriminator, err := t.Discriminator()
+	if err != nil {
+		return nil, err
+	}
+	switch discriminator {
+	case "v1":
+		return t.AsOneOfVariant1()
+	case "v6":
+		return t.AsOneOfVariant6()
+	default:
+		return nil, errors.New("unknown discriminator value: " + discriminator)
+	}
 }
 
 // AsOneOfObject20 returns the union data inside the OneOfObject2 as a OneOfObject20
@@ -1983,4 +2083,67 @@ func (t *OneOfObject9) UnmarshalJSON(b []byte) error {
 	}
 
 	return err
+}
+
+// Override default JSON handling for OneOfObject13 to handle AdditionalProperties and union
+func (a *OneOfObject13) UnmarshalJSON(b []byte) error {
+	err := a.union.UnmarshalJSON(b)
+	if err != nil {
+		return err
+	}
+	object := make(map[string]json.RawMessage)
+	err = json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["type"]; found {
+		err = json.Unmarshal(raw, &a.Type)
+		if err != nil {
+			return fmt.Errorf("error reading 'type': %w", err)
+		}
+		delete(object, "type")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for OneOfObject13 to handle AdditionalProperties and union
+func (a OneOfObject13) MarshalJSON() ([]byte, error) {
+	var err error
+	b, err := a.union.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	object := make(map[string]json.RawMessage)
+	if a.union != nil {
+		err = json.Unmarshal(b, &object)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	object["type"], err = json.Marshal(a.Type)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'type': %w", err)
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
 }

--- a/internal/test/components/components.yaml
+++ b/internal/test/components/components.yaml
@@ -325,6 +325,23 @@ components:
         - oneOf:
             - $ref: '#/components/schemas/OneOfVariant3'
             - $ref: '#/components/schemas/OneOfVariant4'
+    OneOfObject13:
+      description: oneOf with fixed discriminator and other fields allowed
+      type: object
+      properties:
+        type:
+          type: string
+      oneOf:
+        - $ref: '#/components/schemas/OneOfVariant1'
+        - $ref: '#/components/schemas/OneOfVariant6'
+      discriminator:
+        propertyName: type
+        mapping:
+          v1: '#/components/schemas/OneOfVariant1'
+          v6: '#/components/schemas/OneOfVariant6'
+      required:
+        - type
+      additionalProperties: true
     AnyOfObject1:
       description: simple anyOf case
       anyOf:

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -386,7 +386,7 @@ func GenerateTypeDefinitions(t *template.Template, swagger *openapi3.T, ops []Op
 		return "", fmt.Errorf("error generating union boilerplate: %w", err)
 	}
 
-	unionAndAdditionalBoilerplate, err := GenerateUnionBoilerplate(t, allTypes)
+	unionAndAdditionalBoilerplate, err := GenerateUnionAndAdditionalProopertiesBoilerplate(t, allTypes)
 	if err != nil {
 		return "", fmt.Errorf("error generating boilerplate for union types with additionalProperties: %w", err)
 	}
@@ -730,7 +730,7 @@ func GenerateAdditionalPropertyBoilerplate(t *template.Template, typeDefs []Type
 
 		m[t.TypeName] = true
 
-		if t.Schema.HasAdditionalProperties && len(t.Schema.UnionElements) == 0 {
+		if t.Schema.HasAdditionalProperties {
 			filteredTypes = append(filteredTypes, t)
 		}
 	}
@@ -747,7 +747,7 @@ func GenerateAdditionalPropertyBoilerplate(t *template.Template, typeDefs []Type
 func GenerateUnionBoilerplate(t *template.Template, typeDefs []TypeDefinition) (string, error) {
 	var filteredTypes []TypeDefinition
 	for _, t := range typeDefs {
-		if len(t.Schema.UnionElements) != 0 && !t.Schema.HasAdditionalProperties {
+		if len(t.Schema.UnionElements) != 0 {
 			filteredTypes = append(filteredTypes, t)
 		}
 	}
@@ -776,14 +776,14 @@ func GenerateUnionAndAdditionalProopertiesBoilerplate(t *template.Template, type
 	if len(filteredTypes) == 0 {
 		return "", nil
 	}
-
+	return "", nil
 	context := struct {
 		Types []TypeDefinition
 	}{
 		Types: filteredTypes,
 	}
 
-	return GenerateTemplates([]string{"union-and-additonal-properties.tmpl"}, t, context)
+	return GenerateTemplates([]string{"union-and-additional-properties.tmpl"}, t, context)
 }
 
 // SanitizeCode runs sanitizers across the generated Go code to ensure the

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -776,7 +776,6 @@ func GenerateUnionAndAdditionalProopertiesBoilerplate(t *template.Template, type
 	if len(filteredTypes) == 0 {
 		return "", nil
 	}
-	return "", nil
 	context := struct {
 		Types []TypeDefinition
 	}{

--- a/pkg/codegen/templates/additional-properties.tmpl
+++ b/pkg/codegen/templates/additional-properties.tmpl
@@ -17,7 +17,7 @@ func (a *{{.TypeName}}) Set(fieldName string, value {{$addType}}) {
     a.AdditionalProperties[fieldName] = value
 }
 
-{{if eq 0 (len .Schema.UnionElements) -}}}
+{{if eq 0 (len .Schema.UnionElements) -}}
 // Override default JSON handling for {{.TypeName}} to handle AdditionalProperties
 func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
     object := make(map[string]json.RawMessage)

--- a/pkg/codegen/templates/additional-properties.tmpl
+++ b/pkg/codegen/templates/additional-properties.tmpl
@@ -17,6 +17,7 @@ func (a *{{.TypeName}}) Set(fieldName string, value {{$addType}}) {
     a.AdditionalProperties[fieldName] = value
 }
 
+{{if eq 0 (len .Schema.UnionElements) -}}}
 // Override default JSON handling for {{.TypeName}} to handle AdditionalProperties
 func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
     object := make(map[string]json.RawMessage)
@@ -67,4 +68,5 @@ func (a {{.TypeName}}) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(object)
 }
+{{end}}
 {{end}}

--- a/pkg/codegen/templates/union-and-additional-properties.tmpl
+++ b/pkg/codegen/templates/union-and-additional-properties.tmpl
@@ -1,0 +1,53 @@
+{{range .Types}}{{$addType := .Schema.AdditionalPropertiesType.TypeDecl}}
+
+// Override default JSON handling for {{.TypeName}} to handle AdditionalProperties and union
+func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
+    object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+{{range .Schema.Properties}}
+    if raw, found := object["{{.JsonFieldName}}"]; found {
+        err = json.Unmarshal(raw, &a.{{.GoFieldName}})
+        if err != nil {
+            return fmt.Errorf("error reading '{{.JsonFieldName}}': %w", err)
+        }
+        delete(object, "{{.JsonFieldName}}")
+    }
+{{end}}
+    if len(object) != 0 {
+        a.AdditionalProperties = make(map[string]{{$addType}})
+        for fieldName, fieldBuf := range object {
+            var fieldVal {{$addType}}
+            err := json.Unmarshal(fieldBuf, &fieldVal)
+            if err != nil {
+                return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+            }
+            a.AdditionalProperties[fieldName] = fieldVal
+        }
+    }
+	return nil
+}
+
+// Override default JSON handling for {{.TypeName}} to handle AdditionalProperties and union
+func (a {{.TypeName}}) MarshalJSON() ([]byte, error) {
+    var err error
+    object := make(map[string]json.RawMessage)
+{{range .Schema.Properties}}
+{{if not .Required}}if a.{{.GoFieldName}} != nil { {{end}}
+    object["{{.JsonFieldName}}"], err = json.Marshal(a.{{.GoFieldName}})
+    if err != nil {
+        return nil, fmt.Errorf("error marshaling '{{.JsonFieldName}}': %w", err)
+    }
+{{if not .Required}} }{{end}}
+{{end}}
+    for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+{{end}}

--- a/pkg/codegen/templates/union-and-additional-properties.tmpl
+++ b/pkg/codegen/templates/union-and-additional-properties.tmpl
@@ -7,7 +7,7 @@
 
 // Override default JSON handling for {{.TypeName}} to handle AdditionalProperties and union
 func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
-    err := t.union.UnmarshalJSON(b)
+    err := a.union.UnmarshalJSON(b)
     if err != nil {
         return err
     }
@@ -42,12 +42,12 @@ func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
 // Override default JSON handling for {{.TypeName}} to handle AdditionalProperties and union
 func (a {{.TypeName}}) MarshalJSON() ([]byte, error) {
     var err error
-    b, err := t.union.MarshalJSON()
+    b, err := a.union.MarshalJSON()
     if err != nil {
         return nil, err
     }
     object := make(map[string]json.RawMessage)
-    if t.union != nil {
+    if a.union != nil {
         err = json.Unmarshal(b, &object)
         if err != nil {
             return nil, err

--- a/pkg/codegen/templates/union-and-additional-properties.tmpl
+++ b/pkg/codegen/templates/union-and-additional-properties.tmpl
@@ -1,9 +1,18 @@
-{{range .Types}}{{$addType := .Schema.AdditionalPropertiesType.TypeDecl}}
+{{range .Types}}
+
+{{$addType := .Schema.AdditionalPropertiesType.TypeDecl}}
+{{$typeName := .TypeName -}}
+{{$discriminator := .Schema.Discriminator}}
+{{$properties := .Schema.Properties -}}
 
 // Override default JSON handling for {{.TypeName}} to handle AdditionalProperties and union
 func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
+    err := t.union.UnmarshalJSON(b)
+    if err != nil {
+        return err
+    }
     object := make(map[string]json.RawMessage)
-	err := json.Unmarshal(b, &object)
+	err = json.Unmarshal(b, &object)
 	if err != nil {
 		return err
 	}
@@ -33,7 +42,17 @@ func (a *{{.TypeName}}) UnmarshalJSON(b []byte) error {
 // Override default JSON handling for {{.TypeName}} to handle AdditionalProperties and union
 func (a {{.TypeName}}) MarshalJSON() ([]byte, error) {
     var err error
+    b, err := t.union.MarshalJSON()
+    if err != nil {
+        return nil, err
+    }
     object := make(map[string]json.RawMessage)
+    if t.union != nil {
+        err = json.Unmarshal(b, &object)
+        if err != nil {
+            return nil, err
+        }
+    }
 {{range .Schema.Properties}}
 {{if not .Required}}if a.{{.GoFieldName}} != nil { {{end}}
     object["{{.JsonFieldName}}"], err = json.Marshal(a.{{.GoFieldName}})

--- a/pkg/codegen/templates/union.tmpl
+++ b/pkg/codegen/templates/union.tmpl
@@ -86,6 +86,8 @@
         {{end}}
     {{end}}
 
+    {{if not .Schema.HasAdditionalProperties}}
+
     func (t {{.TypeName}}) MarshalJSON() ([]byte, error) {
         b, err := t.union.MarshalJSON()
         {{if ne 0 (len .Schema.Properties) -}}
@@ -132,4 +134,5 @@
         {{end -}}
         return err
     }
+    {{end}}
 {{end}}


### PR DESCRIPTION
Demonstrates and fixes a problem when a schema has both `additionalProperties` and `oneOf` union, and two clashing `MarshalJSON` and `UnmarshalJSON` methods are generated:

https://github.com/deepmap/oapi-codegen/issues/763

The handling isn't perfect, because the fields that belong to the variants also get copied into the additionalProperties on unmarshal (since in the general case with delayed unmarshalling we don't yet know which of the variants we are dealing with)
but it's strictly better than the previous behaviour when invalid code was generated, while it doesn't change the behaviour in all other cases.

An alternative treatment could be that in such cases the additional properties are "propagated down" into the oneOf elements