### PR TITLE
cleanup: Remove dependency github.com/cyberdelia/templates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/deepmap/oapi-codegen
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0
-	github.com/cyberdelia/templates v1.0.0
 	github.com/getkin/kin-openapi v0.104.0
 	github.com/gin-gonic/gin v1.8.1
 	github.com/go-chi/chi/v5 v5.0.7

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7D
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyberdelia/templates v1.0.0 h1:9QMxMNj0deS+mhdrlpqJdjKgKyj3y6o44JABXL237ZA=
-github.com/cyberdelia/templates v1.0.0/go.mod h1:FP2410OYqQxXlUvpRmWfR8C5nxMmviRI8wK7vseMqZc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -3,6 +3,5 @@
 package tools
 
 import (
-	_ "github.com/cyberdelia/templates"
 	_ "github.com/matryer/moq"
 )


### PR DESCRIPTION
It seems like during the [switch](https://github.com/deepmap/oapi-codegen/commit/bd5a9da83dee05811c7764ae8b2f469367a8368d#diff-32d0a1dc00ed0c3bd9c5d7f62a16c4c7ed7e02d3ff5c9fe9c2020c99d458cb74) from cyberdelia/templates to the new embed package the dependency was not cleaned up. 