### PR TITLE
Add Problem Details content types

### DIFF
--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -29,9 +29,9 @@ const (
 )
 
 var (
-	contentTypesJSON = []string{echo.MIMEApplicationJSON, "text/x-json"}
+	contentTypesJSON = []string{echo.MIMEApplicationJSON, "text/x-json", "application/problem+json"}
 	contentTypesYAML = []string{"application/yaml", "application/x-yaml", "text/yaml", "text/x-yaml"}
-	contentTypesXML  = []string{echo.MIMEApplicationXML, echo.MIMETextXML}
+	contentTypesXML  = []string{echo.MIMEApplicationXML, echo.MIMETextXML, "application/problems+xml"}
 
 	responseTypeSuffix = "Response"
 )


### PR DESCRIPTION
[RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807#section-6) defines standard content types of HTTP APIs returning Problem Details responses
* `application/problem+json`
* `application/problem+xml`

Adding these types to the list of standard types to support these scenarios.

Something else to consider could be allowing `application/<something>+json` to always map to JSON/XML or whatever?  Worth the effort?