### PR TITLE
Onboard to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
To keep us up-to-date with our dependencies, we should use Dependabot.
Weekly updates should hopefully be a good way of staying maintainable,
without being too much PR noise.
