### PR TITLE
Enable forcing non-pointer types using Nullable

### DIFF
--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -93,8 +93,8 @@ func (p Property) GoFieldName() string {
 
 func (p Property) GoTypeDef() string {
 	typeDef := p.Schema.TypeDecl()
-	if !p.Schema.SkipOptionalPointer &&
-		(!p.Required || p.Nullable ||
+	if p.Nullable && !p.Schema.SkipOptionalPointer &&
+		(!p.Required ||
 			(p.ReadOnly && (!p.Required || !globalState.options.Compatibility.DisableRequiredReadOnlyAsPointer)) ||
 			p.WriteOnly) {
 


### PR DESCRIPTION
Proposed update to GoTypeDef to enable forcing a non pointer type. This is useful in go to avoid using `*string` instead of `string` in most cases where the value is not required, but there's no need to differentiate between `nil` and empty string values.

There may need to be some more semantics around this in order to force the pointer in some cases where `p.Nullable` is true.  We probably need some discussion around this prior to merging.

See also #479