### PR TITLE
829 fix: shouldBind instead of Bind to prevent abort

### DIFF
--- a/internal/test/strict-server/gin/server.gen.go
+++ b/internal/test/strict-server/gin/server.gen.go
@@ -705,7 +705,8 @@ func (sh *strictHandler) JSONExample(ctx *gin.Context) {
 	var request JSONExampleRequestObject
 
 	var body JSONExampleJSONRequestBody
-	if err := ctx.Bind(&body); err != nil {
+	if err := ctx.ShouldBind(&body); err != nil {
+		ctx.Status(http.StatusBadRequest)
 		ctx.Error(err)
 		return
 	}
@@ -768,7 +769,8 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx *gin.Context) {
 
 	if strings.HasPrefix(ctx.GetHeader("Content-Type"), "application/json") {
 		var body MultipleRequestAndResponseTypesJSONRequestBody
-		if err := ctx.Bind(&body); err != nil {
+		if err := ctx.ShouldBind(&body); err != nil {
+			ctx.Status(http.StatusBadRequest)
 			ctx.Error(err)
 			return
 		}
@@ -832,7 +834,8 @@ func (sh *strictHandler) ReusableResponses(ctx *gin.Context) {
 	var request ReusableResponsesRequestObject
 
 	var body ReusableResponsesJSONRequestBody
-	if err := ctx.Bind(&body); err != nil {
+	if err := ctx.ShouldBind(&body); err != nil {
+		ctx.Status(http.StatusBadRequest)
 		ctx.Error(err)
 		return
 	}
@@ -986,7 +989,8 @@ func (sh *strictHandler) HeadersExample(ctx *gin.Context, params HeadersExampleP
 	request.Params = params
 
 	var body HeadersExampleJSONRequestBody
-	if err := ctx.Bind(&body); err != nil {
+	if err := ctx.ShouldBind(&body); err != nil {
+		ctx.Status(http.StatusBadRequest)
 		ctx.Error(err)
 		return
 	}

--- a/pkg/codegen/templates/strict/strict-gin.tmpl
+++ b/pkg/codegen/templates/strict/strict-gin.tmpl
@@ -35,7 +35,8 @@ type strictHandler struct {
             {{if $multipleBodies}}if strings.HasPrefix(ctx.GetHeader("Content-Type"), "{{.ContentType}}") { {{end}}
                 {{if eq .NameTag "JSON" -}}
                     var body {{$opid}}{{.NameTag}}RequestBody
-                    if err := ctx.Bind(&body); err != nil {
+                    if err := ctx.ShouldBind(&body); err != nil {
+                        ctx.Status(http.StatusBadRequest)
                         ctx.Error(err)
                         return
                     }


### PR DESCRIPTION
Fix for #829

Use shouldBind instead of (must)Bind to allow custom error response. 