### PR TITLE
Make external ref internalization optional

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -233,8 +233,12 @@ func Generate(spec *openapi3.T, opts Configuration) (string, error) {
 	}
 
 	var inlinedSpec string
+	var refNameResolver openapi3.RefNameResolver
+	if opts.OutputOptions.InternalizeRefs {
+		refNameResolver = openapi3.DefaultRefNameResolver
+	}
 	if opts.Generate.EmbeddedSpec {
-		inlinedSpec, err = GenerateInlinedSpec(t, importMapping, spec)
+		inlinedSpec, err = GenerateInlinedSpec(t, importMapping, spec, refNameResolver)
 		if err != nil {
 			return "", fmt.Errorf("error generating Go handlers for Paths: %w", err)
 		}

--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -82,6 +82,7 @@ type OutputOptions struct {
 	ExcludeSchemas     []string `yaml:"exclude-schemas,omitempty"`      // Exclude from generation schemas with given names. Ignored when empty.
 	ResponseTypeSuffix string   `yaml:"response-type-suffix,omitempty"` // The suffix used for responses types
 	ClientTypeName     string   `yaml:"client-type-name,omitempty"`     // Override the default generated client type with the value
+	InternalizeRefs    bool     `yaml:"internalize-refs,omitempty"`     // Internalize external $ref types
 }
 
 // UpdateDefaults sets reasonable default values for unset fields in Configuration

--- a/pkg/codegen/inline.go
+++ b/pkg/codegen/inline.go
@@ -26,9 +26,11 @@ import (
 
 // GenerateInlinedSpec generates a gzipped, base64 encoded JSON representation of the
 // swagger definition, which we embed inside the generated code.
-func GenerateInlinedSpec(t *template.Template, importMapping importMap, swagger *openapi3.T) (string, error) {
+func GenerateInlinedSpec(t *template.Template, importMapping importMap, swagger *openapi3.T, refNameResolver openapi3.RefNameResolver) (string, error) {
 	// ensure that any external file references are embedded into the embedded spec
-	swagger.InternalizeRefs(context.Background(), nil)
+	if refNameResolver != nil {
+		swagger.InternalizeRefs(context.Background(), refNameResolver)
+	}
 	// Marshal to json
 	encoded, err := swagger.MarshalJSON()
 	if err != nil {


### PR DESCRIPTION
This disables the call to `InternalizeRefs` by default in `GenerateInlinedSpec`.

Currently, internalizing external references results in broken validator due to https://github.com/getkin/kin-openapi/issues/618 and is unnecessary because of `import-mapping` configuration feature. 

Not sure if the call to `InternalizeRefs` is an artifact, so added a flag to enable in output options but can remove it all together as well per the maintainers' discretion.