### PR TITLE
feat(config): add type mapping

### DIFF
--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -82,6 +82,32 @@ type OutputOptions struct {
 	ExcludeSchemas     []string `yaml:"exclude-schemas,omitempty"`      // Exclude from generation schemas with given names. Ignored when empty.
 	ResponseTypeSuffix string   `yaml:"response-type-suffix,omitempty"` // The suffix used for responses types
 	ClientTypeName     string   `yaml:"client-type-name,omitempty"`     // Override the default generated client type with the value
+
+	// TypeMappings provides the ability to configure how types are mapped
+	// including overriding the default behaviour.
+	// Entries keys are in the format: <schemaType>:<schemaFormat>.
+	//
+	// An example of a custom type for type: "string", format: "uuid":
+	//   type-mappings:
+	//     string-uuid:
+	//       skip-optional-pointer: true
+	//       define-via-alias: true
+	TypeMappings map[string]TypeMapping `yaml:"type-mappings,omitempty"`
+}
+
+// TypeMapping defines a schema type mapping override.
+type TypeMapping struct {
+	// GoType is the go type that will be used to represent the schema.
+	GoType string `yaml:"go-type"`
+
+	// SkipOptionalPointer should be set t true if we don't need a pointer type
+	// even when they are optional.
+	SkipOptionalPointer bool `yaml:"skip-optional-pointer"`
+
+	// DefineViaAlias if true schema will declare a type via alias
+	// `type Foo = bool`, otherwise the type definition will be a classic
+	// `type Foo bool`
+	DefineViaAlias bool `yaml:"define-via-alias"`
 }
 
 // UpdateDefaults sets reasonable default values for unset fields in Configuration

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -473,6 +473,14 @@ func oapiSchemaToGoType(schema *openapi3.Schema, path []string, outSchema *Schem
 	f := schema.Format
 	t := schema.Type
 
+	if tm, ok := globalState.options.OutputOptions.TypeMappings[t+"-"+f]; ok {
+		// Config TypeMapping override.
+		outSchema.GoType = tm.GoType
+		outSchema.DefineViaAlias = tm.DefineViaAlias
+		outSchema.SkipOptionalPointer = tm.SkipOptionalPointer
+		return nil
+	}
+
 	switch t {
 	case "array":
 		// For arrays, we'll get the type of the Items and throw a

--- a/pkg/codegen/schema_test.go
+++ b/pkg/codegen/schema_test.go
@@ -1,0 +1,120 @@
+package codegen
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+type testSchema struct {
+	schema openapi3.Schema
+	path   []string
+	want   Schema
+	err    string
+}
+
+func Test_oapiSchemaToGoType(t *testing.T) {
+	tests := make(map[string]*testSchema)
+	addTest := func(schemaType, schemaFormat, want, err string) {
+		tests[schemaType+"-"+schemaFormat] = &testSchema{
+			schema: openapi3.Schema{
+				Type:   schemaType,
+				Format: schemaFormat,
+			},
+			want: Schema{
+				GoType:         want,
+				DefineViaAlias: true,
+			},
+			err: err,
+		}
+	}
+
+	// Integers.
+	for _, format := range []string{
+		"int64",
+		"int32", "int16", "int8", "int",
+		"uint64", "uint32", "uint16", "uint8", "uint",
+		"unknown",
+	} {
+		want := format
+		switch format {
+		case "unknown", "":
+			want = "int"
+		}
+		addTest("integer", format, want, "")
+	}
+
+	// Numbers.
+	for _, tt := range [][3]string{
+		{"double", "float64"},
+		{"float", "float32"},
+		{"", "float32"},
+		{"unknown", "", "invalid number format: unknown"},
+	} {
+		addTest("number", tt[0], tt[1], tt[2])
+	}
+
+	// Booleans.
+	addTest("boolean", "", "bool", "")
+	addTest("boolean", "unknown", "", "invalid format (unknown) for boolean")
+
+	// Strings.
+	for _, tt := range [][3]string{
+		{"byte", "[]byte"},
+		{"email", "openapi_types.Email"},
+		{"date", "openapi_types.Date"},
+		{"date-time", "time.Time"},
+		{"json", "json.RawMessage"},
+		{"uuid", "openapi_types.UUID"},
+		{"binary", "openapi_types.File"},
+		{"", "string"},
+		{"other", "string"},
+	} {
+		addTest("string", tt[0], tt[1], tt[2])
+	}
+	tests["string-json"].want.SkipOptionalPointer = true
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			outSchema := &Schema{}
+			err := oapiSchemaToGoType(&tt.schema, tt.path, outSchema)
+			if tt.err != "" {
+				require.EqualError(t, err, tt.err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, *outSchema)
+		})
+	}
+
+	// Overrides
+	old := globalState.options.OutputOptions.TypeMappings
+	globalState.options.OutputOptions.TypeMappings = map[string]TypeMapping{
+		"string-uuid": {
+			GoType:              "mypkg.UUID",
+			SkipOptionalPointer: true,
+		},
+	}
+	defer func() { globalState.options.OutputOptions.TypeMappings = old }()
+
+	tests = make(map[string]*testSchema)
+	addTest("string", "uuid", "mypkg.UUID", "")
+	tests["string-uuid"].want.SkipOptionalPointer = true
+	tests["string-uuid"].want.DefineViaAlias = false
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			outSchema := &Schema{}
+			err := oapiSchemaToGoType(&tt.schema, tt.path, outSchema)
+			if tt.err != "" {
+				require.EqualError(t, err, tt.err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, *outSchema)
+		})
+	}
+}


### PR DESCRIPTION
Add the ability to override type the default type mapping behaviour so that users can easily provide global control of their go type generation without having to use x-go-type for every occurrence.