### PR TITLE
chore: move install mapping to global state

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -37,8 +37,9 @@ var templates embed.FS
 // globalState stores all global state. Please don't put global state anywhere
 // else so that we can easily track it.
 var globalState struct {
-	options Configuration
-	spec    *openapi3.T
+	options       Configuration
+	spec          *openapi3.T
+	importMapping importMap
 }
 
 // goImport represents a go package to be imported in the generated code
@@ -66,8 +67,6 @@ func (im importMap) GoImports() []string {
 	}
 	return goImports
 }
-
-var importMapping importMap
 
 func constructImportMapping(importMapping map[string]string) importMap {
 	var (
@@ -101,8 +100,7 @@ func Generate(spec *openapi3.T, opts Configuration) (string, error) {
 	// This is global state
 	globalState.options = opts
 	globalState.spec = spec
-
-	importMapping = constructImportMapping(opts.ImportMapping)
+	globalState.importMapping = constructImportMapping(opts.ImportMapping)
 
 	filterOperationsByTag(spec, opts)
 	if !opts.OutputOptions.SkipPrune {
@@ -234,7 +232,7 @@ func Generate(spec *openapi3.T, opts Configuration) (string, error) {
 
 	var inlinedSpec string
 	if opts.Generate.EmbeddedSpec {
-		inlinedSpec, err = GenerateInlinedSpec(t, importMapping, spec)
+		inlinedSpec, err = GenerateInlinedSpec(t, globalState.importMapping, spec)
 		if err != nil {
 			return "", fmt.Errorf("error generating Go handlers for Paths: %w", err)
 		}
@@ -243,7 +241,7 @@ func Generate(spec *openapi3.T, opts Configuration) (string, error) {
 	var buf bytes.Buffer
 	w := bufio.NewWriter(&buf)
 
-	externalImports := append(importMapping.GoImports(), importMap(xGoTypeImports).GoImports()...)
+	externalImports := append(globalState.importMapping.GoImports(), importMap(xGoTypeImports).GoImports()...)
 	importsOut, err := GenerateImports(t, externalImports, opts.PackageName)
 	if err != nil {
 		return "", fmt.Errorf("error generating imports: %w", err)

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -334,7 +334,7 @@ func refPathToGoType(refPath string, local bool) (string, error) {
 		return "", fmt.Errorf("unsupported reference: %s", refPath)
 	}
 	remoteComponent, flatComponent := pathParts[0], pathParts[1]
-	if goImport, ok := importMapping[remoteComponent]; !ok {
+	if goImport, ok := globalState.importMapping[remoteComponent]; !ok {
 		return "", fmt.Errorf("unrecognized external reference '%s'; please provide the known import for this reference using option --import-mapping", remoteComponent)
 	} else {
 		goType, err := refPathToGoType("#"+flatComponent, false)

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -134,12 +134,12 @@ func TestSortedRequestBodyKeys(t *testing.T) {
 }
 
 func TestRefPathToGoType(t *testing.T) {
-	old := importMapping
-	importMapping = constructImportMapping(map[string]string{
+	old := globalState.importMapping
+	globalState.importMapping = constructImportMapping(map[string]string{
 		"doc.json":                    "externalref0",
 		"http://deepmap.com/doc.json": "externalref1",
 	})
-	defer func() { importMapping = old }()
+	defer func() { globalState.importMapping = old }()
 
 	tests := []struct {
 		name   string


### PR DESCRIPTION
Move importMapping into globalState along side other global variables so its all in one place as per comment on that struct.