### PR TITLE
Fix error handling when empty query string passed

### DIFF
--- a/pkg/codegen/templates/gin/gin-wrappers.tmpl
+++ b/pkg/codegen/templates/gin/gin-wrappers.tmpl
@@ -69,9 +69,8 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(c *gin.Context) {
           params.{{.GoName}} = {{if not .Required}}&{{end}}value
         {{end}}
         }{{if .Required}} else {
-           if !siw.ErrorHandler(c, fmt.Errorf("Query argument {{.ParamName}} is required, but not found: %s", err), http.StatusBadRequest) {
-             return
-           }
+          siw.ErrorHandler(c, fmt.Errorf("Query argument {{.ParamName}} is required, but not found: %s", err), http.StatusBadRequest)
+          return
         }{{end}}
       {{end}}
 


### PR DESCRIPTION
This fixes an error that occurs when using query parameter with gin.

Though siw.ErrorHandler returns no value, the template code tries to use the return value.

```
siw.ErrorHandler(c, fmt.Errorf("Query argument <ParamName> is required, but not found: %s", err), http.StatusBadRequest) (no value) used as valuecompiler[TooManyValues](https://pkg.go.dev/golang.org/x/tools/internal/typesinternal#TooManyValues)
```

Change of this p-r fixes the error in my environment.