### PR TITLE
Fixes #748, issue with generated strict server response function when schema object using anyof

### DIFF
--- a/pkg/codegen/templates/strict/strict-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-interface.tmpl
@@ -79,7 +79,8 @@
                 w.WriteHeader({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
                 {{$hasBodyVar := or ($hasHeaders) (not $fixedStatusCode) (not .IsSupported)}}
                 {{if eq .NameTag "JSON" -}}
-                    return json.NewEncoder(w).Encode({{if $hasBodyVar}}response.Body{{else}}response{{end}})
+                    {{$hasUnionElements := ne 0 (len .Schema.UnionElements)}}
+                    return json.NewEncoder(w).Encode(response{{if $hasBodyVar}}.Body{{else if $hasUnionElements}}.union{{end}})
                 {{else if eq .NameTag "Text" -}}
                     _, err := w.Write([]byte({{if $hasBodyVar}}response.Body{{else}}response{{end}}))
                     return err


### PR DESCRIPTION
Fixes #748, issue with generated strict server response function when schema object using anyof.  Changed template for Visit*Response to check if response has union elements and if it has len, pass `response.union` to encode