### PR TITLE
Add all enum values helper

### DIFF
--- a/pkg/codegen/templates/constants.tmpl
+++ b/pkg/codegen/templates/constants.tmpl
@@ -12,4 +12,9 @@ const (
   {{$name}} {{$Enum.TypeName}} = {{$Enum.ValueWrapper}}{{$value}}{{$Enum.ValueWrapper -}}
 {{end}}
 )
+var All{{$Enum.TypeName}}s = []{{$Enum.TypeName}}{
+{{range $name, $value := $Enum.GetValues -}}
+  {{$name}},
+{{end}}
+}
 {{end}}


### PR DESCRIPTION
Hi, what do you think of something like this?

```go
// Defines values for Weather.
const (
	WeatherSunny   Weather = "sunny"
	WeatherRaining Weather = "raining"
)

var AllWeathers = []Weather{
	WeatherSunny,
	WeatherRaining,
}

```

This would be very useful when integrating with other frameworks or libraries (e.g. writing a terraform provider).
It could also be hidden behind a flag to not bloat by default.

Let me know what you think.