### PR TITLE
change error message when failed parsing date-time in deepObject

### DIFF
--- a/pkg/runtime/deepobject.go
+++ b/pkg/runtime/deepobject.go
@@ -245,7 +245,7 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 				// TODO: why is this marked as an ineffassign?
 				tm, err = time.Parse(types.DateFormat, pathValues.value) //nolint:ineffassign,staticcheck
 				if err != nil {
-					return fmt.Errorf("error parsing tim as RFC3339 or 2006-01-02 time: %s", err)
+					return fmt.Errorf("error parsing '%s' as RFC3339 or 2006-01-02 time: %s", pathValues.value, err)
 				}
 				return fmt.Errorf("invalid date format: %w", err)
 			}


### PR DESCRIPTION
Fixed typo and change message same as here:
https://github.com/deepmap/oapi-codegen/blob/ab90f1927bc5ec3e29af216d4298fbb4780ae36d/pkg/runtime/bindstring.go#L125

Before:
`error parsing tim as RFC3339 or 2006-01-02 time: parsing time "2020-11-22T12:34:56": extra text: "T12:34:56"`

After: 
`error parsing '2020-11-22T12:34:56' as RFC3339 or 2006-01-02 time: parsing time "2020-11-22T12:34:56": extra text: "T12:34:56"` 
