### PR TITLE
gin middleware context.Abort() support

### DIFF
--- a/pkg/codegen/templates/gin/gin-wrappers.tmpl
+++ b/pkg/codegen/templates/gin/gin-wrappers.tmpl
@@ -176,6 +176,9 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(c *gin.Context) {
 
   for _, middleware := range siw.HandlerMiddlewares {
     middleware(c)
+    if(c.IsAborted()){
+			return
+		}
   }
 
   siw.Handler.{{.OperationId}}(c{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})

--- a/pkg/codegen/templates/gin/gin-wrappers.tmpl
+++ b/pkg/codegen/templates/gin/gin-wrappers.tmpl
@@ -177,8 +177,8 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(c *gin.Context) {
   for _, middleware := range siw.HandlerMiddlewares {
     middleware(c)
     if(c.IsAborted()){
-			return
-		}
+      return
+    }
   }
 
   siw.Handler.{{.OperationId}}(c{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})


### PR DESCRIPTION
When registering middleware functions in gin calling `c.Abort()` on the gin context prevents execution of any follow up middleware functions as well as the endpoint service function.

Registering middleware functions in `oapi-codegen` generated gin-wrappers does not handle aborted contextst and executes all following middleware functions and the routed endpoint service function.

resolves #485 