### PR TITLE
Assign values of type Map in deep objects

### DIFF
--- a/pkg/runtime/deepobject.go
+++ b/pkg/runtime/deepobject.go
@@ -200,6 +200,19 @@ func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
 	it := iv.Type()
 
 	switch it.Kind() {
+	case reflect.Map:
+		dstMap := reflect.MakeMap(iv.Type())
+		for key, value := range pathValues.fields {
+			dstKey := reflect.ValueOf(key)
+			dstVal := reflect.New(iv.Type().Elem())
+			err := assignPathValues(dstVal.Interface(), value)
+			if err != nil {
+				return fmt.Errorf("error binding map: %w", err)
+			}
+			dstMap.SetMapIndex(dstKey, dstVal.Elem())
+		}
+		iv.Set(dstMap)
+		return nil
 	case reflect.Slice:
 		sliceLength := len(pathValues.fields)
 		dstSlice := reflect.MakeSlice(it, sliceLength, sliceLength)

--- a/pkg/runtime/deepobject_test.go
+++ b/pkg/runtime/deepobject_test.go
@@ -17,18 +17,20 @@ type InnerObject struct {
 
 // These are all possible field types, mandatory and optional.
 type AllFields struct {
-	I   int          `json:"i"`
-	Oi  *int         `json:"oi,omitempty"`
-	F   float32      `json:"f"`
-	Of  *float32     `json:"of,omitempty"`
-	B   bool         `json:"b"`
-	Ob  *bool        `json:"ob,omitempty"`
-	As  []string     `json:"as"`
-	Oas *[]string    `json:"oas,omitempty"`
-	O   InnerObject  `json:"o"`
-	Oo  *InnerObject `json:"oo,omitempty"`
-	D   MockBinder   `json:"d"`
-	Od  *MockBinder  `json:"od,omitempty"`
+	I   int                `json:"i"`
+	Oi  *int               `json:"oi,omitempty"`
+	F   float32            `json:"f"`
+	Of  *float32           `json:"of,omitempty"`
+	B   bool               `json:"b"`
+	Ob  *bool              `json:"ob,omitempty"`
+	As  []string           `json:"as"`
+	Oas *[]string          `json:"oas,omitempty"`
+	O   InnerObject        `json:"o"`
+	Oo  *InnerObject       `json:"oo,omitempty"`
+	D   MockBinder         `json:"d"`
+	Od  *MockBinder        `json:"od,omitempty"`
+	M   map[string]string  `json:"m"`
+	Om  *map[string]string `json:"om,omitempty"`
 }
 
 func TestDeepObject(t *testing.T) {
@@ -39,6 +41,9 @@ func TestDeepObject(t *testing.T) {
 	oo := InnerObject{
 		Name: "Marcin Romaszewicz",
 		ID:   123,
+	}
+	om := map[string]string{
+		"additional": "foo",
 	}
 	d := MockBinder{Time: time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC)}
 
@@ -58,6 +63,8 @@ func TestDeepObject(t *testing.T) {
 		Oo: &oo,
 		D:  d,
 		Od: &d,
+		M:  om,
+		Om: &om,
 	}
 
 	marshaled, err := MarshalDeepObject(srcObj, "p")

--- a/pkg/runtime/deepobject_test.go
+++ b/pkg/runtime/deepobject_test.go
@@ -17,20 +17,20 @@ type InnerObject struct {
 
 // These are all possible field types, mandatory and optional.
 type AllFields struct {
-	I   int                `json:"i"`
-	Oi  *int               `json:"oi,omitempty"`
-	F   float32            `json:"f"`
-	Of  *float32           `json:"of,omitempty"`
-	B   bool               `json:"b"`
-	Ob  *bool              `json:"ob,omitempty"`
-	As  []string           `json:"as"`
-	Oas *[]string          `json:"oas,omitempty"`
-	O   InnerObject        `json:"o"`
-	Oo  *InnerObject       `json:"oo,omitempty"`
-	D   MockBinder         `json:"d"`
-	Od  *MockBinder        `json:"od,omitempty"`
-	M   map[string]string  `json:"m"`
-	Om  *map[string]string `json:"om,omitempty"`
+	I   int             `json:"i"`
+	Oi  *int            `json:"oi,omitempty"`
+	F   float32         `json:"f"`
+	Of  *float32        `json:"of,omitempty"`
+	B   bool            `json:"b"`
+	Ob  *bool           `json:"ob,omitempty"`
+	As  []string        `json:"as"`
+	Oas *[]string       `json:"oas,omitempty"`
+	O   InnerObject     `json:"o"`
+	Oo  *InnerObject    `json:"oo,omitempty"`
+	D   MockBinder      `json:"d"`
+	Od  *MockBinder     `json:"od,omitempty"`
+	M   map[string]int  `json:"m"`
+	Om  *map[string]int `json:"om,omitempty"`
 }
 
 func TestDeepObject(t *testing.T) {
@@ -42,8 +42,8 @@ func TestDeepObject(t *testing.T) {
 		Name: "Marcin Romaszewicz",
 		ID:   123,
 	}
-	om := map[string]string{
-		"additional": "foo",
+	om := map[string]int{
+		"additional": 1,
 	}
 	d := MockBinder{Time: time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC)}
 


### PR DESCRIPTION
This might be able to help with handling `additionalProperties` arbitrary maps as described in #930.