### PR TITLE
fix generated client code cannot convert UUIDs to string when used as…

### DIFF
--- a/pkg/runtime/styleparam.go
+++ b/pkg/runtime/styleparam.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/deepmap/oapi-codegen/pkg/types"
+	"github.com/google/uuid"
 )
 
 // Parameter escaping works differently based on where a header is found
@@ -428,6 +429,10 @@ func primitiveToString(value interface{}) (string, error) {
 	case reflect.Struct:
 		// If input has Marshaler, such as object has Additional Property or AnyOf,
 		// We use this Marshaler and convert into interface{} before styling.
+		if v, ok := value.(uuid.UUID); ok {
+			output = v.String()
+			break
+		}
 		if m, ok := value.(json.Marshaler); ok {
 			buf, err := m.MarshalJSON()
 			if err != nil {


### PR DESCRIPTION
… path parameters.

fixes https://github.com/deepmap/oapi-codegen/issues/943