### PR TITLE
Fix README.md example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ into objects which match the OpenAPI 3.0 definition. The code generator in this
 directory does a lot of that for you. You would run it like so:
 
     go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@latest
-    oapi-codegen petstore-expanded.yaml > petstore.gen.go
+    oapi-codegen -package petstore petstore-expanded.yaml > petstore.gen.go
 
 Let's go through that `petstore.gen.go` file to show you everything which was
 generated.


### PR DESCRIPTION
Currently the example in README.md is not working:

```text
➜  oapi oapi-codegen petstore-expanded.yaml > petstore.gen.go
configuration error: package name must be specified
```

This can be fixed by providing the required tag for -package