### PR TITLE
Add form struct tag for x-www-form-urlencoded request schemas

### DIFF
--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -663,6 +663,17 @@ func GenerateBodyDefinitions(operationID string, bodyOrRef *openapi3.RequestBody
 		// type under #/components, we'll define a type for it, so
 		// that we have an easy to use type for marshaling.
 		if bodySchema.RefType == "" {
+			if contentType == "application/x-www-form-urlencoded" {
+				// Apply the appropriate structure tag if the request
+				// schema was defined under the operations' section.
+				for i := range bodySchema.Properties {
+					bodySchema.Properties[i].NeedsFormTag = true
+				}
+
+				// Regenerate the Golang struct adding the new form tag.
+				bodySchema.GoType = GenStructFromSchema(bodySchema)
+			}
+
 			td := TypeDefinition{
 				TypeName: bodyTypeName,
 				Schema:   bodySchema,


### PR DESCRIPTION
Fixes #997 

If a request schema was defined in the operations section, and if its content type is `application/x-www-form-urlencoded`, the corresponding model needs to be tagged with the `form` struct tag, so that it could be unmarshalled properly.

`GenerateBodyDefinitions` knows exactly which content type needs to be applied to which schema type, and perhaps this adjustment could be made to the generated code at that point.