### PR TITLE
Global configuration to add custom struct tags to all generated models

### DIFF
--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -87,6 +87,7 @@ type OutputOptions struct {
 	ExcludeSchemas     []string `yaml:"exclude-schemas,omitempty"`      // Exclude from generation schemas with given names. Ignored when empty.
 	ResponseTypeSuffix string   `yaml:"response-type-suffix,omitempty"` // The suffix used for responses types
 	ClientTypeName     string   `yaml:"client-type-name,omitempty"`     // Override the default generated client type with the value
+	AdditionalTags     []string `yaml:"additional-tags,omitempty"`      // Defines the list of additional struct tags to add to the generated models.
 }
 
 // UpdateDefaults sets reasonable default values for unset fields in Configuration

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -653,10 +653,18 @@ func GenFieldsFromProperties(props []Property) []string {
 			if p.NeedsFormTag {
 				fieldTags["form"] = p.JsonFieldName
 			}
+
+			for _, tag := range globalState.options.OutputOptions.AdditionalTags {
+				fieldTags[tag] = p.JsonFieldName
+			}
 		} else {
 			fieldTags["json"] = p.JsonFieldName + ",omitempty"
 			if p.NeedsFormTag {
 				fieldTags["form"] = p.JsonFieldName + ",omitempty"
+			}
+
+			for _, tag := range globalState.options.OutputOptions.AdditionalTags {
+				fieldTags[tag] = p.JsonFieldName + ",omitempty"
 			}
 		}
 


### PR DESCRIPTION
Hi,

We have a special use-case of openapi to generate models. In that generation, we need to have custom tags on top of the already present `json` tag.

We first started to use `x-oapi-codegen-extra-tags` which works great but has the following disadvantages:
 - a lot of boilerplate in the specs to add this to all properties,
 - does not work with $ref.

This change therefore adds a new parameter in the configuration section `output-options` to specify a list of additional struct tags to define.

Example:

```
output-options:
  additional-tags:
    - specialtag
```
