### PR TITLE
Create a new context before passing it to strict handlers

### DIFF
--- a/pkg/codegen/templates/imports.tmpl
+++ b/pkg/codegen/templates/imports.tmpl
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
+ 	"github.com/deepmap/oapi-codegen/pkg/middleware"
+
 	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/go-chi/chi/v5"

--- a/pkg/codegen/templates/imports.tmpl
+++ b/pkg/codegen/templates/imports.tmpl
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"time"
 
+    "github.com/deepmap/oapi-codegen/pkg/middleware"
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
- 	"github.com/deepmap/oapi-codegen/pkg/middleware"
 
 	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/getkin/kin-openapi/openapi3"

--- a/pkg/codegen/templates/strict/strict-echo.tmpl
+++ b/pkg/codegen/templates/strict/strict-echo.tmpl
@@ -68,7 +68,8 @@ type strictHandler struct {
         {{end}}{{/* range .Bodies */}}
 
         handler := func(ctx echo.Context, request interface{}) (interface{}, error){
-            return sh.ssi.{{.OperationId}}(ctx.Request().Context(), request.({{$opid | ucFirst}}RequestObject))
+            nctx := context.WithValue(context.Background(), middleware.EchoContextKey, ctx)
+            return sh.ssi.{{.OperationId}}(nctx, request.({{$opid | ucFirst}}RequestObject))
         }
         for _, middleware := range sh.middlewares {
             handler = middleware(handler, "{{.OperationId}}")


### PR DESCRIPTION
Hello,
I don't know if this is relevant but when using the authenticate example and for example setting the current_user in the echo context after performing my authentication / authorization logic I can't retrieve it because only the context of the *http.Request is passed to the strict handler and not the echo context.
I create a new context and inject the echo context with the key defined in the middleware package so in every strict handler we can now grab the echo context or the request handler by calling `.Request()` method on the echo context.

Well I don't know if this is clear, don't hesitate to tell me why this is a bad idea if this is one !