### PR TITLE
Handle empty application/json request bodies

### DIFF
--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -661,7 +661,7 @@ func GenerateBodyDefinitions(operationID string, bodyOrRef *openapi3.RequestBody
 		}
 
 		// If the body is a pre-defined type
-		if IsGoTypeReference(content.Schema.Ref) {
+		if content.Schema != nil && IsGoTypeReference(content.Schema.Ref) {
 			// Convert the reference path to Go type
 			refType, err := RefPathToGoType(content.Schema.Ref)
 			if err != nil {


### PR DESCRIPTION
If you define a POST request with an empty json body the codegen will fail with 
panic: runtime error: invalid memory address or nil pointer dereference

Example of a definition that will fail:
```
 '/token':
    post:
      operationId: post-token
      requestBody:
        content:
          application/json: {}
```