### PR TITLE
fixes an error message containing a nil err object

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -155,7 +155,7 @@ func main() {
 			t := true
 			oldConfigStyle = &t
 		} else if oldErr != nil && newErr != nil {
-			errExit("error parsing configuration style as old version or new version: %v\n", err)
+			errExit("error parsing configuration style as old version or new version\n\nerror when parsing using old config version:\n%v\n\nerror when parsing using new config version:\n%v\n", oldErr, newErr)
 		}
 		// Else we fall through, and we still don't know, so we need to infer it from flags.
 	}


### PR DESCRIPTION
Fixes: #1047 

Error message before the patch:
```
$ oapi-codegen -config codegen.cfg.yml battleship-oapi.yaml
error parsing configuration style as old version or new version: <nil>
[1]    106688 exit 1     oapi-codegen -config codegen.cfg.yml battleship-oapi.yaml
```

and after the patch:
```
$ oapi-codegen -config codegen.cfg.yml battleship-oapi.yaml
error parsing configuration style as old version or new version

error when parsing using old config version:
yaml: unmarshal errors:
  line 3: cannot unmarshal !!map into []string

error when parsing using new config version:
yaml: unmarshal errors:
  line 5: field server not found in type codegen.GenerateOptions
[1]    109954 exit 1     oapi-codegen -config codegen.cfg.yml battleship-oapi.yaml
```

This fix is just a quick hack to show the problem. If it's not good enough for merging please point me in the right direction and I'm happy to make it more consistent with the rest of the codebase.