### PR TITLE
Small Features: YAML struct tags, Exclude Depreciated Filter

### DIFF
--- a/examples/authenticated-api/echo/api/api.gen.go
+++ b/examples/authenticated-api/echo/api/api.gen.go
@@ -27,21 +27,21 @@ const (
 // Error defines model for Error.
 type Error struct {
 	// Code Error code
-	Code int32 `json:"code"`
+	Code int32 `json:"code" yaml:"code"`
 
 	// Message Error message
-	Message string `json:"message"`
+	Message string `json:"message" yaml:"message"`
 }
 
 // Thing defines model for Thing.
 type Thing struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 }
 
 // ThingWithID defines model for ThingWithID.
 type ThingWithID struct {
-	Id   int64  `json:"id"`
-	Name string `json:"name"`
+	Id   int64  `json:"id" yaml:"id"`
+	Name string `json:"name" yaml:"name"`
 }
 
 // AddThingJSONRequestBody defines body for AddThing for application/json ContentType.

--- a/examples/custom-client-type/custom-client-type.gen.go
+++ b/examples/custom-client-type/custom-client-type.gen.go
@@ -15,7 +15,7 @@ import (
 
 // Client defines model for Client.
 type Client struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 }
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function

--- a/examples/petstore-expanded/chi/api/petstore.gen.go
+++ b/examples/petstore-expanded/chi/api/petstore.gen.go
@@ -21,40 +21,40 @@ import (
 // Error defines model for Error.
 type Error struct {
 	// Code Error code
-	Code int32 `json:"code"`
+	Code int32 `json:"code" yaml:"code"`
 
 	// Message Error message
-	Message string `json:"message"`
+	Message string `json:"message" yaml:"message"`
 }
 
 // NewPet defines model for NewPet.
 type NewPet struct {
 	// Name Name of the pet
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Tag Type of the pet
-	Tag *string `json:"tag,omitempty"`
+	Tag *string `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
 // Pet defines model for Pet.
 type Pet struct {
 	// Id Unique id of the pet
-	Id int64 `json:"id"`
+	Id int64 `json:"id" yaml:"id"`
 
 	// Name Name of the pet
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Tag Type of the pet
-	Tag *string `json:"tag,omitempty"`
+	Tag *string `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// Tags tags to filter by
-	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty"`
+	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty" yaml:"tags,omitempty"`
 
 	// Limit maximum number of results to return
-	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
+	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty" yaml:"limit,omitempty"`
 }
 
 // AddPetJSONRequestBody defines body for AddPet for application/json ContentType.

--- a/examples/petstore-expanded/echo/api/models/models.gen.go
+++ b/examples/petstore-expanded/echo/api/models/models.gen.go
@@ -6,40 +6,40 @@ package models
 // Error defines model for Error.
 type Error struct {
 	// Code Error code
-	Code int32 `json:"code"`
+	Code int32 `json:"code" yaml:"code"`
 
 	// Message Error message
-	Message string `json:"message"`
+	Message string `json:"message" yaml:"message"`
 }
 
 // NewPet defines model for NewPet.
 type NewPet struct {
 	// Name Name of the pet
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Tag Type of the pet
-	Tag *string `json:"tag,omitempty"`
+	Tag *string `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
 // Pet defines model for Pet.
 type Pet struct {
 	// Id Unique id of the pet
-	Id int64 `json:"id"`
+	Id int64 `json:"id" yaml:"id"`
 
 	// Name Name of the pet
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Tag Type of the pet
-	Tag *string `json:"tag,omitempty"`
+	Tag *string `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// Tags tags to filter by
-	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty"`
+	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty" yaml:"tags,omitempty"`
 
 	// Limit maximum number of results to return
-	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
+	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty" yaml:"limit,omitempty"`
 }
 
 // AddPetJSONRequestBody defines body for AddPet for application/json ContentType.

--- a/examples/petstore-expanded/gin/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/gin/api/petstore-types.gen.go
@@ -6,40 +6,40 @@ package api
 // Error defines model for Error.
 type Error struct {
 	// Code Error code
-	Code int32 `json:"code"`
+	Code int32 `json:"code" yaml:"code"`
 
 	// Message Error message
-	Message string `json:"message"`
+	Message string `json:"message" yaml:"message"`
 }
 
 // NewPet defines model for NewPet.
 type NewPet struct {
 	// Name Name of the pet
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Tag Type of the pet
-	Tag *string `json:"tag,omitempty"`
+	Tag *string `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
 // Pet defines model for Pet.
 type Pet struct {
 	// Id Unique id of the pet
-	Id int64 `json:"id"`
+	Id int64 `json:"id" yaml:"id"`
 
 	// Name Name of the pet
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Tag Type of the pet
-	Tag *string `json:"tag,omitempty"`
+	Tag *string `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// Tags tags to filter by
-	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty"`
+	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty" yaml:"tags,omitempty"`
 
 	// Limit maximum number of results to return
-	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
+	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty" yaml:"limit,omitempty"`
 }
 
 // AddPetJSONRequestBody defines body for AddPet for application/json ContentType.

--- a/examples/petstore-expanded/gorilla/api/petstore.gen.go
+++ b/examples/petstore-expanded/gorilla/api/petstore.gen.go
@@ -21,40 +21,40 @@ import (
 // Error defines model for Error.
 type Error struct {
 	// Code Error code
-	Code int32 `json:"code"`
+	Code int32 `json:"code" yaml:"code"`
 
 	// Message Error message
-	Message string `json:"message"`
+	Message string `json:"message" yaml:"message"`
 }
 
 // NewPet defines model for NewPet.
 type NewPet struct {
 	// Name Name of the pet
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Tag Type of the pet
-	Tag *string `json:"tag,omitempty"`
+	Tag *string `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
 // Pet defines model for Pet.
 type Pet struct {
 	// Id Unique id of the pet
-	Id int64 `json:"id"`
+	Id int64 `json:"id" yaml:"id"`
 
 	// Name Name of the pet
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Tag Type of the pet
-	Tag *string `json:"tag,omitempty"`
+	Tag *string `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// Tags tags to filter by
-	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty"`
+	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty" yaml:"tags,omitempty"`
 
 	// Limit maximum number of results to return
-	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
+	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty" yaml:"limit,omitempty"`
 }
 
 // AddPetJSONRequestBody defines body for AddPet for application/json ContentType.

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -19,40 +19,40 @@ import (
 // Error defines model for Error.
 type Error struct {
 	// Code Error code
-	Code int32 `json:"code"`
+	Code int32 `json:"code" yaml:"code"`
 
 	// Message Error message
-	Message string `json:"message"`
+	Message string `json:"message" yaml:"message"`
 }
 
 // NewPet defines model for NewPet.
 type NewPet struct {
 	// Name Name of the pet
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Tag Type of the pet
-	Tag *string `json:"tag,omitempty"`
+	Tag *string `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
 // Pet defines model for Pet.
 type Pet struct {
 	// Id Unique id of the pet
-	Id int64 `json:"id"`
+	Id int64 `json:"id" yaml:"id"`
 
 	// Name Name of the pet
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Tag Type of the pet
-	Tag *string `json:"tag,omitempty"`
+	Tag *string `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// Tags tags to filter by
-	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty"`
+	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty" yaml:"tags,omitempty"`
 
 	// Limit maximum number of results to return
-	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
+	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty" yaml:"limit,omitempty"`
 }
 
 // AddPetJSONRequestBody defines body for AddPet for application/json ContentType.

--- a/examples/petstore-expanded/strict/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/strict/api/petstore-server.gen.go
@@ -336,7 +336,7 @@ func (response AddPetdefaultJSONResponse) VisitAddPetResponse(w http.ResponseWri
 }
 
 type DeletePetRequestObject struct {
-	Id int64 `json:"id"`
+	Id int64 `json:"id" yaml:"id"`
 }
 
 type DeletePetResponseObject interface {
@@ -364,7 +364,7 @@ func (response DeletePetdefaultJSONResponse) VisitDeletePetResponse(w http.Respo
 }
 
 type FindPetByIDRequestObject struct {
-	Id int64 `json:"id"`
+	Id int64 `json:"id" yaml:"id"`
 }
 
 type FindPetByIDResponseObject interface {

--- a/examples/petstore-expanded/strict/api/petstore-types.gen.go
+++ b/examples/petstore-expanded/strict/api/petstore-types.gen.go
@@ -6,40 +6,40 @@ package api
 // Error defines model for Error.
 type Error struct {
 	// Code Error code
-	Code int32 `json:"code"`
+	Code int32 `json:"code" yaml:"code"`
 
 	// Message Error message
-	Message string `json:"message"`
+	Message string `json:"message" yaml:"message"`
 }
 
 // NewPet defines model for NewPet.
 type NewPet struct {
 	// Name Name of the pet
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Tag Type of the pet
-	Tag *string `json:"tag,omitempty"`
+	Tag *string `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
 // Pet defines model for Pet.
 type Pet struct {
 	// Id Unique id of the pet
-	Id int64 `json:"id"`
+	Id int64 `json:"id" yaml:"id"`
 
 	// Name Name of the pet
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Tag Type of the pet
-	Tag *string `json:"tag,omitempty"`
+	Tag *string `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
 // FindPetsParams defines parameters for FindPets.
 type FindPetsParams struct {
 	// Tags tags to filter by
-	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty"`
+	Tags *[]string `form:"tags,omitempty" json:"tags,omitempty" yaml:"tags,omitempty"`
 
 	// Limit maximum number of results to return
-	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
+	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty" yaml:"limit,omitempty"`
 }
 
 // AddPetJSONRequestBody defines body for AddPet for application/json ContentType.

--- a/internal/test/all_of/v1/openapi.gen.go
+++ b/internal/test/all_of/v1/openapi.gen.go
@@ -25,9 +25,9 @@ type Person struct {
 // PersonProperties These are fields that specify a person. They are all optional, and
 // would be used by an `Edit` style API endpoint, where each is optional.
 type PersonProperties struct {
-	FirstName          *string `json:"FirstName,omitempty"`
-	GovernmentIDNumber *int64  `json:"GovernmentIDNumber,omitempty"`
-	LastName           *string `json:"LastName,omitempty"`
+	FirstName          *string `json:"FirstName,omitempty" yaml:"FirstName,omitempty"`
+	GovernmentIDNumber *int64  `json:"GovernmentIDNumber,omitempty" yaml:"GovernmentIDNumber,omitempty"`
+	LastName           *string `json:"LastName,omitempty" yaml:"LastName,omitempty"`
 }
 
 // PersonWithID defines model for PersonWithID.
@@ -35,7 +35,7 @@ type PersonWithID struct {
 	// Embedded struct due to allOf(#/components/schemas/Person)
 	Person `yaml:",inline"`
 	// Embedded fields due to inline allOf schema
-	ID int64 `json:"ID"`
+	ID int64 `json:"ID" yaml:"ID"`
 }
 
 // Base64 encoded, gzipped, json marshaled Swagger object

--- a/internal/test/all_of/v2/openapi.gen.go
+++ b/internal/test/all_of/v2/openapi.gen.go
@@ -17,25 +17,25 @@ import (
 
 // Person defines model for Person.
 type Person struct {
-	FirstName          string `json:"FirstName"`
-	GovernmentIDNumber *int64 `json:"GovernmentIDNumber,omitempty"`
-	LastName           string `json:"LastName"`
+	FirstName          string `json:"FirstName" yaml:"FirstName"`
+	GovernmentIDNumber *int64 `json:"GovernmentIDNumber,omitempty" yaml:"GovernmentIDNumber,omitempty"`
+	LastName           string `json:"LastName" yaml:"LastName"`
 }
 
 // PersonProperties These are fields that specify a person. They are all optional, and
 // would be used by an `Edit` style API endpoint, where each is optional.
 type PersonProperties struct {
-	FirstName          *string `json:"FirstName,omitempty"`
-	GovernmentIDNumber *int64  `json:"GovernmentIDNumber,omitempty"`
-	LastName           *string `json:"LastName,omitempty"`
+	FirstName          *string `json:"FirstName,omitempty" yaml:"FirstName,omitempty"`
+	GovernmentIDNumber *int64  `json:"GovernmentIDNumber,omitempty" yaml:"GovernmentIDNumber,omitempty"`
+	LastName           *string `json:"LastName,omitempty" yaml:"LastName,omitempty"`
 }
 
 // PersonWithID defines model for PersonWithID.
 type PersonWithID struct {
-	FirstName          string `json:"FirstName"`
-	GovernmentIDNumber *int64 `json:"GovernmentIDNumber,omitempty"`
-	ID                 int64  `json:"ID"`
-	LastName           string `json:"LastName"`
+	FirstName          string `json:"FirstName" yaml:"FirstName"`
+	GovernmentIDNumber *int64 `json:"GovernmentIDNumber,omitempty" yaml:"GovernmentIDNumber,omitempty"`
+	ID                 int64  `json:"ID" yaml:"ID"`
+	LastName           string `json:"LastName" yaml:"LastName"`
 }
 
 // Base64 encoded, gzipped, json marshaled Swagger object

--- a/internal/test/any_of/param/param.gen.go
+++ b/internal/test/any_of/param/param.gen.go
@@ -22,14 +22,14 @@ type Test struct {
 
 // Test0 defines model for .
 type Test0 struct {
-	Item1 string `json:"item1"`
-	Item2 string `json:"item2"`
+	Item1 string `json:"item1" yaml:"item1"`
+	Item2 string `json:"item2" yaml:"item2"`
 }
 
 // Test1 defines model for .
 type Test1 struct {
-	Item2 *string `json:"item2,omitempty"`
-	Item3 *string `json:"item3,omitempty"`
+	Item2 *string `json:"item2,omitempty" yaml:"item2,omitempty"`
+	Item3 *string `json:"item3,omitempty" yaml:"item3,omitempty"`
 }
 
 // Test2 defines model for test2.
@@ -45,8 +45,8 @@ type Test21 = string
 
 // GetTestParams defines parameters for GetTest.
 type GetTestParams struct {
-	Test  *Test    `form:"test,omitempty" json:"test,omitempty"`
-	Test2 *[]Test2 `form:"test2,omitempty" json:"test2,omitempty"`
+	Test  *Test    `form:"test,omitempty" json:"test,omitempty" yaml:"test,omitempty"`
+	Test2 *[]Test2 `form:"test2,omitempty" json:"test2,omitempty" yaml:"test2,omitempty"`
 }
 
 // AsTest0 returns the union data inside the Test as a Test0

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -20,8 +20,8 @@ const (
 
 // SchemaObject defines model for SchemaObject.
 type SchemaObject struct {
-	FirstName string `json:"firstName"`
-	Role      string `json:"role"`
+	FirstName string `json:"firstName" yaml:"firstName"`
+	Role      string `json:"role" yaml:"role"`
 }
 
 // PostVendorJsonJSONBody defines parameters for PostVendorJson.

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -1350,7 +1350,7 @@ func (t *OneOfObject13) MergeOneOfVariant6(v OneOfVariant6) error {
 
 func (t OneOfObject13) Discriminator() (string, error) {
 	var discriminator struct {
-		Discriminator string `json:"type"`
+		Discriminator string `json:"type" yaml:"type"`
 	}
 	err := json.Unmarshal(t.union, &discriminator)
 	return discriminator.Discriminator, err
@@ -1727,7 +1727,7 @@ func (t *OneOfObject5) MergeOneOfVariant5(v OneOfVariant5) error {
 
 func (t OneOfObject5) Discriminator() (string, error) {
 	var discriminator struct {
-		Discriminator string `json:"discriminator"`
+		Discriminator string `json:"discriminator" yaml:"discriminator"`
 	}
 	err := json.Unmarshal(t.union, &discriminator)
 	return discriminator.Discriminator, err
@@ -1816,7 +1816,7 @@ func (t *OneOfObject6) MergeOneOfVariant5(v OneOfVariant5) error {
 
 func (t OneOfObject6) Discriminator() (string, error) {
 	var discriminator struct {
-		Discriminator string `json:"discriminator"`
+		Discriminator string `json:"discriminator" yaml:"discriminator"`
 	}
 	err := json.Unmarshal(t.union, &discriminator)
 	return discriminator.Discriminator, err
@@ -1905,7 +1905,7 @@ func (t *OneOfObject61) MergeOneOfVariant5(v OneOfVariant5) error {
 
 func (t OneOfObject61) Discriminator() (string, error) {
 	var discriminator struct {
-		Discriminator string `json:"discriminator"`
+		Discriminator string `json:"discriminator" yaml:"discriminator"`
 	}
 	err := json.Unmarshal(t.union, &discriminator)
 	return discriminator.Discriminator, err
@@ -1994,7 +1994,7 @@ func (t *OneOfObject62) MergeOneOfVariant51(v OneOfVariant51) error {
 
 func (t OneOfObject62) Discriminator() (string, error) {
 	var discriminator struct {
-		Discriminator string `json:"discriminator"`
+		Discriminator string `json:"discriminator" yaml:"discriminator"`
 	}
 	err := json.Unmarshal(t.union, &discriminator)
 	return discriminator.Discriminator, err
@@ -2245,7 +2245,7 @@ func (t *OneOfObject9) MergeOneOfVariant6(v OneOfVariant6) error {
 
 func (t OneOfObject9) Discriminator() (string, error) {
 	var discriminator struct {
-		Discriminator string `json:"type"`
+		Discriminator string `json:"type" yaml:"type"`
 	}
 	err := json.Unmarshal(t.union, &discriminator)
 	return discriminator.Discriminator, err

--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -94,34 +94,34 @@ const (
 
 // AdditionalPropertiesObject1 Has additional properties of type int
 type AdditionalPropertiesObject1 struct {
-	Id                   int            `json:"id"`
-	Name                 string         `json:"name"`
-	Optional             *string        `json:"optional,omitempty"`
+	Id                   int            `json:"id" yaml:"id"`
+	Name                 string         `json:"name" yaml:"name"`
+	Optional             *string        `json:"optional,omitempty" yaml:"optional,omitempty"`
 	AdditionalProperties map[string]int `json:"-"`
 }
 
 // AdditionalPropertiesObject2 Does not allow additional properties
 type AdditionalPropertiesObject2 struct {
-	Id   int    `json:"id"`
-	Name string `json:"name"`
+	Id   int    `json:"id" yaml:"id"`
+	Name string `json:"name" yaml:"name"`
 }
 
 // AdditionalPropertiesObject3 Allows any additional property
 type AdditionalPropertiesObject3 struct {
-	Name                 string                 `json:"name"`
+	Name                 string                 `json:"name" yaml:"name"`
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
 // AdditionalPropertiesObject4 Has anonymous field which has additional properties
 type AdditionalPropertiesObject4 struct {
-	Inner                AdditionalPropertiesObject4_Inner `json:"inner"`
-	Name                 string                            `json:"name"`
+	Inner                AdditionalPropertiesObject4_Inner `json:"inner" yaml:"inner"`
+	Name                 string                            `json:"name" yaml:"name"`
 	AdditionalProperties map[string]interface{}            `json:"-"`
 }
 
 // AdditionalPropertiesObject4_Inner defines model for AdditionalPropertiesObject4.Inner.
 type AdditionalPropertiesObject4_Inner struct {
-	Name                 string                 `json:"name"`
+	Name                 string                 `json:"name" yaml:"name"`
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 
@@ -165,9 +165,9 @@ type FunnyValues string
 
 // ObjectWithJsonField defines model for ObjectWithJsonField.
 type ObjectWithJsonField struct {
-	Name   string          `json:"name"`
-	Value1 json.RawMessage `json:"value1"`
-	Value2 json.RawMessage `json:"value2,omitempty"`
+	Name   string          `json:"name" yaml:"name"`
+	Value1 json.RawMessage `json:"value1" yaml:"value1"`
+	Value2 json.RawMessage `json:"value2,omitempty" yaml:"value2,omitempty"`
 }
 
 // OneOfObject1 oneOf with references and no discriminator
@@ -177,9 +177,9 @@ type OneOfObject1 struct {
 
 // OneOfObject10 fixed properties, variable required - will compile, but not much sense
 type OneOfObject10 struct {
-	One   *string `json:"one,omitempty"`
-	Three *bool   `json:"three,omitempty"`
-	Two   *int    `json:"two,omitempty"`
+	One   *string `json:"one,omitempty" yaml:"one,omitempty"`
+	Three *bool   `json:"three,omitempty" yaml:"three,omitempty"`
+	Two   *int    `json:"two,omitempty" yaml:"two,omitempty"`
 	union json.RawMessage
 }
 
@@ -219,7 +219,7 @@ type OneOfObject121 = float32
 
 // OneOfObject13 oneOf with fixed discriminator and other fields allowed
 type OneOfObject13 struct {
-	Type                 string                 `json:"type"`
+	Type                 string                 `json:"type" yaml:"type"`
 	AdditionalProperties map[string]interface{} `json:"-"`
 	union                json.RawMessage
 }
@@ -231,7 +231,7 @@ type OneOfObject2 struct {
 
 // OneOfObject20 defines model for .
 type OneOfObject20 struct {
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
 // OneOfObject21 defines model for .
@@ -242,7 +242,7 @@ type OneOfObject22 = bool
 
 // OneOfObject3 inline OneOf
 type OneOfObject3 struct {
-	Union *OneOfObject3_Union `json:"union,omitempty"`
+	Union *OneOfObject3_Union `json:"union,omitempty" yaml:"union,omitempty"`
 }
 
 // OneOfObject3_Union defines model for OneOfObject3.Union.
@@ -252,7 +252,7 @@ type OneOfObject3_Union struct {
 
 // OneOfObject4 oneOf plus fixed type - custom marshaling/unmarshalling
 type OneOfObject4 struct {
-	FixedProperty *string `json:"fixedProperty,omitempty"`
+	FixedProperty *string `json:"fixedProperty,omitempty" yaml:"fixedProperty,omitempty"`
 	union         json.RawMessage
 }
 
@@ -286,19 +286,19 @@ type OneOfObject7_Item struct {
 
 // OneOfObject8 oneOf with fixed properties
 type OneOfObject8 struct {
-	Fixed *string `json:"fixed,omitempty"`
+	Fixed *string `json:"fixed,omitempty" yaml:"fixed,omitempty"`
 	union json.RawMessage
 }
 
 // OneOfObject9 oneOf with fixed descriminator
 type OneOfObject9 struct {
-	Type  string `json:"type"`
+	Type  string `json:"type" yaml:"type"`
 	union json.RawMessage
 }
 
 // OneOfVariant1 defines model for OneOfVariant1.
 type OneOfVariant1 struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 }
 
 // OneOfVariant2 defines model for OneOfVariant2.
@@ -309,48 +309,48 @@ type OneOfVariant3 = bool
 
 // OneOfVariant4 defines model for OneOfVariant4.
 type OneOfVariant4 struct {
-	Discriminator string `json:"discriminator"`
-	Name          string `json:"name"`
+	Discriminator string `json:"discriminator" yaml:"discriminator"`
+	Name          string `json:"name" yaml:"name"`
 }
 
 // OneOfVariant5 defines model for OneOfVariant5.
 type OneOfVariant5 struct {
-	Discriminator string `json:"discriminator"`
-	Id            int    `json:"id"`
+	Discriminator string `json:"discriminator" yaml:"discriminator"`
+	Id            int    `json:"id" yaml:"id"`
 }
 
 // OneOfVariant6 defines model for OneOfVariant6.
 type OneOfVariant6 struct {
-	Values OneOfVariant2 `json:"values"`
+	Values OneOfVariant2 `json:"values" yaml:"values"`
 }
 
 // ReferenceToRenameMe When a Schema is renamed, $ref should refer to the new name
 type ReferenceToRenameMe struct {
 	// ToNewName This schema should be renamed via x-go-name when generating
-	NewName NewName `json:"ToNewName"`
+	NewName NewName `json:"ToNewName" yaml:"ToNewName"`
 }
 
 // NewName This schema should be renamed via x-go-name when generating
 type NewName struct {
-	Prop1 string `json:"prop1"`
-	Prop2 string `json:"prop2"`
+	Prop1 string `json:"prop1" yaml:"prop1"`
+	Prop2 string `json:"prop2" yaml:"prop2"`
 }
 
 // SchemaObject defines model for SchemaObject.
 type SchemaObject struct {
-	FirstName string `json:"firstName"`
+	FirstName string `json:"firstName" yaml:"firstName"`
 
 	// ReadOnlyRequiredProp This property is required and readOnly, so the go model should have it as a pointer,
 	// as it will not be included when it is sent from client to server.
-	ReadOnlyRequiredProp  *string `json:"readOnlyRequiredProp,omitempty"`
-	Role                  string  `json:"role"`
-	WriteOnlyRequiredProp *int    `json:"writeOnlyRequiredProp,omitempty"`
+	ReadOnlyRequiredProp  *string `json:"readOnlyRequiredProp,omitempty" yaml:"readOnlyRequiredProp,omitempty"`
+	Role                  string  `json:"role" yaml:"role"`
+	WriteOnlyRequiredProp *int    `json:"writeOnlyRequiredProp,omitempty" yaml:"writeOnlyRequiredProp,omitempty"`
 }
 
 // OneOfVariant51 defines model for one_of_variant51.
 type OneOfVariant51 struct {
-	Discriminator string `json:"discriminator"`
-	Id            int    `json:"id"`
+	Discriminator string `json:"discriminator" yaml:"discriminator"`
+	Id            int    `json:"id" yaml:"id"`
 }
 
 // EnumParam1 defines model for EnumParam1.
@@ -367,17 +367,17 @@ type RenamedParameterObject string
 
 // RenamedResponseObject defines model for ResponseObject.
 type RenamedResponseObject struct {
-	Field SchemaObject `json:"Field"`
+	Field SchemaObject `json:"Field" yaml:"Field"`
 }
 
 // RenamedRequestBody defines model for RequestBody.
 type RenamedRequestBody struct {
-	Field SchemaObject `json:"Field"`
+	Field SchemaObject `json:"Field" yaml:"Field"`
 }
 
 // EnsureEverythingIsReferencedJSONBody defines parameters for EnsureEverythingIsReferenced.
 type EnsureEverythingIsReferencedJSONBody struct {
-	Field SchemaObject `json:"Field"`
+	Field SchemaObject `json:"Field" yaml:"Field"`
 }
 
 // EnsureEverythingIsReferencedTextBody defines parameters for EnsureEverythingIsReferenced.
@@ -386,19 +386,19 @@ type EnsureEverythingIsReferencedTextBody = string
 // ParamsWithAddPropsParams defines parameters for ParamsWithAddProps.
 type ParamsWithAddPropsParams struct {
 	// P1 This parameter has additional properties
-	P1 map[string]interface{} `json:"p1"`
+	P1 map[string]interface{} `json:"p1" yaml:"p1"`
 
 	// P2 This parameter has an anonymous inner property which needs to be
 	// turned into a proper type for additionalProperties to work
 	P2 struct {
-		Inner map[string]string `json:"inner"`
-	} `form:"p2" json:"p2"`
+		Inner map[string]string `json:"inner" yaml:"inner"`
+	} `form:"p2" json:"p2" yaml:"p2"`
 }
 
 // BodyWithAddPropsJSONBody defines parameters for BodyWithAddProps.
 type BodyWithAddPropsJSONBody struct {
-	Inner                map[string]int         `json:"inner"`
-	Name                 string                 `json:"name"`
+	Inner                map[string]int         `json:"inner" yaml:"inner"`
+	Name                 string                 `json:"name" yaml:"name"`
 	AdditionalProperties map[string]interface{} `json:"-"`
 }
 

--- a/internal/test/externalref/externalref.gen.go
+++ b/internal/test/externalref/externalref.gen.go
@@ -19,9 +19,9 @@ import (
 
 // Container defines model for Container.
 type Container struct {
-	ObjectA *externalRef0.ObjectA   `json:"object_a,omitempty"`
-	ObjectB *externalRef1.ObjectB   `json:"object_b,omitempty"`
-	ObjectC *map[string]interface{} `json:"object_c,omitempty"`
+	ObjectA *externalRef0.ObjectA   `json:"object_a,omitempty" yaml:"object_a,omitempty"`
+	ObjectB *externalRef1.ObjectB   `json:"object_b,omitempty" yaml:"object_b,omitempty"`
+	ObjectC *map[string]interface{} `json:"object_c,omitempty" yaml:"object_c,omitempty"`
 }
 
 // Base64 encoded, gzipped, json marshaled Swagger object

--- a/internal/test/externalref/packageA/externalref.gen.go
+++ b/internal/test/externalref/packageA/externalref.gen.go
@@ -18,8 +18,8 @@ import (
 
 // ObjectA defines model for ObjectA.
 type ObjectA struct {
-	Name    *string               `json:"name,omitempty"`
-	ObjectB *externalRef0.ObjectB `json:"object_b,omitempty"`
+	Name    *string               `json:"name,omitempty" yaml:"name,omitempty"`
+	ObjectB *externalRef0.ObjectB `json:"object_b,omitempty" yaml:"object_b,omitempty"`
 }
 
 // Base64 encoded, gzipped, json marshaled Swagger object

--- a/internal/test/externalref/packageB/externalref.gen.go
+++ b/internal/test/externalref/packageB/externalref.gen.go
@@ -17,7 +17,7 @@ import (
 
 // ObjectB defines model for ObjectB.
 type ObjectB struct {
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
 // Base64 encoded, gzipped, json marshaled Swagger object

--- a/internal/test/issues/issue-312/issue.gen.go
+++ b/internal/test/issues/issue-312/issue.gen.go
@@ -24,22 +24,22 @@ import (
 // Error defines model for Error.
 type Error struct {
 	// Code Error code
-	Code int32 `json:"code"`
+	Code int32 `json:"code" yaml:"code"`
 
 	// Message Error message
-	Message string `json:"message"`
+	Message string `json:"message" yaml:"message"`
 }
 
 // Pet defines model for Pet.
 type Pet struct {
 	// Name The name of the pet.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 }
 
 // PetNames defines model for PetNames.
 type PetNames struct {
 	// Names The names of the pets.
-	Names []string `json:"names"`
+	Names []string `json:"names" yaml:"names"`
 }
 
 // ValidatePetsJSONRequestBody defines body for ValidatePets for application/json ContentType.

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -25,13 +25,13 @@ type ArrayValue = []Value
 
 // Document defines model for Document.
 type Document struct {
-	Fields *map[string]Value `json:"fields,omitempty"`
+	Fields *map[string]Value `json:"fields,omitempty" yaml:"fields,omitempty"`
 }
 
 // Value defines model for Value.
 type Value struct {
-	ArrayValue  *ArrayValue `json:"arrayValue,omitempty"`
-	StringValue *string     `json:"stringValue,omitempty"`
+	ArrayValue  *ArrayValue `json:"arrayValue,omitempty" yaml:"arrayValue,omitempty"`
+	StringValue *string     `json:"stringValue,omitempty" yaml:"stringValue,omitempty"`
 }
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function

--- a/internal/test/issues/issue-579/issue.gen.go
+++ b/internal/test/issues/issue-579/issue.gen.go
@@ -12,6 +12,6 @@ type AliasedDate = openapi_types.Date
 
 // Pet defines model for Pet.
 type Pet struct {
-	Born   *AliasedDate        `json:"born,omitempty"`
-	BornAt *openapi_types.Date `json:"born_at,omitempty"`
+	Born   *AliasedDate        `json:"born,omitempty" yaml:"born,omitempty"`
+	BornAt *openapi_types.Date `json:"born_at,omitempty" yaml:"born_at,omitempty"`
 }

--- a/internal/test/issues/issue-832/issue.gen.go
+++ b/internal/test/issues/issue-832/issue.gen.go
@@ -25,8 +25,8 @@ const (
 
 // Document defines model for Document.
 type Document struct {
-	Name   *string          `json:"name,omitempty"`
-	Status *Document_Status `json:"status,omitempty"`
+	Name   *string          `json:"name,omitempty" yaml:"name,omitempty"`
+	Status *Document_Status `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 // Document_Status defines model for Document.status.
@@ -34,7 +34,7 @@ type Document_Status string
 
 // DocumentStatus defines model for DocumentStatus.
 type DocumentStatus struct {
-	Value *string `json:"value,omitempty"`
+	Value *string `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // Base64 encoded, gzipped, json marshaled Swagger object

--- a/internal/test/issues/issue-grab_import_names/issue.gen.go
+++ b/internal/test/issues/issue-grab_import_names/issue.gen.go
@@ -24,10 +24,10 @@ import (
 // GetFooParams defines parameters for GetFoo.
 type GetFooParams struct {
 	// Foo base64. bytes. chi. context. echo. errors. fmt. gzip. http. io. json. openapi3.
-	Foo *string `json:"Foo,omitempty"`
+	Foo *string `json:"Foo,omitempty" yaml:"Foo,omitempty"`
 
 	// Bar openapi_types. path. runtime. strings. time.Duration time.Time url. xml. yaml.
-	Bar *string `json:"Bar,omitempty"`
+	Bar *string `json:"Bar,omitempty" yaml:"Bar,omitempty"`
 }
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function

--- a/internal/test/issues/issue-removed-external-ref/gen/spec_base/issue.gen.go
+++ b/internal/test/issues/issue-removed-external-ref/gen/spec_base/issue.gen.go
@@ -19,9 +19,9 @@ type DirectBar = externalRef0.Foo
 
 // PackedBar defines model for PackedBar.
 type PackedBar struct {
-	Core    *externalRef0.Foo `json:"core,omitempty"`
-	Directd *DirectBar        `json:"directd,omitempty"`
-	Id      *string           `json:"id,omitempty"`
+	Core    *externalRef0.Foo `json:"core,omitempty" yaml:"core,omitempty"`
+	Directd *DirectBar        `json:"directd,omitempty" yaml:"directd,omitempty"`
+	Id      *string           `json:"id,omitempty" yaml:"id,omitempty"`
 }
 
 // ServerInterface represents all server handlers.
@@ -222,10 +222,10 @@ type PostNoTroubleResponseObject interface {
 }
 
 type PostNoTrouble200JSONResponse struct {
-	DirectBar   *DirectBar        `json:"directBar,omitempty"`
-	DirectFoo   *externalRef0.Foo `json:"directFoo,omitempty"`
-	IndirectFoo *PackedBar        `json:"indirectFoo,omitempty"`
-	Name        *string           `json:"name,omitempty"`
+	DirectBar   *DirectBar        `json:"directBar,omitempty" yaml:"directBar,omitempty"`
+	DirectFoo   *externalRef0.Foo `json:"directFoo,omitempty" yaml:"directFoo,omitempty"`
+	IndirectFoo *PackedBar        `json:"indirectFoo,omitempty" yaml:"indirectFoo,omitempty"`
+	Name        *string           `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
 func (response PostNoTrouble200JSONResponse) VisitPostNoTroubleResponse(w http.ResponseWriter) error {

--- a/internal/test/issues/issue-removed-external-ref/gen/spec_ext/issue.gen.go
+++ b/internal/test/issues/issue-removed-external-ref/gen/spec_ext/issue.gen.go
@@ -13,19 +13,19 @@ import (
 
 // CamelSchema defines model for CamelSchema.
 type CamelSchema struct {
-	Id *string `json:"id,omitempty"`
+	Id *string `json:"id,omitempty" yaml:"id,omitempty"`
 }
 
 // Foo defines model for Foo.
 type Foo struct {
-	CamelSchema  *CamelSchema  `json:"CamelSchema,omitempty"`
-	InternalAttr *string       `json:"internalAttr,omitempty"`
-	PascalSchema *PascalSchema `json:"pascalSchema,omitempty"`
+	CamelSchema  *CamelSchema  `json:"CamelSchema,omitempty" yaml:"CamelSchema,omitempty"`
+	InternalAttr *string       `json:"internalAttr,omitempty" yaml:"internalAttr,omitempty"`
+	PascalSchema *PascalSchema `json:"pascalSchema,omitempty" yaml:"pascalSchema,omitempty"`
 }
 
 // PascalSchema defines model for pascalSchema.
 type PascalSchema struct {
-	Id *string `json:"id,omitempty"`
+	Id *string `json:"id,omitempty" yaml:"id,omitempty"`
 }
 
 // Pascal defines model for pascal.

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -29,48 +29,48 @@ const (
 
 // ComplexObject defines model for ComplexObject.
 type ComplexObject struct {
-	Id      int    `json:"Id"`
-	IsAdmin bool   `json:"IsAdmin"`
-	Object  Object `json:"Object"`
+	Id      int    `json:"Id" yaml:"Id"`
+	IsAdmin bool   `json:"IsAdmin" yaml:"IsAdmin"`
+	Object  Object `json:"Object" yaml:"Object"`
 }
 
 // Object defines model for Object.
 type Object struct {
-	FirstName string `json:"firstName"`
-	Role      string `json:"role"`
+	FirstName string `json:"firstName" yaml:"firstName"`
+	Role      string `json:"role" yaml:"role"`
 }
 
 // GetCookieParams defines parameters for GetCookie.
 type GetCookieParams struct {
 	// P primitive
-	P *int32 `form:"p,omitempty" json:"p,omitempty"`
+	P *int32 `form:"p,omitempty" json:"p,omitempty" yaml:"p,omitempty"`
 
 	// Ep primitive
-	Ep *int32 `form:"ep,omitempty" json:"ep,omitempty"`
+	Ep *int32 `form:"ep,omitempty" json:"ep,omitempty" yaml:"ep,omitempty"`
 
 	// Ea exploded array
-	Ea *[]int32 `form:"ea,omitempty" json:"ea,omitempty"`
+	Ea *[]int32 `form:"ea,omitempty" json:"ea,omitempty" yaml:"ea,omitempty"`
 
 	// A array
-	A *[]int32 `form:"a,omitempty" json:"a,omitempty"`
+	A *[]int32 `form:"a,omitempty" json:"a,omitempty" yaml:"a,omitempty"`
 
 	// Eo exploded object
-	Eo *Object `form:"eo,omitempty" json:"eo,omitempty"`
+	Eo *Object `form:"eo,omitempty" json:"eo,omitempty" yaml:"eo,omitempty"`
 
 	// O object
-	O *Object `form:"o,omitempty" json:"o,omitempty"`
+	O *Object `form:"o,omitempty" json:"o,omitempty" yaml:"o,omitempty"`
 
 	// Co complex object
-	Co *ComplexObject `form:"co,omitempty" json:"co,omitempty"`
+	Co *ComplexObject `form:"co,omitempty" json:"co,omitempty" yaml:"co,omitempty"`
 
 	// N1s name starting with number
-	N1s *string `form:"1s,omitempty" json:"1s,omitempty"`
+	N1s *string `form:"1s,omitempty" json:"1s,omitempty" yaml:"1s,omitempty"`
 }
 
 // EnumParamsParams defines parameters for EnumParams.
 type EnumParamsParams struct {
 	// EnumPathParam Parameter with enum values
-	EnumPathParam *EnumParamsParamsEnumPathParam `form:"enumPathParam,omitempty" json:"enumPathParam,omitempty"`
+	EnumPathParam *EnumParamsParamsEnumPathParam `form:"enumPathParam,omitempty" json:"enumPathParam,omitempty" yaml:"enumPathParam,omitempty"`
 }
 
 // EnumParamsParamsEnumPathParam defines parameters for EnumParams.
@@ -79,64 +79,64 @@ type EnumParamsParamsEnumPathParam int32
 // GetHeaderParams defines parameters for GetHeader.
 type GetHeaderParams struct {
 	// XPrimitive primitive
-	XPrimitive *int32 `json:"X-Primitive,omitempty"`
+	XPrimitive *int32 `json:"X-Primitive,omitempty" yaml:"X-Primitive,omitempty"`
 
 	// XPrimitiveExploded primitive
-	XPrimitiveExploded *int32 `json:"X-Primitive-Exploded,omitempty"`
+	XPrimitiveExploded *int32 `json:"X-Primitive-Exploded,omitempty" yaml:"X-Primitive-Exploded,omitempty"`
 
 	// XArrayExploded exploded array
-	XArrayExploded *[]int32 `json:"X-Array-Exploded,omitempty"`
+	XArrayExploded *[]int32 `json:"X-Array-Exploded,omitempty" yaml:"X-Array-Exploded,omitempty"`
 
 	// XArray array
-	XArray *[]int32 `json:"X-Array,omitempty"`
+	XArray *[]int32 `json:"X-Array,omitempty" yaml:"X-Array,omitempty"`
 
 	// XObjectExploded exploded object
-	XObjectExploded *Object `json:"X-Object-Exploded,omitempty"`
+	XObjectExploded *Object `json:"X-Object-Exploded,omitempty" yaml:"X-Object-Exploded,omitempty"`
 
 	// XObject object
-	XObject *Object `json:"X-Object,omitempty"`
+	XObject *Object `json:"X-Object,omitempty" yaml:"X-Object,omitempty"`
 
 	// XComplexObject complex object
-	XComplexObject *ComplexObject `json:"X-Complex-Object,omitempty"`
+	XComplexObject *ComplexObject `json:"X-Complex-Object,omitempty" yaml:"X-Complex-Object,omitempty"`
 
 	// N1StartingWithNumber name starting with number
-	N1StartingWithNumber *string `json:"1-Starting-With-Number,omitempty"`
+	N1StartingWithNumber *string `json:"1-Starting-With-Number,omitempty" yaml:"1-Starting-With-Number,omitempty"`
 }
 
 // GetDeepObjectParams defines parameters for GetDeepObject.
 type GetDeepObjectParams struct {
 	// DeepObj deep object
-	DeepObj ComplexObject `json:"deepObj"`
+	DeepObj ComplexObject `json:"deepObj" yaml:"deepObj"`
 }
 
 // GetQueryFormParams defines parameters for GetQueryForm.
 type GetQueryFormParams struct {
 	// Ea exploded array
-	Ea *[]int32 `form:"ea,omitempty" json:"ea,omitempty"`
+	Ea *[]int32 `form:"ea,omitempty" json:"ea,omitempty" yaml:"ea,omitempty"`
 
 	// A array
-	A *[]int32 `form:"a,omitempty" json:"a,omitempty"`
+	A *[]int32 `form:"a,omitempty" json:"a,omitempty" yaml:"a,omitempty"`
 
 	// Eo exploded object
-	Eo *Object `form:"eo,omitempty" json:"eo,omitempty"`
+	Eo *Object `form:"eo,omitempty" json:"eo,omitempty" yaml:"eo,omitempty"`
 
 	// O object
-	O *Object `form:"o,omitempty" json:"o,omitempty"`
+	O *Object `form:"o,omitempty" json:"o,omitempty" yaml:"o,omitempty"`
 
 	// Ep exploded primitive
-	Ep *int32 `form:"ep,omitempty" json:"ep,omitempty"`
+	Ep *int32 `form:"ep,omitempty" json:"ep,omitempty" yaml:"ep,omitempty"`
 
 	// P primitive
-	P *int32 `form:"p,omitempty" json:"p,omitempty"`
+	P *int32 `form:"p,omitempty" json:"p,omitempty" yaml:"p,omitempty"`
 
 	// Ps primitive string
-	Ps *string `form:"ps,omitempty" json:"ps,omitempty"`
+	Ps *string `form:"ps,omitempty" json:"ps,omitempty" yaml:"ps,omitempty"`
 
 	// Co complex object
-	Co *ComplexObject `form:"co,omitempty" json:"co,omitempty"`
+	Co *ComplexObject `form:"co,omitempty" json:"co,omitempty" yaml:"co,omitempty"`
 
 	// N1s name starting with number
-	N1s *string `form:"1s,omitempty" json:"1s,omitempty"`
+	N1s *string `form:"1s,omitempty" json:"1s,omitempty" yaml:"1s,omitempty"`
 }
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -51,24 +51,24 @@ type CustomStringType = string
 // DeprecatedProperty defines model for DeprecatedProperty.
 type DeprecatedProperty struct {
 	// NewProp Use this now!
-	NewProp string `json:"newProp"`
+	NewProp string `json:"newProp" yaml:"newProp"`
 	// Deprecated:
-	OldProp1 *string `json:"oldProp1,omitempty"`
+	OldProp1 *string `json:"oldProp1,omitempty" yaml:"oldProp1,omitempty"`
 
 	// OldProp2 It used to do this and that
 	// Deprecated:
-	OldProp2 *string `json:"oldProp2,omitempty"`
+	OldProp2 *string `json:"oldProp2,omitempty" yaml:"oldProp2,omitempty"`
 	// Deprecated: Use NewProp instead!
-	OldProp3 *string `json:"oldProp3,omitempty"`
+	OldProp3 *string `json:"oldProp3,omitempty" yaml:"oldProp3,omitempty"`
 
 	// OldProp4 It used to do this and that
 	// Deprecated: Use NewProp instead!
-	OldProp4 *string `json:"oldProp4,omitempty"`
+	OldProp4 *string `json:"oldProp4,omitempty" yaml:"oldProp4,omitempty"`
 }
 
 // EnumInObjInArray defines model for EnumInObjInArray.
 type EnumInObjInArray = []struct {
-	Val *EnumInObjInArrayVal `json:"val,omitempty"`
+	Val *EnumInObjInArrayVal `json:"val,omitempty" yaml:"val,omitempty"`
 }
 
 // EnumInObjInArrayVal defines model for EnumInObjInArray.Val.
@@ -79,21 +79,21 @@ type GenericObject = map[string]interface{}
 
 // NullableProperties defines model for NullableProperties.
 type NullableProperties struct {
-	Optional            *string `json:"optional,omitempty"`
-	OptionalAndNullable *string `json:"optionalAndNullable"`
-	Required            string  `json:"required"`
-	RequiredAndNullable *string `json:"requiredAndNullable"`
+	Optional            *string `json:"optional,omitempty" yaml:"optional,omitempty"`
+	OptionalAndNullable *string `json:"optionalAndNullable" yaml:"optionalAndNullable"`
+	Required            string  `json:"required" yaml:"required"`
+	RequiredAndNullable *string `json:"requiredAndNullable" yaml:"requiredAndNullable"`
 }
 
 // OuterTypeWithAnonymousInner defines model for OuterTypeWithAnonymousInner.
 type OuterTypeWithAnonymousInner struct {
-	Inner InnerRenamedAnonymousObject `json:"inner"`
-	Name  string                      `json:"name"`
+	Inner InnerRenamedAnonymousObject `json:"inner" yaml:"inner"`
+	Name  string                      `json:"name" yaml:"name"`
 }
 
 // InnerRenamedAnonymousObject defines model for .
 type InnerRenamedAnonymousObject struct {
-	Id int `json:"id"`
+	Id int `json:"id" yaml:"id"`
 }
 
 // StringInPath defines model for StringInPath.
@@ -104,7 +104,7 @@ type Issue9JSONBody = interface{}
 
 // Issue9Params defines parameters for Issue9.
 type Issue9Params struct {
-	Foo string `form:"foo" json:"foo"`
+	Foo string `form:"foo" json:"foo" yaml:"foo"`
 }
 
 // Issue185JSONRequestBody defines body for Issue185 for application/json ContentType.
@@ -735,13 +735,13 @@ type EnsureEverythingIsReferencedResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
-		AnyType1 *AnyType1 `json:"anyType1,omitempty"`
+		AnyType1 *AnyType1 `json:"anyType1,omitempty" yaml:"anyType1,omitempty"`
 
 		// AnyType2 AnyType2 represents any type.
 		//
 		// This should be an interface{}
-		AnyType2         *AnyType2         `json:"anyType2,omitempty"`
-		CustomStringType *CustomStringType `foo:"bar" json:"customStringType,omitempty"`
+		AnyType2         *AnyType2         `json:"anyType2,omitempty" yaml:"anyType2,omitempty"`
+		CustomStringType *CustomStringType `foo:"bar" json:"customStringType,omitempty" yaml:"customStringType,omitempty"`
 	}
 }
 
@@ -1048,13 +1048,13 @@ func ParseEnsureEverythingIsReferencedResponse(rsp *http.Response) (*EnsureEvery
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
-			AnyType1 *AnyType1 `json:"anyType1,omitempty"`
+			AnyType1 *AnyType1 `json:"anyType1,omitempty" yaml:"anyType1,omitempty"`
 
 			// AnyType2 AnyType2 represents any type.
 			//
 			// This should be an interface{}
-			AnyType2         *AnyType2         `json:"anyType2,omitempty"`
-			CustomStringType *CustomStringType `foo:"bar" json:"customStringType,omitempty"`
+			AnyType2         *AnyType2         `json:"anyType2,omitempty" yaml:"anyType2,omitempty"`
+			CustomStringType *CustomStringType `foo:"bar" json:"customStringType,omitempty" yaml:"customStringType,omitempty"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err

--- a/internal/test/server/server.gen.go
+++ b/internal/test/server/server.gen.go
@@ -21,63 +21,63 @@ const (
 
 // EveryTypeOptional defines model for EveryTypeOptional.
 type EveryTypeOptional struct {
-	ArrayInlineField     *[]int              `json:"array_inline_field,omitempty"`
-	ArrayReferencedField *[]SomeObject       `json:"array_referenced_field,omitempty"`
-	BoolField            *bool               `json:"bool_field,omitempty"`
-	ByteField            *[]byte             `json:"byte_field,omitempty"`
-	DateField            *openapi_types.Date `json:"date_field,omitempty"`
-	DateTimeField        *time.Time          `json:"date_time_field,omitempty"`
-	DoubleField          *float64            `json:"double_field,omitempty"`
-	FloatField           *float32            `json:"float_field,omitempty"`
+	ArrayInlineField     *[]int              `json:"array_inline_field,omitempty" yaml:"array_inline_field,omitempty"`
+	ArrayReferencedField *[]SomeObject       `json:"array_referenced_field,omitempty" yaml:"array_referenced_field,omitempty"`
+	BoolField            *bool               `json:"bool_field,omitempty" yaml:"bool_field,omitempty"`
+	ByteField            *[]byte             `json:"byte_field,omitempty" yaml:"byte_field,omitempty"`
+	DateField            *openapi_types.Date `json:"date_field,omitempty" yaml:"date_field,omitempty"`
+	DateTimeField        *time.Time          `json:"date_time_field,omitempty" yaml:"date_time_field,omitempty"`
+	DoubleField          *float64            `json:"double_field,omitempty" yaml:"double_field,omitempty"`
+	FloatField           *float32            `json:"float_field,omitempty" yaml:"float_field,omitempty"`
 	InlineObjectField    *struct {
-		Name   string `json:"name"`
-		Number int    `json:"number"`
-	} `json:"inline_object_field,omitempty"`
-	Int32Field      *int32      `json:"int32_field,omitempty"`
-	Int64Field      *int64      `json:"int64_field,omitempty"`
-	IntField        *int        `json:"int_field,omitempty"`
-	NumberField     *float32    `json:"number_field,omitempty"`
-	ReferencedField *SomeObject `json:"referenced_field,omitempty"`
-	StringField     *string     `json:"string_field,omitempty"`
+		Name   string `json:"name" yaml:"name"`
+		Number int    `json:"number" yaml:"number"`
+	} `json:"inline_object_field,omitempty" yaml:"inline_object_field,omitempty"`
+	Int32Field      *int32      `json:"int32_field,omitempty" yaml:"int32_field,omitempty"`
+	Int64Field      *int64      `json:"int64_field,omitempty" yaml:"int64_field,omitempty"`
+	IntField        *int        `json:"int_field,omitempty" yaml:"int_field,omitempty"`
+	NumberField     *float32    `json:"number_field,omitempty" yaml:"number_field,omitempty"`
+	ReferencedField *SomeObject `json:"referenced_field,omitempty" yaml:"referenced_field,omitempty"`
+	StringField     *string     `json:"string_field,omitempty" yaml:"string_field,omitempty"`
 }
 
 // EveryTypeRequired defines model for EveryTypeRequired.
 type EveryTypeRequired struct {
-	ArrayInlineField     []int                `json:"array_inline_field"`
-	ArrayReferencedField []SomeObject         `json:"array_referenced_field"`
-	BoolField            bool                 `json:"bool_field"`
-	ByteField            []byte               `json:"byte_field"`
-	DateField            openapi_types.Date   `json:"date_field"`
-	DateTimeField        time.Time            `json:"date_time_field"`
-	DoubleField          float64              `json:"double_field"`
-	EmailField           *openapi_types.Email `json:"email_field,omitempty"`
-	FloatField           float32              `json:"float_field"`
+	ArrayInlineField     []int                `json:"array_inline_field" yaml:"array_inline_field"`
+	ArrayReferencedField []SomeObject         `json:"array_referenced_field" yaml:"array_referenced_field"`
+	BoolField            bool                 `json:"bool_field" yaml:"bool_field"`
+	ByteField            []byte               `json:"byte_field" yaml:"byte_field"`
+	DateField            openapi_types.Date   `json:"date_field" yaml:"date_field"`
+	DateTimeField        time.Time            `json:"date_time_field" yaml:"date_time_field"`
+	DoubleField          float64              `json:"double_field" yaml:"double_field"`
+	EmailField           *openapi_types.Email `json:"email_field,omitempty" yaml:"email_field,omitempty"`
+	FloatField           float32              `json:"float_field" yaml:"float_field"`
 	InlineObjectField    struct {
-		Name   string `json:"name"`
-		Number int    `json:"number"`
-	} `json:"inline_object_field"`
-	Int32Field      int32      `json:"int32_field"`
-	Int64Field      int64      `json:"int64_field"`
-	IntField        int        `json:"int_field"`
-	NumberField     float32    `json:"number_field"`
-	ReferencedField SomeObject `json:"referenced_field"`
-	StringField     string     `json:"string_field"`
+		Name   string `json:"name" yaml:"name"`
+		Number int    `json:"number" yaml:"number"`
+	} `json:"inline_object_field" yaml:"inline_object_field"`
+	Int32Field      int32      `json:"int32_field" yaml:"int32_field"`
+	Int64Field      int64      `json:"int64_field" yaml:"int64_field"`
+	IntField        int        `json:"int_field" yaml:"int_field"`
+	NumberField     float32    `json:"number_field" yaml:"number_field"`
+	ReferencedField SomeObject `json:"referenced_field" yaml:"referenced_field"`
+	StringField     string     `json:"string_field" yaml:"string_field"`
 }
 
 // ReservedKeyword defines model for ReservedKeyword.
 type ReservedKeyword struct {
-	Channel *string `json:"channel,omitempty"`
+	Channel *string `json:"channel,omitempty" yaml:"channel,omitempty"`
 }
 
 // Resource defines model for Resource.
 type Resource struct {
-	Name  string  `json:"name"`
-	Value float32 `json:"value"`
+	Name  string  `json:"name" yaml:"name"`
+	Value float32 `json:"value" yaml:"value"`
 }
 
 // SomeObject defines model for some_object.
 type SomeObject struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 }
 
 // Argument defines model for argument.
@@ -88,19 +88,19 @@ type ResponseWithReference = SomeObject
 
 // SimpleResponse defines model for SimpleResponse.
 type SimpleResponse struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 }
 
 // GetWithArgsParams defines parameters for GetWithArgs.
 type GetWithArgsParams struct {
 	// OptionalArgument An optional query argument
-	OptionalArgument *int64 `form:"optional_argument,omitempty" json:"optional_argument,omitempty"`
+	OptionalArgument *int64 `form:"optional_argument,omitempty" json:"optional_argument,omitempty" yaml:"optional_argument,omitempty"`
 
 	// RequiredArgument An optional query argument
-	RequiredArgument int64 `form:"required_argument" json:"required_argument"`
+	RequiredArgument int64 `form:"required_argument" json:"required_argument" yaml:"required_argument"`
 
 	// HeaderArgument An optional query argument
-	HeaderArgument *int32 `json:"header_argument,omitempty"`
+	HeaderArgument *int32 `json:"header_argument,omitempty" yaml:"header_argument,omitempty"`
 }
 
 // GetWithContentTypeParamsContentType defines parameters for GetWithContentType.
@@ -109,13 +109,13 @@ type GetWithContentTypeParamsContentType string
 // CreateResource2Params defines parameters for CreateResource2.
 type CreateResource2Params struct {
 	// InlineQueryArgument Some query argument
-	InlineQueryArgument *int `form:"inline_query_argument,omitempty" json:"inline_query_argument,omitempty"`
+	InlineQueryArgument *int `form:"inline_query_argument,omitempty" json:"inline_query_argument,omitempty" yaml:"inline_query_argument,omitempty"`
 }
 
 // UpdateResource3JSONBody defines parameters for UpdateResource3.
 type UpdateResource3JSONBody struct {
-	Id   *int    `json:"id,omitempty"`
-	Name *string `json:"name,omitempty"`
+	Id   *int    `json:"id,omitempty" yaml:"id,omitempty"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
 // CreateResourceJSONRequestBody defines body for CreateResource for application/json ContentType.

--- a/internal/test/strict-server/chi/server.gen.go
+++ b/internal/test/strict-server/chi/server.gen.go
@@ -586,7 +586,7 @@ func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestA
 }
 
 type ReservedGoKeywordParametersRequestObject struct {
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 }
 
 type ReservedGoKeywordParametersResponseObject interface {

--- a/internal/test/strict-server/chi/types.gen.go
+++ b/internal/test/strict-server/chi/types.gen.go
@@ -5,7 +5,7 @@ package api
 
 // Example defines model for example.
 type Example struct {
-	Value *string `json:"value,omitempty"`
+	Value *string `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // Reusableresponse defines model for reusableresponse.
@@ -19,8 +19,8 @@ type TextExampleTextBody = string
 
 // HeadersExampleParams defines parameters for HeadersExample.
 type HeadersExampleParams struct {
-	Header1 string `json:"header1"`
-	Header2 *int   `json:"header2,omitempty"`
+	Header1 string `json:"header1" yaml:"header1"`
+	Header2 *int   `json:"header2,omitempty" yaml:"header2,omitempty"`
 }
 
 // JSONExampleJSONRequestBody defines body for JSONExample for application/json ContentType.

--- a/internal/test/strict-server/client/client.gen.go
+++ b/internal/test/strict-server/client/client.gen.go
@@ -18,7 +18,7 @@ import (
 
 // Example defines model for example.
 type Example struct {
-	Value *string `json:"value,omitempty"`
+	Value *string `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // Reusableresponse defines model for reusableresponse.
@@ -32,8 +32,8 @@ type TextExampleTextBody = string
 
 // HeadersExampleParams defines parameters for HeadersExample.
 type HeadersExampleParams struct {
-	Header1 string `json:"header1"`
-	Header2 *int   `json:"header2,omitempty"`
+	Header1 string `json:"header1" yaml:"header1"`
+	Header2 *int   `json:"header2,omitempty" yaml:"header2,omitempty"`
 }
 
 // JSONExampleJSONRequestBody defines body for JSONExample for application/json ContentType.

--- a/internal/test/strict-server/echo/server.gen.go
+++ b/internal/test/strict-server/echo/server.gen.go
@@ -400,7 +400,7 @@ func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestA
 }
 
 type ReservedGoKeywordParametersRequestObject struct {
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 }
 
 type ReservedGoKeywordParametersResponseObject interface {

--- a/internal/test/strict-server/echo/types.gen.go
+++ b/internal/test/strict-server/echo/types.gen.go
@@ -5,7 +5,7 @@ package api
 
 // Example defines model for example.
 type Example struct {
-	Value *string `json:"value,omitempty"`
+	Value *string `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // Reusableresponse defines model for reusableresponse.
@@ -19,8 +19,8 @@ type TextExampleTextBody = string
 
 // HeadersExampleParams defines parameters for HeadersExample.
 type HeadersExampleParams struct {
-	Header1 string `json:"header1"`
-	Header2 *int   `json:"header2,omitempty"`
+	Header1 string `json:"header1" yaml:"header1"`
+	Header2 *int   `json:"header2,omitempty" yaml:"header2,omitempty"`
 }
 
 // JSONExampleJSONRequestBody defines body for JSONExample for application/json ContentType.

--- a/internal/test/strict-server/gin/server.gen.go
+++ b/internal/test/strict-server/gin/server.gen.go
@@ -457,7 +457,7 @@ func (response MultipleRequestAndResponseTypes400Response) VisitMultipleRequestA
 }
 
 type ReservedGoKeywordParametersRequestObject struct {
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 }
 
 type ReservedGoKeywordParametersResponseObject interface {

--- a/internal/test/strict-server/gin/types.gen.go
+++ b/internal/test/strict-server/gin/types.gen.go
@@ -5,7 +5,7 @@ package api
 
 // Example defines model for example.
 type Example struct {
-	Value *string `json:"value,omitempty"`
+	Value *string `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // Reusableresponse defines model for reusableresponse.
@@ -19,8 +19,8 @@ type TextExampleTextBody = string
 
 // HeadersExampleParams defines parameters for HeadersExample.
 type HeadersExampleParams struct {
-	Header1 string `json:"header1"`
-	Header2 *int   `json:"header2,omitempty"`
+	Header1 string `json:"header1" yaml:"header1"`
+	Header2 *int   `json:"header2,omitempty" yaml:"header2,omitempty"`
 }
 
 // JSONExampleJSONRequestBody defines body for JSONExample for application/json ContentType.

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -106,6 +106,10 @@ func Generate(spec *openapi3.T, opts Configuration) (string, error) {
 	globalState.importMapping = constructImportMapping(opts.ImportMapping)
 
 	filterOperationsByTag(spec, opts)
+	if (opts.OutputOptions.ExcludeDepreciated) {
+		excludeOperationsIfDepreciated(spec.Paths)
+	}
+
 	if !opts.OutputOptions.SkipPrune {
 		pruneUnusedComponents(spec)
 	}

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -274,10 +274,10 @@ type GetTestByNameResponse struct {
 
 	// Check the client method signatures:
 	assert.Contains(t, code, "type GetTestByNameParams struct {")
-	assert.Contains(t, code, "Top *int `form:\"$top,omitempty\" json:\"$top,omitempty\"`")
+	assert.Contains(t, code, "Top *int `form:\"$top,omitempty\" json:\"$top,omitempty\" yaml:\"$top,omitempty\"`")
 	assert.Contains(t, code, "func (c *Client) GetTestByName(ctx context.Context, name string, params *GetTestByNameParams, reqEditors ...RequestEditorFn) (*http.Response, error) {")
 	assert.Contains(t, code, "func (c *ClientWithResponses) GetTestByNameWithResponse(ctx context.Context, name string, params *GetTestByNameParams, reqEditors ...RequestEditorFn) (*GetTestByNameResponse, error) {")
-	assert.Contains(t, code, "DeadSince *time.Time    `json:\"dead_since,omitempty\" tag1:\"value1\" tag2:\"value2\"`")
+	assert.Contains(t, code, "DeadSince *time.Time    `json:\"dead_since,omitempty\" tag1:\"value1\" tag2:\"value2\" yaml:\"dead_since,omitempty\"`")
 	assert.Contains(t, code, "type EnumTestNumerics int")
 	assert.Contains(t, code, "N2 EnumTestNumerics = 2")
 	assert.Contains(t, code, "type EnumTestEnumNames int")

--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -85,6 +85,7 @@ type OutputOptions struct {
 	UserTemplates map[string]string `yaml:"user-templates,omitempty"` // Override built-in templates from user-provided files
 
 	ExcludeSchemas      []string `yaml:"exclude-schemas,omitempty"`      // Exclude from generation schemas with given names. Ignored when empty.
+	ExcludeDepreciated  bool     `yaml:"exclude-depreciated,omitempty"`  // Exclude operations from generation if they are depreciated. Ignored if false or blank.
 	ResponseTypeSuffix  string   `yaml:"response-type-suffix,omitempty"` // The suffix used for responses types
 	ClientTypeName      string   `yaml:"client-type-name,omitempty"`     // Override the default generated client type with the value
 	InitialismOverrides bool     `yaml:"initialism-overrides,omitempty"` // Whether to use the initialism overrides

--- a/pkg/codegen/filter.go
+++ b/pkg/codegen/filter.go
@@ -1,8 +1,5 @@
 package codegen
 
-import (
-	"fmt"
-)
 import "github.com/getkin/kin-openapi/openapi3"
 
 func filterOperationsByTag(swagger *openapi3.T, opts Configuration) {
@@ -60,7 +57,6 @@ func excludeOperationsIfDepreciated(paths openapi3.Paths) {
 		if op == nil {
 			return false
 		}
-		fmt.Printf("%s - Deprecated: %t\n", op.Summary, op.Deprecated)
 		return op.Deprecated
 	}, true)
 }

--- a/pkg/codegen/filter.go
+++ b/pkg/codegen/filter.go
@@ -1,5 +1,8 @@
 package codegen
 
+import (
+	"fmt"
+)
 import "github.com/getkin/kin-openapi/openapi3"
 
 func filterOperationsByTag(swagger *openapi3.T, opts Configuration) {
@@ -34,7 +37,7 @@ func includeOperations(paths openapi3.Paths, filter OperationPredicate, exclude 
 
 
 func includeOperationsWithTags(paths openapi3.Paths, tags []string, exclude bool) {
-	return includeOperations(paths, func(op *openapi3.Operation) { return operationHasTag(op, tags)} )
+	includeOperations(paths, func(op *openapi3.Operation) bool { return operationHasTag(op, tags)}, exclude)
 }
 
 // operationHasTag returns true if the operation is tagged with any of tags
@@ -53,10 +56,11 @@ func operationHasTag(op *openapi3.Operation, tags []string) bool {
 }
 
 func excludeOperationsIfDepreciated(paths openapi3.Paths) {
-	return includeOperations(paths, func(op *openapi3.Operation) {
+	includeOperations(paths, func(op *openapi3.Operation) bool {
 		if op == nil {
 			return false
 		}
+		fmt.Printf("%s - Deprecated: %t\n", op.Summary, op.Deprecated)
 		return op.Deprecated
-	}, false)
+	}, true)
 }

--- a/pkg/codegen/filter_test.go
+++ b/pkg/codegen/filter_test.go
@@ -66,4 +66,31 @@ func TestFilterOperationsByTag(t *testing.T) {
 		assert.Contains(t, code, `"/test/:name"`)
 		assert.NotContains(t, code, `"/cat"`)
 	})
+
+	t.Run("exclude depreciated", func(t *testing.T) {
+		opts := Configuration{
+			PackageName: packageName,
+			Generate: GenerateOptions{
+				EchoServer:   true,
+				Models:       true,
+			},
+			OutputOptions: OutputOptions{
+				ExcludeDepreciated: true,
+			},
+		}
+		
+		loader := openapi3.NewLoader()
+		loader.IsExternalRefsAllowed = true
+
+		// Get a spec from the test definition in this file:
+		swagger, err := loader.LoadFromData([]byte(testOpenAPIDefinition))
+		assert.NoError(t, err)
+
+		// Run our code generation:
+		code, err := Generate(swagger, opts)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, code)
+		assert.Contains(t, code, `"/cat"`)
+		assert.NotContains(t, code, `"/enum"`)
+	})
 }

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -54,6 +54,17 @@ func (pd *ParameterDefinition) JsonTag() string {
 	}
 }
 
+// YamlTag generates the YAML annotation to map GoType to yaml type name. If Parameter
+// Foo is marshaled to yaml as "foo", this will create the annotation
+// 'yaml:"foo"'
+func (pd *ParameterDefinition) YamlTag() string {
+	if pd.Required {
+		return fmt.Sprintf("`yaml:\"%s\"`", pd.ParamName)
+	} else {
+		return fmt.Sprintf("`yaml:\"%s,omitempty\"`", pd.ParamName)
+	}
+}
+
 func (pd *ParameterDefinition) IsJson() bool {
 	p := pd.Spec
 	if len(p.Content) == 1 {

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -48,20 +48,9 @@ func (pd ParameterDefinition) TypeDef() string {
 // 'json:"foo"'
 func (pd *ParameterDefinition) JsonTag() string {
 	if pd.Required {
-		return fmt.Sprintf("`json:\"%s\"`", pd.ParamName)
+		return fmt.Sprintf("`json:\"%s\" yaml:\"%s\"`", pd.ParamName, pd.ParamName)
 	} else {
-		return fmt.Sprintf("`json:\"%s,omitempty\"`", pd.ParamName)
-	}
-}
-
-// YamlTag generates the YAML annotation to map GoType to yaml type name. If Parameter
-// Foo is marshaled to yaml as "foo", this will create the annotation
-// 'yaml:"foo"'
-func (pd *ParameterDefinition) YamlTag() string {
-	if pd.Required {
-		return fmt.Sprintf("`yaml:\"%s\"`", pd.ParamName)
-	} else {
-		return fmt.Sprintf("`yaml:\"%s,omitempty\"`", pd.ParamName)
+		return fmt.Sprintf("`json:\"%s,omitempty\" yaml:\"%s,omitempty\"`", pd.ParamName, pd.ParamName)
 	}
 }
 

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -190,11 +190,7 @@ type Discriminator struct {
 }
 
 func (d *Discriminator) JSONTag() string {
-	return fmt.Sprintf("`json:\"%s\"`", d.Property)
-}
-
-func (d *Discriminator) YAMLTag() string {
-	return fmt.Sprintf("`yaml:\"%s\"`", d.Property)
+	return fmt.Sprintf("`json:\"%s\" yaml:\"%s\"`", d.Property, d.Property)
 }
 
 func (d *Discriminator) PropertyName() string {

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -193,6 +193,10 @@ func (d *Discriminator) JSONTag() string {
 	return fmt.Sprintf("`json:\"%s\"`", d.Property)
 }
 
+func (d *Discriminator) YAMLTag() string {
+	return fmt.Sprintf("`yaml:\"%s\"`", d.Property)
+}
+
 func (d *Discriminator) PropertyName() string {
 	return SchemaNameToTypeName(d.Property)
 }

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -677,11 +677,13 @@ func GenFieldsFromProperties(props []Property) []string {
 
 		if !omitEmpty {
 			fieldTags["json"] = p.JsonFieldName
+			fieldTags["yaml"] = p.JsonFieldName
 			if p.NeedsFormTag {
 				fieldTags["form"] = p.JsonFieldName
 			}
 		} else {
 			fieldTags["json"] = p.JsonFieldName + ",omitempty"
+			fieldTags["yaml"] = p.JsonFieldName + ",omitempty"
 			if p.NeedsFormTag {
 				fieldTags["form"] = p.JsonFieldName + ",omitempty"
 			}

--- a/pkg/codegen/templates/union.tmpl
+++ b/pkg/codegen/templates/union.tmpl
@@ -62,7 +62,7 @@
     {{if $discriminator}}
         func (t {{.TypeName}}) Discriminator() (string, error) {
             var discriminator struct {
-                Discriminator string {{$discriminator.JSONTag}}
+                Discriminator string {{$discriminator.JSONTag}} {{$discriminator.YAMLTag}}
             }
             err := json.Unmarshal(t.union, &discriminator)
             return discriminator.Discriminator, err

--- a/pkg/codegen/templates/union.tmpl
+++ b/pkg/codegen/templates/union.tmpl
@@ -62,7 +62,7 @@
     {{if $discriminator}}
         func (t {{.TypeName}}) Discriminator() (string, error) {
             var discriminator struct {
-                Discriminator string {{$discriminator.JSONTag}} {{$discriminator.YAMLTag}}
+                Discriminator string {{$discriminator.JSONTag}}
             }
             err := json.Unmarshal(t.union, &discriminator)
             return discriminator.Discriminator, err

--- a/pkg/codegen/test_spec.yaml
+++ b/pkg/codegen/test_spec.yaml
@@ -93,6 +93,7 @@ paths:
         - enum
       summary: References enum
       operationId: getEnum
+      deprecated: true
       responses:
         200:
           description: Success


### PR DESCRIPTION
I have a few small tweaks I'm testing out locally - created a PR to track them in case they are useful to others.

- Adds YAML struct tags identical to the JSON ones already generated. 
- Adds a new filter `exclude-depreciated` that does what it says on the tin and excludes depreciated operations from the generated code.

Please let me know if there's a better way to accomplish these, or if there's any improvements recommended!


(In particular, I'm not sure if I'm expected to have ran `make generate` before pushing up this PR - if not, the `*.gen.go` files can be removed from this PR easily)