### PR TITLE
Introduce content type into generated JSON types

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ you can focus on implementing the business logic for your service.
 
 We have chosen to focus on [Echo](https://github.com/labstack/echo) as
 our default HTTP routing engine, due to its speed and simplicity for the generated
-stubs, and [Chi](https://github.com/go-chi/chi), and [Gin](https://github.com/gin-gonic/gin)
-have also been added by contributors as additional routers. We chose Echo because
-the `Context` object is a mockable interface, and it allows for some advanced
-testing.
+stubs, and [Chi](https://github.com/go-chi/chi), [Gin](https://github.com/gin-gonic/gin),
+and [gorilla/mux](https://github.com/gorilla/mux) have also been added by
+contributors as additional routers. We chose Echo because the `Context` object
+is a mockable interface, and it allows for some advanced testing.
 
 This package tries to be too simple rather than too generic, so we've made some
 design decisions in favor of simplicity, knowing that we can't generate strongly

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -189,6 +189,9 @@ type ClientInterface interface {
 	// EnsureEverythingIsReferenced request
 	EnsureEverythingIsReferenced(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// Issue1051 request
+	Issue1051(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// Issue127 request
 	Issue127(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -220,6 +223,18 @@ type ClientInterface interface {
 
 func (c *Client) EnsureEverythingIsReferenced(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewEnsureEverythingIsReferencedRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) Issue1051(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIssue1051Request(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -360,6 +375,33 @@ func NewEnsureEverythingIsReferencedRequest(server string) (*http.Request, error
 	}
 
 	operationPath := fmt.Sprintf("/ensure-everything-is-referenced")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewIssue1051Request generates requests for Issue1051
+func NewIssue1051Request(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/issues/1051")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -704,6 +746,9 @@ type ClientWithResponsesInterface interface {
 	// EnsureEverythingIsReferenced request
 	EnsureEverythingIsReferencedWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*EnsureEverythingIsReferencedResponse, error)
 
+	// Issue1051 request
+	Issue1051WithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*Issue1051Response, error)
+
 	// Issue127 request
 	Issue127WithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*Issue127Response, error)
 
@@ -757,6 +802,29 @@ func (r EnsureEverythingIsReferencedResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r EnsureEverythingIsReferencedResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type Issue1051Response struct {
+	Body                             []byte
+	HTTPResponse                     *http.Response
+	JSON200                          *map[string]interface{}
+	ApplicationvndSomethingV1JSON200 *map[string]interface{}
+}
+
+// Status returns HTTPResponse.Status
+func (r Issue1051Response) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r Issue1051Response) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -946,6 +1014,15 @@ func (c *ClientWithResponses) EnsureEverythingIsReferencedWithResponse(ctx conte
 	return ParseEnsureEverythingIsReferencedResponse(rsp)
 }
 
+// Issue1051WithResponse request returning *Issue1051Response
+func (c *ClientWithResponses) Issue1051WithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*Issue1051Response, error) {
+	rsp, err := c.Issue1051(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIssue1051Response(rsp)
+}
+
 // Issue127WithResponse request returning *Issue127Response
 func (c *ClientWithResponses) Issue127WithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*Issue127Response, error) {
 	rsp, err := c.Issue127(ctx, reqEditors...)
@@ -1062,6 +1139,32 @@ func ParseEnsureEverythingIsReferencedResponse(rsp *http.Response) (*EnsureEvery
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseIssue1051Response parses an HTTP response from a Issue1051WithResponse call
+func ParseIssue1051Response(rsp *http.Response) (*Issue1051Response, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &Issue1051Response{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationvndSomethingV1JSON200 = &dest
 
 	}
 
@@ -1259,6 +1362,9 @@ type ServerInterface interface {
 	// (GET /ensure-everything-is-referenced)
 	EnsureEverythingIsReferenced(ctx echo.Context) error
 
+	// (GET /issues/1051)
+	Issue1051(ctx echo.Context) error
+
 	// (GET /issues/127)
 	Issue127(ctx echo.Context) error
 
@@ -1297,6 +1403,17 @@ func (w *ServerInterfaceWrapper) EnsureEverythingIsReferenced(ctx echo.Context) 
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.EnsureEverythingIsReferenced(ctx)
+	return err
+}
+
+// Issue1051 converts echo context to params.
+func (w *ServerInterfaceWrapper) Issue1051(ctx echo.Context) error {
+	var err error
+
+	ctx.Set(Access_tokenScopes, []string{})
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.Issue1051(ctx)
 	return err
 }
 
@@ -1447,6 +1564,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	}
 
 	router.GET(baseURL+"/ensure-everything-is-referenced", wrapper.EnsureEverythingIsReferenced)
+	router.GET(baseURL+"/issues/1051", wrapper.Issue1051)
 	router.GET(baseURL+"/issues/127", wrapper.Issue127)
 	router.GET(baseURL+"/issues/185", wrapper.Issue185)
 	router.GET(baseURL+"/issues/209/$:str", wrapper.Issue209)
@@ -1461,31 +1579,32 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/7RYT2/buBL/KixfgXexLdtp0ca3vL5u4QW2CZoseqhzoMWxxUYaqiRlRzD03RdDypZd",
-	"SW6zaXOJJHJmfvOHv+F4x2Od5RoBneWzHc+FERk4MP7t1hmF6zneCJfQuwQbG5U7pZHP+BWzfp3lwiXs",
-	"IMkHXNEyfeUDjiIDPuPW0YKBb4UyIPnMmQIG3MYJZIJUuzKvtylc86qq9oseyOtbJ4yzn5VLPhbZEkwb",
-	"zV2iLAsijGwy60XYVrmECYZBbLA3pJdfIXa8GvArLO/KHCZ8tmveph3u1ivMQG7AUsSYwJKRwtECFxgQ",
-	"JLpIJVsCE8gUOjArEcOuWiDZeldYp7MQ1jsPZMdX2mTC8RmP/WIDsY7FgD8OtcjVMNYS1oBDeHRGDJ1Y",
-	"2yCu+YwvheEUs/8Ttlg4kDdG52Bc6bManhV4CYQtLbY9/NsCc+QE6u2LFo5qwHXq1U6C6N7SPpl926fd",
-	"209tzx0rLEjmNJM6oBAomUuEO4Pk4meQUACbPUMDwh7c/RhiwRRaB0K+ONL96lfDfhqO6vi0fDkk7QCP",
-	"33fU8nsssjleL7/O8coY4ZOvHGS2XQUbkdI/wCIj/StlLEG2EGuUR8oPJ7LDXP1BeFPVgH8ABKPi67Ch",
-	"OdWNxMciTcUyhZsTLKfItA9ugNdOfL14hXKvy9f04bmnFptY7voXn6b0uwwdnrv1daXrunBgiAeI2K5Q",
-	"Y5npws4RA8GdhkX1fD52iQhnDaaFTcm2fSrHtR7Sx2FN0t7yJ6A3eYBzfYAbdu1+EAe/a1DDbXtd+Ror",
-	"jHLlLbF18ELEMVg7dPoBkN6XIAyYP/bU+Ofnu2HgSRZ2Mr9ztEBe9wkyEYSac5c4l4dWonClO1oGWMdi",
-	"YcGylTZsI4zShWXK2sJ/KlAyvQHDnMpgxG5SEBaYkJIJ5vayJLpAagTLYs1W6hFkgOWUo9IJVm7BbDy0",
-	"DRgbrE9G49E4lDSgyBWf8YvReDThA986fVgiQFsYGMIGTOkSheuhskMDKzCAcajmNbiebggoc63QMXhU",
-	"1llmtScm1rR8FgukXhUbIE5iCj2HLdDmEHsmQ+1oQ24KBOn9ouITZGYu+Yy/9wDfH/DN7acGHRWGzTXa",
-	"kOTpeEz/Yo0O0IMWeZ6q2GuLvno23B3dCU4LXTR9mr80sOIz/p+ocSWqrwvRoZ9Xg73M9CdlpiQTd/To",
-	"c7Ktnt5BleFvwKNQW9Fk+qY3dX+JB2AUVFagLfJcG8qMD9qj87cNy6TG/zqWG4Asd6zZ5VdHHWmak12y",
-	"+syUnAvEKfuTu8e6HrP0OarI+SgT5kHqLT5bUSmeg4bUSFiJInW/MXi/yOPvK+/t637SKHNga5L3HrBt",
-	"Asj2DTfaczxrjiUTBti+S/aX3dvXdU8E6/6nZfnLgtZxmwjeHtU4wTsOwHR8Gb3cWWeq3ji8SyB+sEyt",
-	"mqEmuCohTkUTgrTsdng6vuRtDIOT4epLt2fNluhk+Kruj1y4GEe7lUhTlxhdrJOq7cEnsNRwJHuAcquN",
-	"PJ5LcgO+SxHZU8ujAPqJqSaOOiQdfl2Mf8atjuHvCOyThsATp9/0Fy5de+vk1JUr7L6QiRW3KgZKp0uA",
-	"0YXXryukES0w9AK3iYqT+rtVEphe0bK/2nZV9gdwPiaWcP1GUm3d6Fsn+tUk2k18Dvor+mafoqPRmCZ3",
-	"PxwfRuOOlL8K15EfJTjYP5vbc062x/uquj97ii/7D2+qAF04udY3RKYw1sZA7NKSntNCgvQ3vpqTQhiW",
-	"WpZ05Vlg428vp132hOVbAaY8Knytn1bw/5on66Z0HInrmrm9Z/w8K16eOV3NbwpspSBtyGQNjomaC+lS",
-	"mQG63oD93mPS8btHR0T8L1ZFXCdctvzynzfClHQ2UthASjQgdVyQax4Xr0/ffobxqT+dXr7cUx49Adel",
-	"UZi0HkdmUVRf92mAGEmAPBP5SChi+H8CAAD//wmLy+yNEwAA",
+	"H4sIAAAAAAAC/7RYXW/buBL9Kyxvgftw/Z0GbfyW2+0WLrBJ0GTRhzoPtDi22EhDlaTsCIb++2JI2bIj",
+	"yW02bV5iiZzhmTPDM6S2PNJpphHQWT7d8kwYkYID459unVG4muGNcDE9S7CRUZlTGvmUXzLrx1kmXMz2",
+	"lrzHFQ3TW97jKFLgU24dDRj4nisDkk+dyaHHbRRDKsi1K7JqmsIVL8tyN+iBnN86YZz9olx8lacLME00",
+	"d7GyLJgwWpNZb8I2ysVMMAxmvd1CevENIsfLHr/E4q7IYMyn2/pp0hJuNcIMZAYsMcYEFowcDuY4x4Ag",
+	"1nki2QKYQKbQgVmKCLblHGmt97l1Og203nkgW77UJhWOT3nkB2uIFRc9/tjXIlP9SEtYAfbh0RnRd2Jl",
+	"g7nmU74QhhNnfxC2SDiQN0ZnYFzhsxp+K/AWCBsabEb4twXmKAjUm1cNHGWP68S7HQfT3Uq7ZHZNn7RP",
+	"P1575lhuQTKnmdQBhUDJXCzcCSRnP4OECKzn9A0Iuw/3KnDBFFoHQr468P3mV8N+Ho7ycLd83SdtD4/f",
+	"t9TyB8zTGV4vvs3w0hjhk68cpLZZBWuR0D/APCX/S2UsQbYQaZQHzvc7smW56oXwS5U9/hEQjIquw4R6",
+	"V9cWV3mSiEUCN0dYjpFpT26A10x8NXiJcufL1/T+d0ct1lxuuwef5/RJhva/2/21pes6d2BIB0jYLlFj",
+	"kerczhCDwB3TojpeH4ZEgrMC08CmZHN9KseV7tPLfiXSfuXPQE9yD+d6DzfM2v6ABz+rV8FtRl36GsuN",
+	"csUtqXWIQkQRWNt3+gGQnhcgDJg/d9L46ctdP+gkCzOZnzmYI6/6BC0RjOp9FzuXhVaicKlbWgZYxyJh",
+	"wbKlNmwtjNK5Zcra3L/KUTK9BsOcSmHAbhIQFpiQkgnmdrZkOkdqBIt8xZbqEWSA5ZSj0gmr3IJZe2hr",
+	"MDasPh6MBqNQ0oAiU3zKzwajwZj3fOv0tAwBbW6gD2swhYsVrvrK9g0swQBGoZpX4Dq6IaDMtELH4FFZ",
+	"Z5nVXphY3fJZJJB6VWSANIkp9Bo2R5tB5JUMtaMJmckRpI+Lik/QMjPJp/yDB/hhj29mP9foqDBsptGG",
+	"JE9GI/oXaXSAHrTIskRF3tvwm1fD7cGZ4LjQRd2n+WsDSz7l/xnWoQyr48Jw38/L3s5m8pM2E7KJWnr0",
+	"KdtGT2+RyvDX48NQW8Px6Hzcmbu/8sSpLAGWglTCny8sI9KEQvbp9vqqJQ0z8uu9vpDz5m49nL9GObA6",
+	"BZ/qwXr8vx87eBr55G134OIBGJUTy9HmWaYN1aSH/ugqHqTG/zqWGYA0c6ye5UcHncxM3r6UmFMlcNz3",
+	"npL2mCYvcUXBD1NhHqTe4IsdFeIlaMiNhKXIE/cbyftFET+tvHfn3XJZZMBWZO8jYJsYkO2OGsNdd2O1",
+	"IDFhgO3OB91l9+68Og2Adf/XsvhlpLWco0K0BzVO8A4JmIwuhq+31pmyk4f3MUQPlqllfZ0LoUqIElFT",
+	"kBTtAU9GF7yJoXd0rfzaHlk9ZXh07SzvD0I4Gw23S5EkLjY6X8VlM4LPYKnVSvYAxUYbeXgjywz4/kxt",
+	"jpo9EejvipVwVJS0xHU2+pmwWq69B2Cfdf09Cvptd+HSgb9KTlW5wu4KmVRxoyKgdLoYGB31/bhCupwG",
+	"hZ7jJlZRXL23SgLTSxr2h/q2yv4IznNiCddvFNXGXaaxo9+Mh9uxz0F3Rd/sUnTwUUDhKnwW2H8UaEn5",
+	"m3AQ+1GCw/onc3sqyOaHjbK8P7mLL7o3b6IAXdi51jdEpjDSxkDkkoJ+J7kE6c+6lSYFGhZaFnTYm2Md",
+	"b6emXXTQ8j0HUxwUvtbPK/h/rZNVUzpk4rpSbh8ZP62KFyd2V/01hS0VJLWYrMAxUWkhHadTQNdJ2O/d",
+	"Ji1ffFoY8d/q8qhKuGzE5V+vhSlobySwhoRkQOoop9A8Ll7tvt3tzaf++N729Z7y6AW4Ko3cJNVFbDoc",
+	"VhcdujoNJECWimwgFCn8PwEAAP//WUiKvIcUAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/schemas/schemas.yaml
+++ b/internal/test/schemas/schemas.yaml
@@ -133,7 +133,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DeprecatedProperty"
-
+  /issues/1051:
+    get:
+      operationId: Issue1051
+      description: |
+        Multiple media types contain JSON
+      responses:
+        '200':
+          content:
+            application/vnd.something.v1+json:
+              schema:
+                type: object
+            application/json:
+              schema:
+                type: object
 components:
   schemas:
     GenericObject:

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -293,12 +293,18 @@ func (o *OperationDefinition) GetResponseTypeDefinitions() ([]ResponseTypeDefini
 
 					var typeName string
 					switch {
+
 					// HAL+JSON:
 					case StringInArray(contentTypeName, contentTypesHalJSON):
 						typeName = fmt.Sprintf("HALJSON%s", ToCamelCase(responseName))
-					// JSON:
-					case StringInArray(contentTypeName, contentTypesJSON) || util.IsMediaTypeJson(contentTypeName):
+					case "application/json" == contentTypeName:
+						// if it's the standard application/json
 						typeName = fmt.Sprintf("JSON%s", ToCamelCase(responseName))
+					// Vendored JSON
+					case StringInArray(contentTypeName, contentTypesJSON) || util.IsMediaTypeJson(contentTypeName):
+						baseTypeName := fmt.Sprintf("%s%s", ToCamelCase(contentTypeName), ToCamelCase(responseName))
+
+						typeName = strings.ReplaceAll(baseTypeName, "Json", "JSON")
 					// YAML:
 					case StringInArray(contentTypeName, contentTypesYAML):
 						typeName = fmt.Sprintf("YAML%s", ToCamelCase(responseName))


### PR DESCRIPTION
As noted in #1051, we have cases where multiple uses of JSON types leads
to a clash in generated type names.

This is a slight breaking change for folks' generated code, but ensures
that conflicts do not happen, and that we are more predictable with
generated type names.

Closes #1051.
