### PR TITLE
Change function comments to start with a name

### DIFF
--- a/examples/petstore-expanded/chi/api/petstore.go
+++ b/examples/petstore-expanded/chi/api/petstore.go
@@ -26,7 +26,7 @@ func NewPetStore() *PetStore {
 	}
 }
 
-// This function wraps sending of an error in the Error format, and
+// sendPetStoreError wraps sending of an error in the Error format, and
 // handling the failure to marshal that.
 func sendPetStoreError(w http.ResponseWriter, code int, message string) {
 	petErr := Error{

--- a/examples/petstore-expanded/echo/api/petstore.go
+++ b/examples/petstore-expanded/echo/api/petstore.go
@@ -39,7 +39,7 @@ func NewPetStore() *PetStore {
 	}
 }
 
-// This function wraps sending of an error in the Error format, and
+// sendPetStoreError wraps sending of an error in the Error format, and
 // handling the failure to marshal that.
 func sendPetStoreError(ctx echo.Context, code int, message string) error {
 	petErr := models.Error{

--- a/examples/petstore-expanded/gin/api/petstore.go
+++ b/examples/petstore-expanded/gin/api/petstore.go
@@ -38,7 +38,7 @@ func NewPetStore() *PetStore {
 	}
 }
 
-// This function wraps sending of an error in the Error format, and
+// sendPetStoreError wraps sending of an error in the Error format, and
 // handling the failure to marshal that.
 func sendPetStoreError(c *gin.Context, code int, message string) {
 	petErr := Error{

--- a/examples/petstore-expanded/gorilla/api/petstore.go
+++ b/examples/petstore-expanded/gorilla/api/petstore.go
@@ -26,7 +26,7 @@ func NewPetStore() *PetStore {
 	}
 }
 
-// This function wraps sending of an error in the Error format, and
+// sendPetStoreError wraps sending of an error in the Error format, and
 // handling the failure to marshal that.
 func sendPetStoreError(w http.ResponseWriter, code int, message string) {
 	petErr := Error{

--- a/pkg/chi-middleware/oapi_validate.go
+++ b/pkg/chi-middleware/oapi_validate.go
@@ -70,7 +70,7 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func
 
 }
 
-// This function is called from the middleware above and actually does the work
+// validateRequest is called from the middleware above and actually does the work
 // of validating a request.
 func validateRequest(r *http.Request, router routers.Router, options *Options) (int, error) {
 

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -843,24 +843,24 @@ func SanitizeCode(goCode string) string {
 // This function will attempt to load a file first, and if it fails, will try to get the
 // data from the remote endpoint.
 func GetUserTemplateText(inputData string) (template string, err error) {
-	//if the input data is more than one line, assume its a template and return that data.
+	// if the input data is more than one line, assume its a template and return that data.
 	if strings.Contains(inputData, "\n") {
 		return inputData, nil
 	}
 
-	//load data from file
+	// load data from file
 	data, err := os.ReadFile(inputData)
-	//return data if found and loaded
+	// return data if found and loaded
 	if err == nil {
 		return string(data), nil
 	}
 
-	//check for non "not found" errors
+	// check for non "not found" errors
 	if !os.IsNotExist(err) {
 		return "", fmt.Errorf("failed to open file %s: %w", inputData, err)
 	}
 
-	//attempt to get data from url
+	// attempt to get data from url
 	resp, err := http.Get(inputData)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute GET request data from %s: %w", inputData, err)

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -913,19 +913,19 @@ func GenerateTypesForOperations(t *template.Template, ops []OperationDefinition)
 	return buf.String(), nil
 }
 
-// GenerateChiServer This function generates all the go code for the ServerInterface as well as
+// GenerateChiServer generates all the go code for the ServerInterface as well as
 // all the wrapper functions around our handlers.
 func GenerateChiServer(t *template.Template, operations []OperationDefinition) (string, error) {
 	return GenerateTemplates([]string{"chi/chi-interface.tmpl", "chi/chi-middleware.tmpl", "chi/chi-handler.tmpl"}, t, operations)
 }
 
-// GenerateFiberServer This function generates all the go code for the ServerInterface as well as
+// GenerateFiberServer generates all the go code for the ServerInterface as well as
 // all the wrapper functions around our handlers.
 func GenerateFiberServer(t *template.Template, operations []OperationDefinition) (string, error) {
 	return GenerateTemplates([]string{"fiber/fiber-interface.tmpl", "fiber/fiber-middleware.tmpl", "fiber/fiber-handler.tmpl"}, t, operations)
 }
 
-// GenerateEchoServer This function generates all the go code for the ServerInterface as well as
+// GenerateEchoServer generates all the go code for the ServerInterface as well as
 // all the wrapper functions around our handlers.
 func GenerateEchoServer(t *template.Template, operations []OperationDefinition) (string, error) {
 	return GenerateTemplates([]string{"echo/echo-interface.tmpl", "echo/echo-wrappers.tmpl", "echo/echo-register.tmpl"}, t, operations)

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -44,7 +44,7 @@ var (
 	titleCaser = cases.Title(language.English)
 )
 
-// This function takes an array of Parameter definition, and generates a valid
+// genParamArgs takes an array of Parameter definition, and generates a valid
 // Go parameter declaration from them, eg:
 // ", foo int, bar string, baz float32". The preceding comma is there to save
 // a lot of work in the template engine.
@@ -60,7 +60,7 @@ func genParamArgs(params []ParameterDefinition) string {
 	return ", " + strings.Join(parts, ", ")
 }
 
-// This function is much like the one above, except it only produces the
+// genParamTypes is much like the one above, except it only produces the
 // types of the parameters for a type declaration. It would produce this
 // from the same input as above:
 // ", int, string, float32".

--- a/pkg/runtime/styleparam.go
+++ b/pkg/runtime/styleparam.go
@@ -463,7 +463,7 @@ func primitiveToString(value interface{}) (string, error) {
 	return output, nil
 }
 
-// This function escapes a parameter value bas on the location of that parameter.
+// escapeParameterString escapes a parameter value bas on the location of that parameter.
 // Query params and path params need different kinds of escaping, while header
 // and cookie params seem not to need escaping.
 func escapeParameterString(value string, paramLocation ParamLocation) string {

--- a/pkg/testutil/response_handlers.go
+++ b/pkg/testutil/response_handlers.go
@@ -33,7 +33,7 @@ func getHandler(mime string) ResponseHandler {
 	return knownHandlers[mime]
 }
 
-// This function assumes that the response contains JSON and unmarshals it
+// jsonHandler assumes that the response contains JSON and unmarshals it
 // into the specified object.
 func jsonHandler(_ string, r io.Reader, obj interface{}, strict bool) error {
 	d := json.NewDecoder(r)

--- a/pkg/util/inputmapping.go
+++ b/pkg/util/inputmapping.go
@@ -47,7 +47,7 @@ func ParseCommandLineList(input string) []string {
 	return args
 }
 
-// This function splits a string along the specified separator, but it
+// splitString splits a string along the specified separator, but it
 // ignores anything between double quotes for splitting. We do simple
 // inside/outside quote counting. Quotes are not stripped from output.
 func splitString(s string, sep rune) []string {


### PR DESCRIPTION
This PR replaces `This function` with a function name to match the common Go comment style.