### PR TITLE
Chi: generate Unimplemented implementation

### DIFF
--- a/pkg/codegen/templates/chi/chi-interface.tmpl
+++ b/pkg/codegen/templates/chi/chi-interface.tmpl
@@ -5,3 +5,13 @@ type ServerInterface interface {
 {{.OperationId}}(w http.ResponseWriter, r *http.Request{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{.OperationId}}Params{{end}})
 {{end}}
 }
+
+// Unimplemented server implementation that returns http.StatusNotImplemented for each endpoint.
+
+type Unimplemented struct {}
+ {{range .}}{{.SummaryAsComment }}
+ // ({{.Method}} {{.Path}})
+ func (_ Unimplemented) {{.OperationId}}(w http.ResponseWriter, r *http.Request{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{.OperationId}}Params{{end}}) {
+	w.WriteHeader(http.StatusNotImplemented)
+ }
+ {{end}}


### PR DESCRIPTION
Update chi-interface.tmpl to generate an implementation for ServerInterface that always returns a `http.StatusNotImplemented`.

The Unimplemented server can be used like this (assuming the code is generated in package spec):

```
type MyAPIServer struct {
  spec.Unimplemented
}
```

Using Unimplemented is optional, but might help when prototyping APIs or in case the OpenAPI spec is managed in a separate repo and mutliple developers.

grpc-go uses a similar strategy. For example see the [examples/route_guide/server/server.go](https://github.com/grpc/grpc-go/blob/master/examples/route_guide/server/server.go#L57) file.

ref: https://github.com/deepmap/oapi-codegen/pull/631