### PR TITLE
Fix: Only generate optional parameters if present

### DIFF
--- a/internal/test/issues/issue-grab_import_names/issue.gen.go
+++ b/internal/test/issues/issue-grab_import_names/issue.gen.go
@@ -143,26 +143,30 @@ func NewGetFooRequest(server string, params *GetFooParams) (*http.Request, error
 		return nil, err
 	}
 
-	if params.Foo != nil {
-		var headerParam0 string
+	if params != nil {
 
-		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "Foo", runtime.ParamLocationHeader, *params.Foo)
-		if err != nil {
-			return nil, err
+		if params.Foo != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "Foo", runtime.ParamLocationHeader, *params.Foo)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Foo", headerParam0)
 		}
 
-		req.Header.Set("Foo", headerParam0)
-	}
+		if params.Bar != nil {
+			var headerParam1 string
 
-	if params.Bar != nil {
-		var headerParam1 string
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "Bar", runtime.ParamLocationHeader, *params.Bar)
+			if err != nil {
+				return nil, err
+			}
 
-		headerParam1, err = runtime.StyleParamWithLocation("simple", false, "Bar", runtime.ParamLocationHeader, *params.Bar)
-		if err != nil {
-			return nil, err
+			req.Header.Set("Bar", headerParam1)
 		}
 
-		req.Header.Set("Bar", headerParam1)
 	}
 
 	return req, nil

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -588,128 +588,130 @@ func NewGetCookieRequest(server string, params *GetCookieParams) (*http.Request,
 		return nil, err
 	}
 
-	if params.P != nil {
-		var cookieParam0 string
+	if params != nil {
 
-		cookieParam0, err = runtime.StyleParamWithLocation("simple", false, "p", runtime.ParamLocationCookie, *params.P)
-		if err != nil {
-			return nil, err
+		if params.P != nil {
+			var cookieParam0 string
+
+			cookieParam0, err = runtime.StyleParamWithLocation("simple", false, "p", runtime.ParamLocationCookie, *params.P)
+			if err != nil {
+				return nil, err
+			}
+
+			cookie0 := &http.Cookie{
+				Name:  "p",
+				Value: cookieParam0,
+			}
+			req.AddCookie(cookie0)
 		}
 
-		cookie0 := &http.Cookie{
-			Name:  "p",
-			Value: cookieParam0,
+		if params.Ep != nil {
+			var cookieParam1 string
+
+			cookieParam1, err = runtime.StyleParamWithLocation("simple", true, "ep", runtime.ParamLocationCookie, *params.Ep)
+			if err != nil {
+				return nil, err
+			}
+
+			cookie1 := &http.Cookie{
+				Name:  "ep",
+				Value: cookieParam1,
+			}
+			req.AddCookie(cookie1)
 		}
-		req.AddCookie(cookie0)
+
+		if params.Ea != nil {
+			var cookieParam2 string
+
+			cookieParam2, err = runtime.StyleParamWithLocation("simple", true, "ea", runtime.ParamLocationCookie, *params.Ea)
+			if err != nil {
+				return nil, err
+			}
+
+			cookie2 := &http.Cookie{
+				Name:  "ea",
+				Value: cookieParam2,
+			}
+			req.AddCookie(cookie2)
+		}
+
+		if params.A != nil {
+			var cookieParam3 string
+
+			cookieParam3, err = runtime.StyleParamWithLocation("simple", false, "a", runtime.ParamLocationCookie, *params.A)
+			if err != nil {
+				return nil, err
+			}
+
+			cookie3 := &http.Cookie{
+				Name:  "a",
+				Value: cookieParam3,
+			}
+			req.AddCookie(cookie3)
+		}
+
+		if params.Eo != nil {
+			var cookieParam4 string
+
+			cookieParam4, err = runtime.StyleParamWithLocation("simple", true, "eo", runtime.ParamLocationCookie, *params.Eo)
+			if err != nil {
+				return nil, err
+			}
+
+			cookie4 := &http.Cookie{
+				Name:  "eo",
+				Value: cookieParam4,
+			}
+			req.AddCookie(cookie4)
+		}
+
+		if params.O != nil {
+			var cookieParam5 string
+
+			cookieParam5, err = runtime.StyleParamWithLocation("simple", false, "o", runtime.ParamLocationCookie, *params.O)
+			if err != nil {
+				return nil, err
+			}
+
+			cookie5 := &http.Cookie{
+				Name:  "o",
+				Value: cookieParam5,
+			}
+			req.AddCookie(cookie5)
+		}
+
+		if params.Co != nil {
+			var cookieParam6 string
+
+			var cookieParamBuf6 []byte
+			cookieParamBuf6, err = json.Marshal(*params.Co)
+			if err != nil {
+				return nil, err
+			}
+			cookieParam6 = url.QueryEscape(string(cookieParamBuf6))
+
+			cookie6 := &http.Cookie{
+				Name:  "co",
+				Value: cookieParam6,
+			}
+			req.AddCookie(cookie6)
+		}
+
+		if params.N1s != nil {
+			var cookieParam7 string
+
+			cookieParam7, err = runtime.StyleParamWithLocation("simple", true, "1s", runtime.ParamLocationCookie, *params.N1s)
+			if err != nil {
+				return nil, err
+			}
+
+			cookie7 := &http.Cookie{
+				Name:  "1s",
+				Value: cookieParam7,
+			}
+			req.AddCookie(cookie7)
+		}
 	}
-
-	if params.Ep != nil {
-		var cookieParam1 string
-
-		cookieParam1, err = runtime.StyleParamWithLocation("simple", true, "ep", runtime.ParamLocationCookie, *params.Ep)
-		if err != nil {
-			return nil, err
-		}
-
-		cookie1 := &http.Cookie{
-			Name:  "ep",
-			Value: cookieParam1,
-		}
-		req.AddCookie(cookie1)
-	}
-
-	if params.Ea != nil {
-		var cookieParam2 string
-
-		cookieParam2, err = runtime.StyleParamWithLocation("simple", true, "ea", runtime.ParamLocationCookie, *params.Ea)
-		if err != nil {
-			return nil, err
-		}
-
-		cookie2 := &http.Cookie{
-			Name:  "ea",
-			Value: cookieParam2,
-		}
-		req.AddCookie(cookie2)
-	}
-
-	if params.A != nil {
-		var cookieParam3 string
-
-		cookieParam3, err = runtime.StyleParamWithLocation("simple", false, "a", runtime.ParamLocationCookie, *params.A)
-		if err != nil {
-			return nil, err
-		}
-
-		cookie3 := &http.Cookie{
-			Name:  "a",
-			Value: cookieParam3,
-		}
-		req.AddCookie(cookie3)
-	}
-
-	if params.Eo != nil {
-		var cookieParam4 string
-
-		cookieParam4, err = runtime.StyleParamWithLocation("simple", true, "eo", runtime.ParamLocationCookie, *params.Eo)
-		if err != nil {
-			return nil, err
-		}
-
-		cookie4 := &http.Cookie{
-			Name:  "eo",
-			Value: cookieParam4,
-		}
-		req.AddCookie(cookie4)
-	}
-
-	if params.O != nil {
-		var cookieParam5 string
-
-		cookieParam5, err = runtime.StyleParamWithLocation("simple", false, "o", runtime.ParamLocationCookie, *params.O)
-		if err != nil {
-			return nil, err
-		}
-
-		cookie5 := &http.Cookie{
-			Name:  "o",
-			Value: cookieParam5,
-		}
-		req.AddCookie(cookie5)
-	}
-
-	if params.Co != nil {
-		var cookieParam6 string
-
-		var cookieParamBuf6 []byte
-		cookieParamBuf6, err = json.Marshal(*params.Co)
-		if err != nil {
-			return nil, err
-		}
-		cookieParam6 = url.QueryEscape(string(cookieParamBuf6))
-
-		cookie6 := &http.Cookie{
-			Name:  "co",
-			Value: cookieParam6,
-		}
-		req.AddCookie(cookie6)
-	}
-
-	if params.N1s != nil {
-		var cookieParam7 string
-
-		cookieParam7, err = runtime.StyleParamWithLocation("simple", true, "1s", runtime.ParamLocationCookie, *params.N1s)
-		if err != nil {
-			return nil, err
-		}
-
-		cookie7 := &http.Cookie{
-			Name:  "1s",
-			Value: cookieParam7,
-		}
-		req.AddCookie(cookie7)
-	}
-
 	return req, nil
 }
 
@@ -786,94 +788,98 @@ func NewGetHeaderRequest(server string, params *GetHeaderParams) (*http.Request,
 		return nil, err
 	}
 
-	if params.XPrimitive != nil {
-		var headerParam0 string
+	if params != nil {
 
-		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Primitive", runtime.ParamLocationHeader, *params.XPrimitive)
-		if err != nil {
-			return nil, err
+		if params.XPrimitive != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "X-Primitive", runtime.ParamLocationHeader, *params.XPrimitive)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Primitive", headerParam0)
 		}
 
-		req.Header.Set("X-Primitive", headerParam0)
-	}
+		if params.XPrimitiveExploded != nil {
+			var headerParam1 string
 
-	if params.XPrimitiveExploded != nil {
-		var headerParam1 string
+			headerParam1, err = runtime.StyleParamWithLocation("simple", true, "X-Primitive-Exploded", runtime.ParamLocationHeader, *params.XPrimitiveExploded)
+			if err != nil {
+				return nil, err
+			}
 
-		headerParam1, err = runtime.StyleParamWithLocation("simple", true, "X-Primitive-Exploded", runtime.ParamLocationHeader, *params.XPrimitiveExploded)
-		if err != nil {
-			return nil, err
+			req.Header.Set("X-Primitive-Exploded", headerParam1)
 		}
 
-		req.Header.Set("X-Primitive-Exploded", headerParam1)
-	}
+		if params.XArrayExploded != nil {
+			var headerParam2 string
 
-	if params.XArrayExploded != nil {
-		var headerParam2 string
+			headerParam2, err = runtime.StyleParamWithLocation("simple", true, "X-Array-Exploded", runtime.ParamLocationHeader, *params.XArrayExploded)
+			if err != nil {
+				return nil, err
+			}
 
-		headerParam2, err = runtime.StyleParamWithLocation("simple", true, "X-Array-Exploded", runtime.ParamLocationHeader, *params.XArrayExploded)
-		if err != nil {
-			return nil, err
+			req.Header.Set("X-Array-Exploded", headerParam2)
 		}
 
-		req.Header.Set("X-Array-Exploded", headerParam2)
-	}
+		if params.XArray != nil {
+			var headerParam3 string
 
-	if params.XArray != nil {
-		var headerParam3 string
+			headerParam3, err = runtime.StyleParamWithLocation("simple", false, "X-Array", runtime.ParamLocationHeader, *params.XArray)
+			if err != nil {
+				return nil, err
+			}
 
-		headerParam3, err = runtime.StyleParamWithLocation("simple", false, "X-Array", runtime.ParamLocationHeader, *params.XArray)
-		if err != nil {
-			return nil, err
+			req.Header.Set("X-Array", headerParam3)
 		}
 
-		req.Header.Set("X-Array", headerParam3)
-	}
+		if params.XObjectExploded != nil {
+			var headerParam4 string
 
-	if params.XObjectExploded != nil {
-		var headerParam4 string
+			headerParam4, err = runtime.StyleParamWithLocation("simple", true, "X-Object-Exploded", runtime.ParamLocationHeader, *params.XObjectExploded)
+			if err != nil {
+				return nil, err
+			}
 
-		headerParam4, err = runtime.StyleParamWithLocation("simple", true, "X-Object-Exploded", runtime.ParamLocationHeader, *params.XObjectExploded)
-		if err != nil {
-			return nil, err
+			req.Header.Set("X-Object-Exploded", headerParam4)
 		}
 
-		req.Header.Set("X-Object-Exploded", headerParam4)
-	}
+		if params.XObject != nil {
+			var headerParam5 string
 
-	if params.XObject != nil {
-		var headerParam5 string
+			headerParam5, err = runtime.StyleParamWithLocation("simple", false, "X-Object", runtime.ParamLocationHeader, *params.XObject)
+			if err != nil {
+				return nil, err
+			}
 
-		headerParam5, err = runtime.StyleParamWithLocation("simple", false, "X-Object", runtime.ParamLocationHeader, *params.XObject)
-		if err != nil {
-			return nil, err
+			req.Header.Set("X-Object", headerParam5)
 		}
 
-		req.Header.Set("X-Object", headerParam5)
-	}
+		if params.XComplexObject != nil {
+			var headerParam6 string
 
-	if params.XComplexObject != nil {
-		var headerParam6 string
+			var headerParamBuf6 []byte
+			headerParamBuf6, err = json.Marshal(*params.XComplexObject)
+			if err != nil {
+				return nil, err
+			}
+			headerParam6 = string(headerParamBuf6)
 
-		var headerParamBuf6 []byte
-		headerParamBuf6, err = json.Marshal(*params.XComplexObject)
-		if err != nil {
-			return nil, err
-		}
-		headerParam6 = string(headerParamBuf6)
-
-		req.Header.Set("X-Complex-Object", headerParam6)
-	}
-
-	if params.N1StartingWithNumber != nil {
-		var headerParam7 string
-
-		headerParam7, err = runtime.StyleParamWithLocation("simple", false, "1-Starting-With-Number", runtime.ParamLocationHeader, *params.N1StartingWithNumber)
-		if err != nil {
-			return nil, err
+			req.Header.Set("X-Complex-Object", headerParam6)
 		}
 
-		req.Header.Set("1-Starting-With-Number", headerParam7)
+		if params.N1StartingWithNumber != nil {
+			var headerParam7 string
+
+			headerParam7, err = runtime.StyleParamWithLocation("simple", false, "1-Starting-With-Number", runtime.ParamLocationHeader, *params.N1StartingWithNumber)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("1-Starting-With-Number", headerParam7)
+		}
+
 	}
 
 	return req, nil

--- a/internal/test/strict-server/client/client.gen.go
+++ b/internal/test/strict-server/client/client.gen.go
@@ -806,24 +806,28 @@ func NewHeadersExampleRequestWithBody(server string, params *HeadersExampleParam
 
 	req.Header.Add("Content-Type", contentType)
 
-	var headerParam0 string
+	if params != nil {
 
-	headerParam0, err = runtime.StyleParamWithLocation("simple", false, "header1", runtime.ParamLocationHeader, params.Header1)
-	if err != nil {
-		return nil, err
-	}
+		var headerParam0 string
 
-	req.Header.Set("header1", headerParam0)
-
-	if params.Header2 != nil {
-		var headerParam1 string
-
-		headerParam1, err = runtime.StyleParamWithLocation("simple", false, "header2", runtime.ParamLocationHeader, *params.Header2)
+		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "header1", runtime.ParamLocationHeader, params.Header1)
 		if err != nil {
 			return nil, err
 		}
 
-		req.Header.Set("header2", headerParam1)
+		req.Header.Set("header1", headerParam0)
+
+		if params.Header2 != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "header2", runtime.ParamLocationHeader, *params.Header2)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("header2", headerParam1)
+		}
+
 	}
 
 	return req, nil

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -233,57 +233,65 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
     }
 
     {{if .HasBody}}req.Header.Add("Content-Type", contentType){{end}}
-{{range $paramIdx, $param := .HeaderParams}}
-    {{if not .Required}} if params.{{.GoName}} != nil { {{end}}
-    var headerParam{{$paramIdx}} string
-    {{if .IsPassThrough}}
-    headerParam{{$paramIdx}} = {{if not .Required}}*{{end}}params.{{.GoName}}
+{{ if .HeaderParams }}
+    if params != nil {
+    {{range $paramIdx, $param := .HeaderParams}}
+        {{if not .Required}} if params.{{.GoName}} != nil { {{end}}
+        var headerParam{{$paramIdx}} string
+        {{if .IsPassThrough}}
+        headerParam{{$paramIdx}} = {{if not .Required}}*{{end}}params.{{.GoName}}
+        {{end}}
+        {{if .IsJson}}
+        var headerParamBuf{{$paramIdx}} []byte
+        headerParamBuf{{$paramIdx}}, err = json.Marshal({{if not .Required}}*{{end}}params.{{.GoName}})
+        if err != nil {
+            return nil, err
+        }
+        headerParam{{$paramIdx}} = string(headerParamBuf{{$paramIdx}})
+        {{end}}
+        {{if .IsStyled}}
+        headerParam{{$paramIdx}}, err = runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationHeader, {{if not .Required}}*{{end}}params.{{.GoName}})
+        if err != nil {
+            return nil, err
+        }
+        {{end}}
+        req.Header.Set("{{.ParamName}}", headerParam{{$paramIdx}})
+        {{if not .Required}}}{{end}}
     {{end}}
-    {{if .IsJson}}
-    var headerParamBuf{{$paramIdx}} []byte
-    headerParamBuf{{$paramIdx}}, err = json.Marshal({{if not .Required}}*{{end}}params.{{.GoName}})
-    if err != nil {
-        return nil, err
     }
-    headerParam{{$paramIdx}} = string(headerParamBuf{{$paramIdx}})
-    {{end}}
-    {{if .IsStyled}}
-    headerParam{{$paramIdx}}, err = runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationHeader, {{if not .Required}}*{{end}}params.{{.GoName}})
-    if err != nil {
-        return nil, err
-    }
-    {{end}}
-    req.Header.Set("{{.ParamName}}", headerParam{{$paramIdx}})
-    {{if not .Required}}}{{end}}
-{{end}}
+{{- end }}{{/* if .HeaderParams */}}
 
-{{range $paramIdx, $param := .CookieParams}}
-    {{if not .Required}} if params.{{.GoName}} != nil { {{end}}
-    var cookieParam{{$paramIdx}} string
-    {{if .IsPassThrough}}
-    cookieParam{{$paramIdx}} = {{if not .Required}}*{{end}}params.{{.GoName}}
-    {{end}}
-    {{if .IsJson}}
-    var cookieParamBuf{{$paramIdx}} []byte
-    cookieParamBuf{{$paramIdx}}, err = json.Marshal({{if not .Required}}*{{end}}params.{{.GoName}})
-    if err != nil {
-        return nil, err
+{{ if .CookieParams }}
+    if params != nil {
+    {{range $paramIdx, $param := .CookieParams}}
+        {{if not .Required}} if params.{{.GoName}} != nil { {{end}}
+        var cookieParam{{$paramIdx}} string
+        {{if .IsPassThrough}}
+        cookieParam{{$paramIdx}} = {{if not .Required}}*{{end}}params.{{.GoName}}
+        {{end}}
+        {{if .IsJson}}
+        var cookieParamBuf{{$paramIdx}} []byte
+        cookieParamBuf{{$paramIdx}}, err = json.Marshal({{if not .Required}}*{{end}}params.{{.GoName}})
+        if err != nil {
+            return nil, err
+        }
+        cookieParam{{$paramIdx}} = url.QueryEscape(string(cookieParamBuf{{$paramIdx}}))
+        {{end}}
+        {{if .IsStyled}}
+        cookieParam{{$paramIdx}}, err = runtime.StyleParamWithLocation("simple", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationCookie, {{if not .Required}}*{{end}}params.{{.GoName}})
+        if err != nil {
+            return nil, err
+        }
+        {{end}}
+        cookie{{$paramIdx}} := &http.Cookie{
+            Name:"{{.ParamName}}",
+            Value:cookieParam{{$paramIdx}},
+        }
+        req.AddCookie(cookie{{$paramIdx}})
+        {{if not .Required}}}{{end}}
+    {{ end -}}
     }
-    cookieParam{{$paramIdx}} = url.QueryEscape(string(cookieParamBuf{{$paramIdx}}))
-    {{end}}
-    {{if .IsStyled}}
-    cookieParam{{$paramIdx}}, err = runtime.StyleParamWithLocation("simple", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationCookie, {{if not .Required}}*{{end}}params.{{.GoName}})
-    if err != nil {
-        return nil, err
-    }
-    {{end}}
-    cookie{{$paramIdx}} := &http.Cookie{
-        Name:"{{.ParamName}}",
-        Value:cookieParam{{$paramIdx}},
-    }
-    req.AddCookie(cookie{{$paramIdx}})
-    {{if not .Required}}}{{end}}
-{{end}}
+{{- end }}{{/* if .CookieParams */}}
     return req, nil
 }
 


### PR DESCRIPTION
As with #1062, we found in #1094 that we've got a few other cases where a `params = nil` can break a generated client.

This adds a safety check to only generate the code if params is present.

Closes #1094.