### PR TITLE
Rename Json to JSON in testutil functions

### DIFF
--- a/examples/authenticated-api/echo/server/server_test.go
+++ b/examples/authenticated-api/echo/server/server_test.go
@@ -40,15 +40,15 @@ func TestAPI(t *testing.T) {
 	// Using the writer JWT should allow us to insert a thing.
 	response = testutil.NewRequest().Post("/things").
 		WithJWSAuth(string(writerJWT)).
-		WithAcceptJson().
-		WithJsonBody(api.Thing{Name: "Thing 1"}).Go(t, e)
+		WithAcceptJSON().
+		WithJSONBody(api.Thing{Name: "Thing 1"}).Go(t, e)
 	require.Equal(t, http.StatusCreated, response.Code())
 
 	// Using the reader JWT should forbid inserting a thing.
 	response = testutil.NewRequest().Post("/things").
 		WithJWSAuth(string(readerJWT)).
-		WithAcceptJson().
-		WithJsonBody(api.Thing{Name: "Thing 2"}).Go(t, e)
+		WithAcceptJSON().
+		WithJSONBody(api.Thing{Name: "Thing 2"}).Go(t, e)
 	require.Equal(t, http.StatusForbidden, response.Code())
 
 	// Both JWT's should allow reading the list of things.
@@ -56,7 +56,7 @@ func TestAPI(t *testing.T) {
 	for _, jwt := range jwts {
 		response := testutil.NewRequest().Get("/things").
 			WithJWSAuth(jwt).
-			WithAcceptJson().Go(t, e)
+			WithAcceptJSON().Go(t, e)
 		assert.Equal(t, http.StatusOK, response.Code())
 	}
 }

--- a/examples/petstore-expanded/chi/petstore_test.go
+++ b/examples/petstore-expanded/chi/petstore_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func doGet(t *testing.T, mux *chi.Mux, url string) *httptest.ResponseRecorder {
-	response := testutil.NewRequest().Get(url).WithAcceptJson().GoWithHTTPHandler(t, mux)
+	response := testutil.NewRequest().Get(url).WithAcceptJSON().GoWithHTTPHandler(t, mux)
 	return response.Recorder
 }
 
@@ -48,7 +48,7 @@ func TestPetStore(t *testing.T) {
 			Tag:  &tag,
 		}
 
-		rr := testutil.NewRequest().Post("/pets").WithJsonBody(newPet).GoWithHTTPHandler(t, r).Recorder
+		rr := testutil.NewRequest().Post("/pets").WithJSONBody(newPet).GoWithHTTPHandler(t, r).Recorder
 		assert.Equal(t, http.StatusCreated, rr.Code)
 
 		var resultPet api.Pet

--- a/examples/petstore-expanded/echo/petstore_test.go
+++ b/examples/petstore-expanded/echo/petstore_test.go
@@ -64,7 +64,7 @@ func TestPetStore(t *testing.T) {
 		Name: "Spot",
 		Tag:  &tag,
 	}
-	result := testutil.NewRequest().Post("/pets").WithJsonBody(newPet).Go(t, e)
+	result := testutil.NewRequest().Post("/pets").WithJSONBody(newPet).Go(t, e)
 	// We expect 201 code on successful pet insertion
 	assert.Equal(t, http.StatusCreated, result.Code())
 
@@ -80,14 +80,14 @@ func TestPetStore(t *testing.T) {
 	petId := resultPet.Id
 
 	// Test the getter function.
-	result = testutil.NewRequest().Get(fmt.Sprintf("/pets/%d", petId)).WithAcceptJson().Go(t, e)
+	result = testutil.NewRequest().Get(fmt.Sprintf("/pets/%d", petId)).WithAcceptJSON().Go(t, e)
 	var resultPet2 models.Pet
 	err = result.UnmarshalBodyToObject(&resultPet2)
 	assert.NoError(t, err, "error getting pet")
 	assert.Equal(t, resultPet, resultPet2)
 
 	// We should get a 404 on invalid ID
-	result = testutil.NewRequest().Get("/pets/27179095781").WithAcceptJson().Go(t, e)
+	result = testutil.NewRequest().Get("/pets/27179095781").WithAcceptJSON().Go(t, e)
 	assert.Equal(t, http.StatusNotFound, result.Code())
 	var petError models.Error
 	err = result.UnmarshalBodyToObject(&petError)
@@ -100,7 +100,7 @@ func TestPetStore(t *testing.T) {
 		Name: "Fido",
 		Tag:  &tag,
 	}
-	result = testutil.NewRequest().Post("/pets").WithJsonBody(newPet).Go(t, e)
+	result = testutil.NewRequest().Post("/pets").WithJSONBody(newPet).Go(t, e)
 	// We expect 201 code on successful pet insertion
 	assert.Equal(t, http.StatusCreated, result.Code())
 	// We should have gotten a response from the server with the new pet. Make
@@ -110,7 +110,7 @@ func TestPetStore(t *testing.T) {
 	petId2 := resultPet.Id
 
 	// Now, list all pets, we should have two
-	result = testutil.NewRequest().Get("/pets").WithAcceptJson().Go(t, e)
+	result = testutil.NewRequest().Get("/pets").WithAcceptJSON().Go(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	var petList []models.Pet
 	err = result.UnmarshalBodyToObject(&petList)
@@ -119,7 +119,7 @@ func TestPetStore(t *testing.T) {
 
 	// Filter pets by tag, we should have 1
 	petList = nil
-	result = testutil.NewRequest().Get("/pets?tags=TagOfFido").WithAcceptJson().Go(t, e)
+	result = testutil.NewRequest().Get("/pets?tags=TagOfFido").WithAcceptJSON().Go(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	err = result.UnmarshalBodyToObject(&petList)
 	assert.NoError(t, err, "error getting response", err)
@@ -127,7 +127,7 @@ func TestPetStore(t *testing.T) {
 
 	// Filter pets by non existent tag, we should have 0
 	petList = nil
-	result = testutil.NewRequest().Get("/pets?tags=NotExists").WithAcceptJson().Go(t, e)
+	result = testutil.NewRequest().Get("/pets?tags=NotExists").WithAcceptJSON().Go(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	err = result.UnmarshalBodyToObject(&petList)
 	assert.NoError(t, err, "error getting response", err)
@@ -148,7 +148,7 @@ func TestPetStore(t *testing.T) {
 
 	// Should have no pets left.
 	petList = nil
-	result = testutil.NewRequest().Get("/pets").WithAcceptJson().Go(t, e)
+	result = testutil.NewRequest().Get("/pets").WithAcceptJSON().Go(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	err = result.UnmarshalBodyToObject(&petList)
 	assert.NoError(t, err, "error getting response", err)

--- a/examples/petstore-expanded/gin/petstore_test.go
+++ b/examples/petstore-expanded/gin/petstore_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func doGet(t *testing.T, handler http.Handler, url string) *httptest.ResponseRecorder {
-	response := testutil.NewRequest().Get(url).WithAcceptJson().GoWithHTTPHandler(t, handler)
+	response := testutil.NewRequest().Get(url).WithAcceptJSON().GoWithHTTPHandler(t, handler)
 	return response.Recorder
 }
 
@@ -30,7 +30,7 @@ func TestPetStore(t *testing.T) {
 			Tag:  &tag,
 		}
 
-		rr := testutil.NewRequest().Post("/pets").WithJsonBody(newPet).GoWithHTTPHandler(t, r).Recorder
+		rr := testutil.NewRequest().Post("/pets").WithJSONBody(newPet).GoWithHTTPHandler(t, r).Recorder
 		assert.Equal(t, http.StatusCreated, rr.Code)
 
 		var resultPet api.Pet

--- a/examples/petstore-expanded/gorilla/petstore_test.go
+++ b/examples/petstore-expanded/gorilla/petstore_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func doGet(t *testing.T, mux *mux.Router, url string) *httptest.ResponseRecorder {
-	response := testutil.NewRequest().Get(url).WithAcceptJson().GoWithHTTPHandler(t, mux)
+	response := testutil.NewRequest().Get(url).WithAcceptJSON().GoWithHTTPHandler(t, mux)
 	return response.Recorder
 }
 
@@ -48,7 +48,7 @@ func TestPetStore(t *testing.T) {
 			Tag:  &tag,
 		}
 
-		rr := testutil.NewRequest().Post("/pets").WithJsonBody(newPet).GoWithHTTPHandler(t, r).Recorder
+		rr := testutil.NewRequest().Post("/pets").WithJSONBody(newPet).GoWithHTTPHandler(t, r).Recorder
 		assert.Equal(t, http.StatusCreated, rr.Code)
 
 		var resultPet api.Pet

--- a/examples/petstore-expanded/strict/petstore_test.go
+++ b/examples/petstore-expanded/strict/petstore_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func doGet(t *testing.T, mux *chi.Mux, url string) *httptest.ResponseRecorder {
-	response := testutil.NewRequest().Get(url).WithAcceptJson().GoWithHTTPHandler(t, mux)
+	response := testutil.NewRequest().Get(url).WithAcceptJSON().GoWithHTTPHandler(t, mux)
 	return response.Recorder
 }
 
@@ -48,7 +48,7 @@ func TestPetStore(t *testing.T) {
 			Tag:  &tag,
 		}
 
-		rr := testutil.NewRequest().Post("/pets").WithJsonBody(newPet).GoWithHTTPHandler(t, r).Recorder
+		rr := testutil.NewRequest().Post("/pets").WithJSONBody(newPet).GoWithHTTPHandler(t, r).Recorder
 		assert.Equal(t, http.StatusOK, rr.Code)
 
 		var resultPet api.Pet

--- a/internal/test/components/components_test.go
+++ b/internal/test/components/components_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func assertJsonEqual(t *testing.T, j1 []byte, j2 []byte) {
+func assertJSONEqual(t *testing.T, j1 []byte, j2 []byte) {
 	t.Helper()
 	assert.JSONEq(t, string(j1), string(j2))
 }
@@ -23,7 +23,7 @@ func TestRawJSON(t *testing.T) {
 	buf2, err := json.Marshal(dst)
 	assert.NoError(t, err)
 
-	assertJsonEqual(t, []byte(buf), buf2)
+	assertJSONEqual(t, []byte(buf), buf2)
 
 }
 
@@ -107,19 +107,19 @@ func TestOneOf(t *testing.T) {
 	assert.NoError(t, err)
 	marshaled, err := json.Marshal(dst)
 	assert.NoError(t, err)
-	assertJsonEqual(t, []byte(variant1), marshaled)
+	assertJSONEqual(t, []byte(variant1), marshaled)
 
 	err = dst.FromOneOfVariant2([]int{1, 2, 3})
 	assert.NoError(t, err)
 	marshaled, err = json.Marshal(dst)
 	assert.NoError(t, err)
-	assertJsonEqual(t, []byte(variant2), marshaled)
+	assertJSONEqual(t, []byte(variant2), marshaled)
 
 	err = dst.FromOneOfVariant3(true)
 	assert.NoError(t, err)
 	marshaled, err = json.Marshal(dst)
 	assert.NoError(t, err)
-	assertJsonEqual(t, []byte(variant3), marshaled)
+	assertJSONEqual(t, []byte(variant3), marshaled)
 }
 
 func TestOneOfWithDiscriminator(t *testing.T) {
@@ -150,13 +150,13 @@ func TestOneOfWithDiscriminator(t *testing.T) {
 	assert.NoError(t, err)
 	marshaled, err := json.Marshal(dst)
 	assert.NoError(t, err)
-	assertJsonEqual(t, []byte(variant4), marshaled)
+	assertJSONEqual(t, []byte(variant4), marshaled)
 
 	err = dst.FromOneOfVariant5(OneOfVariant5{Id: 123})
 	assert.NoError(t, err)
 	marshaled, err = json.Marshal(dst)
 	assert.NoError(t, err)
-	assertJsonEqual(t, []byte(variant5), marshaled)
+	assertJSONEqual(t, []byte(variant5), marshaled)
 }
 
 func TestOneOfWithDiscriminator_PartialMapping(t *testing.T) {
@@ -187,13 +187,13 @@ func TestOneOfWithDiscriminator_PartialMapping(t *testing.T) {
 	require.NoError(t, err)
 	marshaled, err := json.Marshal(dst)
 	require.NoError(t, err)
-	assertJsonEqual(t, []byte(variant4), marshaled)
+	assertJSONEqual(t, []byte(variant4), marshaled)
 
 	err = dst.FromOneOfVariant5(OneOfVariant5{Id: 321})
 	require.NoError(t, err)
 	marshaled, err = json.Marshal(dst)
 	require.NoError(t, err)
-	assertJsonEqual(t, []byte(variant5), marshaled)
+	assertJSONEqual(t, []byte(variant5), marshaled)
 }
 
 func TestOneOfWithDiscriminator_SchemaNameUsed(t *testing.T) {
@@ -224,13 +224,13 @@ func TestOneOfWithDiscriminator_SchemaNameUsed(t *testing.T) {
 	require.NoError(t, err)
 	marshaled, err := json.Marshal(dst)
 	require.NoError(t, err)
-	assertJsonEqual(t, []byte(variant4), marshaled)
+	assertJSONEqual(t, []byte(variant4), marshaled)
 
 	err = dst.FromOneOfVariant51(OneOfVariant51{Id: 987})
 	require.NoError(t, err)
 	marshaled, err = json.Marshal(dst)
 	require.NoError(t, err)
-	assertJsonEqual(t, []byte(variant51), marshaled)
+	assertJSONEqual(t, []byte(variant51), marshaled)
 }
 
 func TestOneOfWithDiscriminator_FullImplicitMapping(t *testing.T) {
@@ -261,13 +261,13 @@ func TestOneOfWithDiscriminator_FullImplicitMapping(t *testing.T) {
 	require.NoError(t, err)
 	marshaled, err := json.Marshal(dst)
 	require.NoError(t, err)
-	assertJsonEqual(t, []byte(variant4), marshaled)
+	assertJSONEqual(t, []byte(variant4), marshaled)
 
 	err = dst.FromOneOfVariant5(OneOfVariant5{Id: 654})
 	require.NoError(t, err)
 	marshaled, err = json.Marshal(dst)
 	require.NoError(t, err)
-	assertJsonEqual(t, []byte(variant5), marshaled)
+	assertJSONEqual(t, []byte(variant5), marshaled)
 }
 
 func TestOneOfWithFixedProperties(t *testing.T) {
@@ -297,13 +297,13 @@ func TestOneOfWithFixedProperties(t *testing.T) {
 	assert.NoError(t, err)
 	marshaled, err := json.Marshal(dst)
 	assert.NoError(t, err)
-	assertJsonEqual(t, []byte(variant1), marshaled)
+	assertJSONEqual(t, []byte(variant1), marshaled)
 
 	err = dst.FromOneOfVariant6(OneOfVariant6{[]int{1, 2, 3}})
 	assert.NoError(t, err)
 	marshaled, err = json.Marshal(dst)
 	assert.NoError(t, err)
-	assertJsonEqual(t, []byte(variant6), marshaled)
+	assertJSONEqual(t, []byte(variant6), marshaled)
 }
 
 func TestAnyOf(t *testing.T) {

--- a/internal/test/strict-server/strict_test.go
+++ b/internal/test/strict-server/strict_test.go
@@ -64,7 +64,7 @@ func testImpl(t *testing.T, handler http.Handler) {
 	t.Run("JSONExample", func(t *testing.T) {
 		value := "123"
 		requestBody := clientAPI.Example{Value: &value}
-		rr := testutil.NewRequest().Post("/json").WithJsonBody(requestBody).GoWithHTTPHandler(t, handler).Recorder
+		rr := testutil.NewRequest().Post("/json").WithJSONBody(requestBody).GoWithHTTPHandler(t, handler).Recorder
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.True(t, strings.HasPrefix(rr.Header().Get("Content-Type"), "application/json"))
 		var responseBody clientAPI.Example
@@ -128,7 +128,7 @@ func testImpl(t *testing.T, handler http.Handler) {
 	t.Run("MultipleRequestAndResponseTypesJSON", func(t *testing.T) {
 		value := "123"
 		requestBody := clientAPI.Example{Value: &value}
-		rr := testutil.NewRequest().Post("/multiple").WithJsonBody(requestBody).GoWithHTTPHandler(t, handler).Recorder
+		rr := testutil.NewRequest().Post("/multiple").WithJSONBody(requestBody).GoWithHTTPHandler(t, handler).Recorder
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.True(t, strings.HasPrefix(rr.Header().Get("Content-Type"), "application/json"))
 		var responseBody clientAPI.Example
@@ -194,7 +194,7 @@ func testImpl(t *testing.T, handler http.Handler) {
 		header2 := "890"
 		value := "asdf"
 		requestBody := clientAPI.Example{Value: &value}
-		rr := testutil.NewRequest().Post("/with-headers").WithHeader("header1", header1).WithHeader("header2", header2).WithJsonBody(requestBody).GoWithHTTPHandler(t, handler).Recorder
+		rr := testutil.NewRequest().Post("/with-headers").WithHeader("header1", header1).WithHeader("header2", header2).WithJSONBody(requestBody).GoWithHTTPHandler(t, handler).Recorder
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.True(t, strings.HasPrefix(rr.Header().Get("Content-Type"), "application/json"))
 		var responseBody clientAPI.Example
@@ -215,7 +215,7 @@ func testImpl(t *testing.T, handler http.Handler) {
 	t.Run("ReusableResponses", func(t *testing.T) {
 		value := "jkl;"
 		requestBody := clientAPI.Example{Value: &value}
-		rr := testutil.NewRequest().Post("/reusable-responses").WithJsonBody(requestBody).GoWithHTTPHandler(t, handler).Recorder
+		rr := testutil.NewRequest().Post("/reusable-responses").WithJSONBody(requestBody).GoWithHTTPHandler(t, handler).Recorder
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.True(t, strings.HasPrefix(rr.Header().Get("Content-Type"), "application/json"))
 		var responseBody clientAPI.Example
@@ -226,7 +226,7 @@ func testImpl(t *testing.T, handler http.Handler) {
 	t.Run("UnionResponses", func(t *testing.T) {
 		value := "union"
 		requestBody := clientAPI.Example{Value: &value}
-		rr := testutil.NewRequest().Post("/with-union").WithJsonBody(requestBody).GoWithHTTPHandler(t, handler).Recorder
+		rr := testutil.NewRequest().Post("/with-union").WithJSONBody(requestBody).GoWithHTTPHandler(t, handler).Recorder
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.True(t, strings.HasPrefix(rr.Header().Get("Content-Type"), "application/json"))
 		var responseBody clientAPI.Example

--- a/pkg/chi-middleware/oapi_validate_test.go
+++ b/pkg/chi-middleware/oapi_validate_test.go
@@ -27,7 +27,7 @@ func doGet(t *testing.T, mux *chi.Mux, rawURL string) *httptest.ResponseRecorder
 		t.Fatalf("Invalid url: %s", rawURL)
 	}
 
-	response := testutil.NewRequest().Get(u.RequestURI()).WithHost(u.Host).WithAcceptJson().GoWithHTTPHandler(t, mux)
+	response := testutil.NewRequest().Get(u.RequestURI()).WithHost(u.Host).WithAcceptJSON().GoWithHTTPHandler(t, mux)
 	return response.Recorder
 }
 
@@ -37,7 +37,7 @@ func doPost(t *testing.T, mux *chi.Mux, rawURL string, jsonBody interface{}) *ht
 		t.Fatalf("Invalid url: %s", rawURL)
 	}
 
-	response := testutil.NewRequest().Post(u.RequestURI()).WithHost(u.Host).WithJsonBody(jsonBody).GoWithHTTPHandler(t, mux)
+	response := testutil.NewRequest().Post(u.RequestURI()).WithHost(u.Host).WithJSONBody(jsonBody).GoWithHTTPHandler(t, mux)
 	return response.Recorder
 }
 

--- a/pkg/gin-middleware/oapi_validate_test.go
+++ b/pkg/gin-middleware/oapi_validate_test.go
@@ -42,7 +42,7 @@ func doGet(t *testing.T, handler http.Handler, rawURL string) *httptest.Response
 		t.Fatalf("Invalid url: %s", rawURL)
 	}
 
-	response := testutil.NewRequest().Get(u.RequestURI()).WithHost(u.Host).WithAcceptJson().GoWithHTTPHandler(t, handler)
+	response := testutil.NewRequest().Get(u.RequestURI()).WithHost(u.Host).WithAcceptJSON().GoWithHTTPHandler(t, handler)
 	return response.Recorder
 }
 
@@ -52,7 +52,7 @@ func doPost(t *testing.T, handler http.Handler, rawURL string, jsonBody interfac
 		t.Fatalf("Invalid url: %s", rawURL)
 	}
 
-	response := testutil.NewRequest().Post(u.RequestURI()).WithHost(u.Host).WithJsonBody(jsonBody).GoWithHTTPHandler(t, handler)
+	response := testutil.NewRequest().Post(u.RequestURI()).WithHost(u.Host).WithJSONBody(jsonBody).GoWithHTTPHandler(t, handler)
 	return response.Recorder
 }
 

--- a/pkg/middleware/oapi_validate_test.go
+++ b/pkg/middleware/oapi_validate_test.go
@@ -42,7 +42,7 @@ func doGet(t *testing.T, e *echo.Echo, rawURL string) *httptest.ResponseRecorder
 		t.Fatalf("Invalid url: %s", rawURL)
 	}
 
-	response := testutil.NewRequest().Get(u.RequestURI()).WithHost(u.Host).WithAcceptJson().GoWithHTTPHandler(t, e)
+	response := testutil.NewRequest().Get(u.RequestURI()).WithHost(u.Host).WithAcceptJSON().GoWithHTTPHandler(t, e)
 	return response.Recorder
 }
 
@@ -52,7 +52,7 @@ func doPost(t *testing.T, e *echo.Echo, rawURL string, jsonBody interface{}) *ht
 		t.Fatalf("Invalid url: %s", rawURL)
 	}
 
-	response := testutil.NewRequest().Post(u.RequestURI()).WithHost(u.Host).WithJsonBody(jsonBody).GoWithHTTPHandler(t, e)
+	response := testutil.NewRequest().Post(u.RequestURI()).WithHost(u.Host).WithJSONBody(jsonBody).GoWithHTTPHandler(t, e)
 	return response.Recorder
 }
 

--- a/pkg/testutil/request_helpers.go
+++ b/pkg/testutil/request_helpers.go
@@ -21,7 +21,7 @@ package testutil
 //   var response ResponseBody
 //   t is *testing.T, from a unit test
 //   e is *echo.Echo
-//   response := NewRequest().Post("/path").WithJsonBody(body).Go(t, e)
+//   response := NewRequest().Post("/path").WithJSONBody(body).Go(t, e)
 //   err := response.UnmarshalBodyToObject(&response)
 import (
 	"bytes"
@@ -98,7 +98,7 @@ func (r *RequestBuilder) WithContentType(value string) *RequestBuilder {
 	return r.WithHeader("Content-Type", value)
 }
 
-func (r *RequestBuilder) WithJsonContentType() *RequestBuilder {
+func (r *RequestBuilder) WithJSONContentType() *RequestBuilder {
 	return r.WithContentType("application/json")
 }
 
@@ -106,7 +106,7 @@ func (r *RequestBuilder) WithAccept(value string) *RequestBuilder {
 	return r.WithHeader("Accept", value)
 }
 
-func (r *RequestBuilder) WithAcceptJson() *RequestBuilder {
+func (r *RequestBuilder) WithAcceptJSON() *RequestBuilder {
 	return r.WithAccept("application/json")
 }
 
@@ -117,15 +117,15 @@ func (r *RequestBuilder) WithBody(body []byte) *RequestBuilder {
 	return r
 }
 
-// WithJsonBody takes an object as input, marshals it to JSON, and sends it
+// WithJSONBody takes an object as input, marshals it to JSON, and sends it
 // as the body with Content-Type: application/json
-func (r *RequestBuilder) WithJsonBody(obj interface{}) *RequestBuilder {
+func (r *RequestBuilder) WithJSONBody(obj interface{}) *RequestBuilder {
 	var err error
 	r.Body, err = json.Marshal(obj)
 	if err != nil {
 		r.Error = fmt.Errorf("failed to marshal json object: %s", err)
 	}
-	return r.WithJsonContentType()
+	return r.WithJSONContentType()
 }
 
 // WithCookie sets a cookie
@@ -206,9 +206,9 @@ func (c *CompletedRequest) UnmarshalBodyToObject(obj interface{}) error {
 	return handler(ctype, c.Recorder.Body, obj, c.Strict)
 }
 
-// UnmarshalJsonToObject assumes that the response contains JSON and unmarshals it
+// UnmarshalJSONToObject assumes that the response contains JSON and unmarshals it
 // into the specified object.
-func (c *CompletedRequest) UnmarshalJsonToObject(obj interface{}) error {
+func (c *CompletedRequest) UnmarshalJSONToObject(obj interface{}) error {
 	return json.Unmarshal(c.Recorder.Body.Bytes(), obj)
 }
 


### PR DESCRIPTION
This PR renames `testutil` functions used in tests:
- WithAcceptJson -> WithAcceptJSON
- WithJsonBody -> WithJSONBody
- assertJsonEqual -> assertJSONEqual
- UnmarshalJsonToObject -> UnmarshalJSONToObject
- WithJsonContentType -> WithJSONContentType