### PR TITLE
fix(validation): skip email validation when the types.Email is nullab…

### DIFF
--- a/pkg/types/email.go
+++ b/pkg/types/email.go
@@ -5,12 +5,19 @@ import (
 	"errors"
 )
 
+// ErrValidationEmail is the sentinel error returned when an email fails validation
+var ErrValidationEmail = errors.New("email: failed to pass regex validation")
+
+// Email represents an email address.
+// It is a string type that must pass regex validation before being marshalled
+// to JSON or unmarshalled from JSON.
 type Email string
 
 func (e Email) MarshalJSON() ([]byte, error) {
 	if !emailRegex.MatchString(string(e)) {
-		return nil, errors.New("email: failed to pass regex validation")
+		return nil, ErrValidationEmail
 	}
+
 	return json.Marshal(string(e))
 }
 
@@ -19,9 +26,11 @@ func (e *Email) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}
-	if !emailRegex.MatchString(s) {
-		return errors.New("email: failed to pass regex validation")
-	}
+
 	*e = Email(s)
+	if e != nil && !emailRegex.MatchString(s) {
+		return ErrValidationEmail
+	}
+
 	return nil
 }

--- a/pkg/types/email_test.go
+++ b/pkg/types/email_test.go
@@ -7,25 +7,170 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEmail_MarshalJSON(t *testing.T) {
-	testEmail := "gaben@valvesoftware.com"
-	b := struct {
+func TestEmail_MarshalJSON_Validation(t *testing.T) {
+	type requiredEmail struct {
 		EmailField Email `json:"email"`
-	}{
-		EmailField: Email(testEmail),
 	}
-	jsonBytes, err := json.Marshal(b)
-	assert.NoError(t, err)
-	assert.JSONEq(t, `{"email":"gaben@valvesoftware.com"}`, string(jsonBytes))
+
+	testCases := map[string]struct {
+		email         Email
+		expectedJSON  []byte
+		expectedError error
+	}{
+		"it should succeed marshalling a valid email and return valid JSON populated with the email": {
+			email:         Email("validemail@openapicodegen.com"),
+			expectedJSON:  []byte(`{"email":"validemail@openapicodegen.com"}`),
+			expectedError: nil,
+		},
+		"it should fail marshalling an invalid email and return a validation error": {
+			email:         Email("invalidemail"),
+			expectedJSON:  nil,
+			expectedError: ErrValidationEmail,
+		},
+		"it should fail marshalling an empty email and return a validation error": {
+			email:         Email(""),
+			expectedJSON:  nil,
+			expectedError: ErrValidationEmail,
+		},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			jsonBytes, err := json.Marshal(requiredEmail{EmailField: tc.email})
+
+			if tc.expectedError != nil {
+				assert.ErrorIs(t, err, tc.expectedError)
+			} else {
+				assert.JSONEq(t, string(tc.expectedJSON), string(jsonBytes))
+			}
+		})
+	}
 }
 
-func TestEmail_UnmarshalJSON(t *testing.T) {
-	testEmail := Email("gaben@valvesoftware.com")
-	jsonStr := `{"email":"gaben@valvesoftware.com"}`
-	b := struct {
+func TestEmail_UnmarshalJSON_RequiredEmail_Validation(t *testing.T) {
+	type requiredEmail struct {
 		EmailField Email `json:"email"`
-	}{}
-	err := json.Unmarshal([]byte(jsonStr), &b)
-	assert.NoError(t, err)
-	assert.Equal(t, testEmail, b.EmailField)
+	}
+
+	requiredEmailTestCases := map[string]struct {
+		jsonStr       string
+		expectedEmail Email
+		expectedError error
+	}{
+		"it should succeed validating a valid email during the unmarshal process": {
+			jsonStr:       `{"email":"gaben@valvesoftware.com"}`,
+			expectedError: nil,
+			expectedEmail: func() Email {
+				e := Email("gaben@valvesoftware.com")
+				return e
+			}(),
+		},
+		"it should fail validating an invalid email": {
+			jsonStr:       `{"email":"not-an-email"}`,
+			expectedError: ErrValidationEmail,
+			expectedEmail: func() Email {
+				e := Email("not-an-email")
+				return e
+			}(),
+		},
+		"it should fail validating an empty email": {
+			jsonStr: `{"email":""}`,
+			expectedEmail: func() Email {
+				e := Email("")
+				return e
+			}(),
+			expectedError: ErrValidationEmail,
+		},
+		"it should fail validating a null email": {
+			jsonStr: `{"email":null}`,
+			expectedEmail: func() Email {
+				e := Email("")
+				return e
+			}(),
+			expectedError: ErrValidationEmail,
+		},
+	}
+
+	for name, tc := range requiredEmailTestCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			b := requiredEmail{}
+			err := json.Unmarshal([]byte(tc.jsonStr), &b)
+			assert.Equal(t, tc.expectedEmail, b.EmailField)
+			assert.ErrorIs(t, err, tc.expectedError)
+		})
+	}
+
+}
+
+func TestEmail_UnmarshalJSON_NullableEmail_Validation(t *testing.T) {
+
+	type nullableEmail struct {
+		EmailField *Email `json:"email,omitempty"`
+	}
+
+	nullableEmailTestCases := map[string]struct {
+		body          nullableEmail
+		jsonStr       string
+		expectedEmail *Email
+		expectedError error
+	}{
+		"it should succeed validating a valid email during the unmarshal process": {
+			body:          nullableEmail{},
+			jsonStr:       `{"email":"gaben@valvesoftware.com"}`,
+			expectedError: nil,
+			expectedEmail: func() *Email {
+				e := Email("gaben@valvesoftware.com")
+				return &e
+			}(),
+		},
+		"it should fail validating an invalid email": {
+			body:          nullableEmail{},
+			jsonStr:       `{"email":"not-an-email"}`,
+			expectedError: ErrValidationEmail,
+			expectedEmail: func() *Email {
+				e := Email("not-an-email")
+				return &e
+			}(),
+		},
+		"it should fail validating an empty email": {
+			body:          nullableEmail{},
+			jsonStr:       `{"email":""}`,
+			expectedError: ErrValidationEmail,
+			expectedEmail: func() *Email {
+				e := Email("")
+				return &e
+			}(),
+		},
+		"it should succeed validating a null email": {
+			body:          nullableEmail{},
+			jsonStr:       `{"email":null}`,
+			expectedEmail: nil,
+			expectedError: nil,
+		},
+		"it should succeed validating a missing email": {
+			body:          nullableEmail{},
+			jsonStr:       `{}`,
+			expectedEmail: nil,
+			expectedError: nil,
+		},
+	}
+
+	for name, tc := range nullableEmailTestCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := json.Unmarshal([]byte(tc.jsonStr), &tc.body)
+			assert.Equal(t, tc.expectedEmail, tc.body.EmailField)
+			if tc.expectedError != nil {
+				assert.ErrorIs(t, err, tc.expectedError)
+			}
+		})
+	}
 }


### PR DESCRIPTION
# WHAT:

- skip email validation when unmarshaling a `*types.Email` with a nil value
- add more tests & a sentinel error

# WHY:

Currently validation is performed when unmarshaling empty emails even when it shouldn't (using a pointer type is akin to a nullable JSON field and therefore shouldn't be validated). This results in being unable to retrieve data using the generated client if the target API returns a null email in the payload even when this one isn't required.

# HOW:

- skip email validation when unmarshaling a `*types.Email` with a nil value