### PR TITLE
support staticcheck st1005

### DIFF
--- a/examples/petstore-expanded/strict/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/strict/api/petstore-server.gen.go
@@ -459,7 +459,7 @@ func (sh *strictHandler) FindPets(w http.ResponseWriter, r *http.Request, params
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -490,7 +490,7 @@ func (sh *strictHandler) AddPet(w http.ResponseWriter, r *http.Request) {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -516,7 +516,7 @@ func (sh *strictHandler) DeletePet(w http.ResponseWriter, r *http.Request, id in
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -542,7 +542,7 @@ func (sh *strictHandler) FindPetByID(w http.ResponseWriter, r *http.Request, id 
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 

--- a/internal/test/issues/issue-removed-external-ref/gen/spec_base/issue.gen.go
+++ b/internal/test/issues/issue-removed-external-ref/gen/spec_base/issue.gen.go
@@ -294,7 +294,7 @@ func (sh *strictHandler) PostInvalidExtRefTrouble(w http.ResponseWriter, r *http
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -318,6 +318,6 @@ func (sh *strictHandler) PostNoTrouble(w http.ResponseWriter, r *http.Request) {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }

--- a/internal/test/strict-server/chi/server.gen.go
+++ b/internal/test/strict-server/chi/server.gen.go
@@ -1017,7 +1017,7 @@ func (sh *strictHandler) JSONExample(w http.ResponseWriter, r *http.Request) {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1048,7 +1048,7 @@ func (sh *strictHandler) MultipartExample(w http.ResponseWriter, r *http.Request
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1113,7 +1113,7 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(w http.ResponseWriter, 
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1139,7 +1139,7 @@ func (sh *strictHandler) ReservedGoKeywordParameters(w http.ResponseWriter, r *h
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1170,7 +1170,7 @@ func (sh *strictHandler) ReusableResponses(w http.ResponseWriter, r *http.Reques
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1202,7 +1202,7 @@ func (sh *strictHandler) TextExample(w http.ResponseWriter, r *http.Request) {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1228,7 +1228,7 @@ func (sh *strictHandler) UnknownExample(w http.ResponseWriter, r *http.Request) 
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1256,7 +1256,7 @@ func (sh *strictHandler) UnspecifiedContentType(w http.ResponseWriter, r *http.R
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1291,7 +1291,7 @@ func (sh *strictHandler) URLEncodedExample(w http.ResponseWriter, r *http.Reques
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1324,7 +1324,7 @@ func (sh *strictHandler) HeadersExample(w http.ResponseWriter, r *http.Request, 
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1355,7 +1355,7 @@ func (sh *strictHandler) UnionExample(w http.ResponseWriter, r *http.Request) {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 

--- a/internal/test/strict-server/echo/server.gen.go
+++ b/internal/test/strict-server/echo/server.gen.go
@@ -803,7 +803,7 @@ func (sh *strictHandler) JSONExample(ctx echo.Context) error {
 	} else if validResponse, ok := response.(JSONExampleResponseObject); ok {
 		return validResponse.VisitJSONExampleResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -832,7 +832,7 @@ func (sh *strictHandler) MultipartExample(ctx echo.Context) error {
 	} else if validResponse, ok := response.(MultipartExampleResponseObject); ok {
 		return validResponse.VisitMultipartExampleResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -892,7 +892,7 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx echo.Context) error
 	} else if validResponse, ok := response.(MultipleRequestAndResponseTypesResponseObject); ok {
 		return validResponse.VisitMultipleRequestAndResponseTypesResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -917,7 +917,7 @@ func (sh *strictHandler) ReservedGoKeywordParameters(ctx echo.Context, pType str
 	} else if validResponse, ok := response.(ReservedGoKeywordParametersResponseObject); ok {
 		return validResponse.VisitReservedGoKeywordParametersResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -946,7 +946,7 @@ func (sh *strictHandler) ReusableResponses(ctx echo.Context) error {
 	} else if validResponse, ok := response.(ReusableResponsesResponseObject); ok {
 		return validResponse.VisitReusableResponsesResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -976,7 +976,7 @@ func (sh *strictHandler) TextExample(ctx echo.Context) error {
 	} else if validResponse, ok := response.(TextExampleResponseObject); ok {
 		return validResponse.VisitTextExampleResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1001,7 +1001,7 @@ func (sh *strictHandler) UnknownExample(ctx echo.Context) error {
 	} else if validResponse, ok := response.(UnknownExampleResponseObject); ok {
 		return validResponse.VisitUnknownExampleResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1028,7 +1028,7 @@ func (sh *strictHandler) UnspecifiedContentType(ctx echo.Context) error {
 	} else if validResponse, ok := response.(UnspecifiedContentTypeResponseObject); ok {
 		return validResponse.VisitUnspecifiedContentTypeResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1061,7 +1061,7 @@ func (sh *strictHandler) URLEncodedExample(ctx echo.Context) error {
 	} else if validResponse, ok := response.(URLEncodedExampleResponseObject); ok {
 		return validResponse.VisitURLEncodedExampleResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1092,7 +1092,7 @@ func (sh *strictHandler) HeadersExample(ctx echo.Context, params HeadersExampleP
 	} else if validResponse, ok := response.(HeadersExampleResponseObject); ok {
 		return validResponse.VisitHeadersExampleResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1121,7 +1121,7 @@ func (sh *strictHandler) UnionExample(ctx echo.Context) error {
 	} else if validResponse, ok := response.(UnionExampleResponseObject); ok {
 		return validResponse.VisitUnionExampleResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }

--- a/internal/test/strict-server/fiber/server.gen.go
+++ b/internal/test/strict-server/fiber/server.gen.go
@@ -780,7 +780,7 @@ func (sh *strictHandler) JSONExample(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -807,7 +807,7 @@ func (sh *strictHandler) MultipartExample(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -858,7 +858,7 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -885,7 +885,7 @@ func (sh *strictHandler) ReservedGoKeywordParameters(ctx *fiber.Ctx, pType strin
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -916,7 +916,7 @@ func (sh *strictHandler) ReusableResponses(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -945,7 +945,7 @@ func (sh *strictHandler) TextExample(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -972,7 +972,7 @@ func (sh *strictHandler) UnknownExample(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1001,7 +1001,7 @@ func (sh *strictHandler) UnspecifiedContentType(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1032,7 +1032,7 @@ func (sh *strictHandler) URLEncodedExample(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1065,7 +1065,7 @@ func (sh *strictHandler) HeadersExample(ctx *fiber.Ctx, params HeadersExamplePar
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1096,7 +1096,7 @@ func (sh *strictHandler) UnionExample(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }

--- a/internal/test/strict-server/gin/server.gen.go
+++ b/internal/test/strict-server/gin/server.gen.go
@@ -869,7 +869,7 @@ func (sh *strictHandler) JSONExample(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -901,7 +901,7 @@ func (sh *strictHandler) MultipartExample(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -968,7 +968,7 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -995,7 +995,7 @@ func (sh *strictHandler) ReservedGoKeywordParameters(ctx *gin.Context, pType str
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1028,7 +1028,7 @@ func (sh *strictHandler) ReusableResponses(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1061,7 +1061,7 @@ func (sh *strictHandler) TextExample(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1088,7 +1088,7 @@ func (sh *strictHandler) UnknownExample(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1117,7 +1117,7 @@ func (sh *strictHandler) UnspecifiedContentType(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1153,7 +1153,7 @@ func (sh *strictHandler) URLEncodedExample(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1188,7 +1188,7 @@ func (sh *strictHandler) HeadersExample(ctx *gin.Context, params HeadersExampleP
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1221,7 +1221,7 @@ func (sh *strictHandler) UnionExample(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 

--- a/pkg/codegen/templates/strict/strict-echo.tmpl
+++ b/pkg/codegen/templates/strict/strict-echo.tmpl
@@ -80,7 +80,7 @@ type strictHandler struct {
         } else if validResponse, ok := response.({{$opid | ucFirst}}ResponseObject); ok {
             return validResponse.Visit{{$opid}}Response(ctx.Response())
         } else if response != nil {
-            return fmt.Errorf("Unexpected response type: %T", response)
+            return fmt.Errorf("unexpected response type: %T", response)
         }
         return nil
     }

--- a/pkg/codegen/templates/strict/strict-fiber.tmpl
+++ b/pkg/codegen/templates/strict/strict-fiber.tmpl
@@ -73,7 +73,7 @@ type strictHandler struct {
                 return fiber.NewError(fiber.StatusBadRequest, err.Error())
             }
         } else if response != nil {
-            return fmt.Errorf("Unexpected response type: %T", response)
+            return fmt.Errorf("unexpected response type: %T", response)
         }
         return nil
     }

--- a/pkg/codegen/templates/strict/strict-gin.tmpl
+++ b/pkg/codegen/templates/strict/strict-gin.tmpl
@@ -88,7 +88,7 @@ type strictHandler struct {
                 ctx.Error(err)
             }
         } else if response != nil {
-            ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+            ctx.Error(fmt.Errorf("unexpected response type: %T", response))
         }
     }
 {{end}}

--- a/pkg/codegen/templates/strict/strict-http.tmpl
+++ b/pkg/codegen/templates/strict/strict-http.tmpl
@@ -103,7 +103,7 @@ type strictHandler struct {
                 sh.options.ResponseErrorHandlerFunc(w, r, err)
             }
         } else if response != nil {
-            sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+            sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
         }
     }
 {{end}}


### PR DESCRIPTION
I want to resolve an issue where generated files are becoming noise due to being the target of `error strings should not be capitalized (ST1005)go-staticcheck.`

Changing the template like in this PR would solve the problem, but this approach may not be preferable because it could affect the generated code of users who are already using it.
