### PR TITLE
fix(template): fix strict-interface template 

### DIFF
--- a/pkg/codegen/templates/strict/strict-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-interface.tmpl
@@ -38,7 +38,9 @@
 
         {{range .Contents}}
             {{$receiverTypeName := printf "%s%s%s%s" $opid $statusCode .NameTagOrContentType "Response"}}
-            {{if and $fixedStatusCode $isRef -}}
+            {{if eq .NameTag "Text" -}}
+                type {{$receiverTypeName}} string
+            {{else if and $fixedStatusCode $isRef -}}
                 type {{$receiverTypeName}} struct{ {{$ref}}{{.NameTagOrContentType}}Response }
             {{else if and (not $hasHeaders) ($fixedStatusCode) (.IsSupported) -}}
                 type {{$receiverTypeName}} {{if eq .NameTag "Multipart"}}func(writer *multipart.Writer)error{{else if .IsSupported}}{{if .Schema.IsRef}}={{end}} {{.Schema.TypeDecl}}{{else}}io.Reader{{end}}


### PR DESCRIPTION
fix strict-interface template  to make sure text response content type uses string type.

This is in reference to #1130 . The code change is probably not semantically correct, happy to make appropriate changes