### PR TITLE
fix #1147

### DIFF
--- a/pkg/codegen/templates/strict/strict-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-interface.tmpl
@@ -63,7 +63,7 @@
                 }
             {{end}}
 
-            {{if and $fixedStatusCode $isRef -}}
+            {{if eq .NameTag "JSON" | and $fixedStatusCode $isRef -}}
             func (response {{$receiverTypeName}}) MarshalJSON() ([]byte, error) {
                 return json.Marshal(response.{{$ref}}{{.NameTagOrContentType}}Response)
             }

--- a/pkg/codegen/templates/strict/strict-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-interface.tmpl
@@ -63,6 +63,12 @@
                 }
             {{end}}
 
+            {{if and $fixedStatusCode $isRef -}}
+            func (response {{$receiverTypeName}}) MarshalJSON() ([]byte, error) {
+                return json.Marshal(response.{{$ref}}{{.NameTagOrContentType}}Response)
+            }
+            {{end}}
+
             func (response {{$receiverTypeName}}) Visit{{$opid}}Response(w http.ResponseWriter) error {
                 {{range $headers -}}
                     w.Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))


### PR DESCRIPTION
Edit template for strict server. Implement `json.Marshaler` for $ref responses with fixed status code.