### PR TITLE
Support encoding.TextUnmarshaler to bind query params

### DIFF
--- a/pkg/runtime/bindparam.go
+++ b/pkg/runtime/bindparam.go
@@ -522,5 +522,10 @@ func indirect(dest interface{}) (interface{}, reflect.Value, reflect.Type) {
 	if t.ConvertibleTo(reflect.TypeOf(types.Date{})) {
 		return dest, reflect.Value{}, nil
 	}
+
+	// If the destination implements encoding.TextUnmarshaler we use it for binding
+	if _, ok := dest.(encoding.TextUnmarshaler); ok {
+		return dest, reflect.Value{}, nil
+	}
 	return nil, v, t
 }

--- a/pkg/runtime/bindparam_test.go
+++ b/pkg/runtime/bindparam_test.go
@@ -335,6 +335,28 @@ func TestBindQueryParameter(t *testing.T) {
 		assert.Equal(t, expected, birthday)
 	})
 
+	t.Run("form to struct with TextUnmarshaler", func(t *testing.T) {
+		expected := big.NewInt(12345678910)
+		n := &big.Int{}
+		queryParams := url.Values{
+			"number": {"12345678910"},
+		}
+		err := BindQueryParameter("form", true, false, "number", queryParams, &n)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, n)
+	})
+
+	t.Run("form to scalar with TextUnmarshaler", func(t *testing.T) {
+		expected := numberTextUnmarshaler(12345678910)
+		n := new(numberTextUnmarshaler)
+		queryParams := url.Values{
+			"number": {"12345678910"},
+		}
+		err := BindQueryParameter("form", true, false, "number", queryParams, &n)
+		assert.NoError(t, err)
+		assert.Equal(t, &expected, n)
+	})
+
 	t.Run("optional", func(t *testing.T) {
 		queryParams := url.Values{
 			"time":   {"2020-12-09T16:09:53+00:00"},

--- a/pkg/runtime/bindstring.go
+++ b/pkg/runtime/bindstring.go
@@ -109,16 +109,7 @@ func BindStringToObject(src string, dst interface{}) error {
 		if err == nil {
 			v.SetBool(val)
 		}
-	case reflect.Array:
-		if tu, ok := dst.(encoding.TextUnmarshaler); ok {
-			if err := tu.UnmarshalText([]byte(src)); err != nil {
-				return fmt.Errorf("error unmarshaling '%s' text as %T: %s", src, dst, err)
-			}
-
-			return nil
-		}
-		fallthrough
-	case reflect.Struct:
+	case reflect.Array, reflect.Struct:
 		// if this is not of type Time or of type Date look to see if this is of type Binder.
 		if dstType, ok := dst.(Binder); ok {
 			return dstType.Bind(src)

--- a/pkg/runtime/bindstring.go
+++ b/pkg/runtime/bindstring.go
@@ -58,6 +58,18 @@ func BindStringToObject(src string, dst interface{}) error {
 		return errors.New("destination is not settable")
 	}
 
+	// For reflect.Struct, needs individual correspondence
+	if t.Kind() != reflect.Struct {
+		// If the destination implements encoding.TextUnmarshaler we use it for binding
+		if tu, ok := dst.(encoding.TextUnmarshaler); ok {
+			if err := tu.UnmarshalText([]byte(src)); err != nil {
+				return fmt.Errorf("error unmarshaling '%s' text as %T: %s", src, dst, err)
+			}
+
+			return nil
+		}
+	}
+
 	switch t.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		var val int64
@@ -157,6 +169,14 @@ func BindStringToObject(src string, dst interface{}) error {
 				v = reflect.Indirect(vtPtr)
 			}
 			v.Set(reflect.ValueOf(parsedDate))
+			return nil
+		}
+
+		if tu, ok := dst.(encoding.TextUnmarshaler); ok {
+			if err := tu.UnmarshalText([]byte(src)); err != nil {
+				return fmt.Errorf("error unmarshaling '%s' text as %T: %s", src, dst, err)
+			}
+
 			return nil
 		}
 

--- a/pkg/runtime/bindstring_test.go
+++ b/pkg/runtime/bindstring_test.go
@@ -16,12 +16,29 @@ package runtime
 import (
 	"fmt"
 	"math"
+	"math/big"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
+
+type numberTextUnmarshaler int64
+
+func (p *numberTextUnmarshaler) UnmarshalText(text []byte) error {
+	n, err := strconv.ParseInt(string(text), 10, 64)
+	if err != nil {
+		return err
+	}
+	*p = numberTextUnmarshaler(n)
+	return nil
+}
+
+func (p *numberTextUnmarshaler) String() string {
+	return fmt.Sprint(int64(*p))
+}
 
 func TestBindStringToObject(t *testing.T) {
 	var i int
@@ -208,4 +225,15 @@ func TestBindStringToObject(t *testing.T) {
 	assert.NoError(t, BindStringToObject(uuidString, &dstUUID))
 	assert.Equal(t, dstUUID.String(), uuidString)
 
+	// struct with TextUnmarshaler
+	bigIntString := "12345678910"
+	var dstBigInt big.Int
+	assert.NoError(t, BindStringToObject(bigIntString, &dstBigInt))
+	assert.Equal(t, dstBigInt.String(), bigIntString)
+
+	// scalar with TextUnmarshaler
+	numberTextUnmarshalerString := "12345678910"
+	var dstNumberTextUnmarshaler numberTextUnmarshaler
+	assert.NoError(t, BindStringToObject(numberTextUnmarshalerString, &dstNumberTextUnmarshaler))
+	assert.Equal(t, dstNumberTextUnmarshaler.String(), numberTextUnmarshalerString)
 }


### PR DESCRIPTION
Path parameters now supports encoding.TextUnmarshaler interface.
https://github.com/deepmap/oapi-codegen/pull/404

Query parameters do not.

I changed to call UnmarshalText instead of  reflect.Set if the destination type implements  encoding.TextUnmarshaler

