### PR TITLE
fix #1147

### DIFF
--- a/internal/test/issues/issue-removed-external-ref/gen/spec_base/issue.gen.go
+++ b/internal/test/issues/issue-removed-external-ref/gen/spec_base/issue.gen.go
@@ -221,6 +221,10 @@ type PostInvalidExtRefTrouble300JSONResponse struct {
 	externalRef0.PascalJSONResponse
 }
 
+func (response PostInvalidExtRefTrouble300JSONResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(response.PascalJSONResponse)
+}
+
 func (response PostInvalidExtRefTrouble300JSONResponse) VisitPostInvalidExtRefTroubleResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(300)

--- a/internal/test/strict-server/chi/server.gen.go
+++ b/internal/test/strict-server/chi/server.gen.go
@@ -693,6 +693,10 @@ type ReusableResponsesResponseObject interface {
 
 type ReusableResponses200JSONResponse struct{ ReusableresponseJSONResponse }
 
+func (response ReusableResponses200JSONResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(response.ReusableresponseJSONResponse)
+}
+
 func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))

--- a/internal/test/strict-server/echo/server.gen.go
+++ b/internal/test/strict-server/echo/server.gen.go
@@ -440,6 +440,10 @@ type ReusableResponsesResponseObject interface {
 
 type ReusableResponses200JSONResponse struct{ ReusableresponseJSONResponse }
 
+func (response ReusableResponses200JSONResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(response.ReusableresponseJSONResponse)
+}
+
 func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))

--- a/internal/test/strict-server/gin/server.gen.go
+++ b/internal/test/strict-server/gin/server.gen.go
@@ -501,6 +501,10 @@ type ReusableResponsesResponseObject interface {
 
 type ReusableResponses200JSONResponse struct{ ReusableresponseJSONResponse }
 
+func (response ReusableResponses200JSONResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(response.ReusableresponseJSONResponse)
+}
+
 func (response ReusableResponses200JSONResponse) VisitReusableResponsesResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("header1", fmt.Sprint(response.Headers.Header1))

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -276,6 +276,15 @@ func stripNewLines(s string) string {
 	return r.Replace(s)
 }
 
+// removePackage returns go name without package prefix
+func removePackage(s string) string {
+	idx := strings.Index(s, ".")
+	if idx == -1 {
+		return s
+	}
+	return s[idx+1:]
+}
+
 // TemplateFunctions is passed to the template engine, and we can call each
 // function here by keyName from the template code.
 var TemplateFunctions = template.FuncMap{
@@ -302,4 +311,5 @@ var TemplateFunctions = template.FuncMap{
 	"stripNewLines":              stripNewLines,
 	"sanitizeGoIdentity":         SanitizeGoIdentity,
 	"toGoComment":                StringWithTypeNameToGoComment,
+	"removePackage":              removePackage,
 }

--- a/pkg/codegen/templates/strict/strict-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-interface.tmpl
@@ -65,6 +65,12 @@
                 }
             {{end}}
 
+            {{if eq .NameTag "JSON" | and $fixedStatusCode $isRef -}}
+                func (response {{$receiverTypeName}}) MarshalJSON() ([]byte, error) {
+                    return json.Marshal(response.{{$ref | removePackage}}{{.NameTagOrContentType}}Response)
+                }
+            {{end}}
+
             func (response {{$receiverTypeName}}) Visit{{$opid}}Response(w http.ResponseWriter) error {
                 {{if eq .NameTag "Multipart" -}}
                     writer := multipart.NewWriter(w)


### PR DESCRIPTION
Another attempt to fix #1147.
This time `go generate ./...` has been run. All tests pass.

New template function is added, which strip package name for external ref type.