### PR TITLE
Add golangci-lint config with enabled gofumpt,gci,nolintlint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 name: Lint project
 on: [push, pull_request]
+env:
+  GOLANGCI_LINT_VERSION: v1.53.3
 jobs:
   build:
     name: Build
@@ -16,5 +18,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Make sure this matches the version we've got in our `Makefile`
-          version: v1.50.1
+          version: ${{ env.GOLANGCI_LINT_VERSION }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,39 @@
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+
+run:
+  concurrency: 4
+  timeout: 10m
+  issues-exit-code: 1
+  tests: true
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - asasalint
+    - dogsled
+    - bidichk
+    - errcheck
+    - gci
+    - gofumpt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nilerr
+    - nolintlint
+    - staticcheck
+    - typecheck
+    - unused
+
+output:
+  print-issued-lines: false
+  sort-results: false
+
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/deepmap/oapi-codegen)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 GOBASE=$(shell pwd)
 GOBIN=$(GOBASE)/bin
 
+GOLANGCI_LINT_VERSION=$(shell awk '/GOLANGCI_LINT_VERSION:/ { print $$2 }' .github/workflows/lint.yml)
+
 help:
 	@echo "This is a helper makefile for oapi-codegen"
 	@echo "Targets:"
@@ -10,7 +12,7 @@ help:
 	@echo "    tidy         tidy go mod"
 
 $(GOBIN)/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v1.50.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) $(GOLANGCI_LINT_VERSION)
 
 .PHONY: tools
 tools: $(GOBIN)/golangci-lint

--- a/cmd/oapi-codegen/oapi-codegen_test.go
+++ b/cmd/oapi-codegen/oapi-codegen_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestLoader(t *testing.T) {
-
 	paths := []string{
 		"../../examples/petstore-expanded/petstore-expanded.yaml",
 		"https://petstore3.swagger.io/api/v3/openapi.json",

--- a/internal/test/any_of/param/param_test.go
+++ b/internal/test/any_of/param/param_test.go
@@ -3,9 +3,10 @@ package param_test
 import (
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/internal/test/any_of/param"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/deepmap/oapi-codegen/internal/test/any_of/param"
 )
 
 func TestAnyOfParameter(t *testing.T) {

--- a/internal/test/client/client_test.go
+++ b/internal/test/client/client_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestTemp(t *testing.T) {
-
 	var (
 		withTrailingSlash    = "https://my-api.com/some-base-url/v1/"
 		withoutTrailingSlash = "https://my-api.com/some-base-url/v1"

--- a/internal/test/components/components_test.go
+++ b/internal/test/components/components_test.go
@@ -24,7 +24,6 @@ func TestRawJSON(t *testing.T) {
 	assert.NoError(t, err)
 
 	assertJsonEqual(t, []byte(buf), buf2)
-
 }
 
 func TestAdditionalProperties(t *testing.T) {

--- a/internal/test/externalref/imports_test.go
+++ b/internal/test/externalref/imports_test.go
@@ -3,9 +3,10 @@ package externalref
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	packageA "github.com/deepmap/oapi-codegen/internal/test/externalref/packageA"
 	packageB "github.com/deepmap/oapi-codegen/internal/test/externalref/packageB"
-	"github.com/stretchr/testify/require"
 )
 
 func TestParameters(t *testing.T) {

--- a/internal/test/issues/issue-312/issue_test.go
+++ b/internal/test/issues/issue-312/issue_test.go
@@ -66,7 +66,6 @@ func TestClient_WhenPathHasIdContainingReservedCharacter_RequestHasCorrectPath(t
 }
 
 func TestClient_ServerUnescapesEscapedArg(t *testing.T) {
-
 	e := echo.New()
 	m := &MockClient{}
 	RegisterHandlers(e, m)

--- a/internal/test/issues/issue-52/issue_test.go
+++ b/internal/test/issues/issue-52/issue_test.go
@@ -4,9 +4,10 @@ import (
 	_ "embed"
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/pkg/codegen"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/require"
+
+	"github.com/deepmap/oapi-codegen/pkg/codegen"
 )
 
 //go:embed spec.yaml

--- a/internal/test/issues/issue-grab_import_names/issue_test.go
+++ b/internal/test/issues/issue-grab_import_names/issue_test.go
@@ -3,9 +3,10 @@ package grabimportnames
 import (
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/pkg/codegen"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/require"
+
+	"github.com/deepmap/oapi-codegen/pkg/codegen"
 )
 
 func TestLineComments(t *testing.T) {

--- a/internal/test/issues/issue-illegal_enum_names/issue_test.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue_test.go
@@ -6,9 +6,10 @@ import (
 	"go/token"
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/pkg/codegen"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/require"
+
+	"github.com/deepmap/oapi-codegen/pkg/codegen"
 )
 
 func TestIllegalEnumNames(t *testing.T) {

--- a/internal/test/parameters/parameters_test.go
+++ b/internal/test/parameters/parameters_test.go
@@ -7,11 +7,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/deepmap/oapi-codegen/pkg/testutil"
 )
 
 type testServer struct {
@@ -261,9 +262,9 @@ func TestParameterBinding(t *testing.T) {
 
 	var expectedPrimitive int32 = 5
 
-	var expectedPrimitiveString = "123;456"
+	expectedPrimitiveString := "123;456"
 
-	var expectedN1Param = "foo"
+	expectedN1Param := "foo"
 
 	// Check the passthrough case
 	//  (GET /passThrough/{param})
@@ -675,9 +676,9 @@ func TestClientQueryParams(t *testing.T) {
 
 	var expectedPrimitive1 int32 = 5
 	var expectedPrimitive2 int32 = 100
-	var expectedPrimitiveString = "123;456"
+	expectedPrimitiveString := "123;456"
 
-	var expectedStartingWithNumber = "111"
+	expectedStartingWithNumber := "111"
 
 	// Check query params
 	qParams := GetQueryFormParams{

--- a/internal/test/strict-server/chi/server.go
+++ b/internal/test/strict-server/chi/server.go
@@ -10,8 +10,7 @@ import (
 	"mime/multipart"
 )
 
-type StrictServer struct {
-}
+type StrictServer struct{}
 
 func (s StrictServer) JSONExample(ctx context.Context, request JSONExampleRequestObject) (JSONExampleResponseObject, error) {
 	return JSONExample200JSONResponse(*request.Body), nil

--- a/internal/test/strict-server/echo/server.go
+++ b/internal/test/strict-server/echo/server.go
@@ -10,8 +10,7 @@ import (
 	"mime/multipart"
 )
 
-type StrictServer struct {
-}
+type StrictServer struct{}
 
 func (s StrictServer) JSONExample(ctx context.Context, request JSONExampleRequestObject) (JSONExampleResponseObject, error) {
 	return JSONExample200JSONResponse(*request.Body), nil

--- a/internal/test/strict-server/fiber/server.go
+++ b/internal/test/strict-server/fiber/server.go
@@ -10,8 +10,7 @@ import (
 	"mime/multipart"
 )
 
-type StrictServer struct {
-}
+type StrictServer struct{}
 
 func (s StrictServer) JSONExample(ctx context.Context, request JSONExampleRequestObject) (JSONExampleResponseObject, error) {
 	return JSONExample200JSONResponse(*request.Body), nil

--- a/internal/test/strict-server/gin/server.go
+++ b/internal/test/strict-server/gin/server.go
@@ -10,8 +10,7 @@ import (
 	"mime/multipart"
 )
 
-type StrictServer struct {
-}
+type StrictServer struct{}
 
 func (s StrictServer) JSONExample(ctx context.Context, request JSONExampleRequestObject) (JSONExampleResponseObject, error) {
 	return JSONExample200JSONResponse(*request.Body), nil

--- a/pkg/chi-middleware/oapi_validate.go
+++ b/pkg/chi-middleware/oapi_validate.go
@@ -51,7 +51,6 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 			// validate request
 			if statusCode, err := validateRequest(r, router, options); err != nil {
 				if options != nil && options.ErrorHandler != nil {
@@ -66,13 +65,11 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func
 			next.ServeHTTP(w, r)
 		})
 	}
-
 }
 
 // validateRequest is called from the middleware above and actually does the work
 // of validating a request.
 func validateRequest(r *http.Request, router routers.Router, options *Options) (int, error) {
-
 	// Find route
 	route, pathParams, err := router.FindRoute(r)
 	if err != nil {

--- a/pkg/chi-middleware/oapi_validate_test.go
+++ b/pkg/chi-middleware/oapi_validate_test.go
@@ -10,12 +10,13 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/deepmap/oapi-codegen/pkg/testutil"
 )
 
 //go:embed test_spec.yaml
@@ -269,7 +270,6 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 		},
 		Options: openapi3filter.Options{
 			AuthenticationFunc: func(c context.Context, input *openapi3filter.AuthenticationInput) error {
-
 				for _, s := range input.Scopes {
 					if s == "someScope" {
 						return nil
@@ -325,11 +325,9 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 		assert.False(t, called, "Handler should not have been called")
 		called = false
 	}
-
 }
 
 func testRequestValidatorBasicFunctions(t *testing.T, r *chi.Mux) {
-
 	called := false
 
 	// Install a request handler for /resource. We want to make sure it doesn't
@@ -401,5 +399,4 @@ func testRequestValidatorBasicFunctions(t *testing.T, r *chi.Mux) {
 		assert.False(t, called, "Handler should not have been called")
 		called = false
 	}
-
 }

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -34,7 +34,6 @@ func checkLint(t *testing.T, filename string, code []byte) {
 }
 
 func TestExamplePetStoreCodeGeneration(t *testing.T) {
-
 	// Input vars for code generation:
 	packageName := "api"
 	opts := Configuration{
@@ -79,7 +78,6 @@ func TestExamplePetStoreCodeGeneration(t *testing.T) {
 }
 
 func TestExamplePetStoreCodeGenerationWithUserTemplates(t *testing.T) {
-
 	userTemplates := map[string]string{"typedef.tmpl": "//blah\n//blah"}
 
 	// Input vars for code generation:
@@ -115,7 +113,6 @@ func TestExamplePetStoreCodeGenerationWithUserTemplates(t *testing.T) {
 }
 
 func TestExamplePetStoreCodeGenerationWithFileUserTemplates(t *testing.T) {
-
 	userTemplates := map[string]string{"typedef.tmpl": "./templates/typedef.tmpl"}
 
 	// Input vars for code generation:
@@ -151,7 +148,6 @@ func TestExamplePetStoreCodeGenerationWithFileUserTemplates(t *testing.T) {
 }
 
 func TestExamplePetStoreCodeGenerationWithHTTPUserTemplates(t *testing.T) {
-
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.NoError(t, err)
 	defer ln.Close()
@@ -200,7 +196,6 @@ func TestExamplePetStoreCodeGenerationWithHTTPUserTemplates(t *testing.T) {
 }
 
 func TestExamplePetStoreParseFunction(t *testing.T) {
-
 	bodyBytes := []byte(`{"id": 5, "name": "testpet", "tag": "cat"}`)
 
 	cannedResponse := &http.Response{
@@ -220,7 +215,6 @@ func TestExamplePetStoreParseFunction(t *testing.T) {
 }
 
 func TestExampleOpenAPICodeGeneration(t *testing.T) {
-
 	// Input vars for code generation:
 	packageName := "testswagger"
 	opts := Configuration{
@@ -371,7 +365,6 @@ func TestGoTypeImport(t *testing.T) {
 
 	// Make sure the generated code is valid:
 	checkLint(t, "test.gen.go", []byte(code))
-
 }
 
 func TestRemoteExternalReference(t *testing.T) {
@@ -432,7 +425,6 @@ func (t *ExampleSchema_Item) FromExternalRef0NewPet(v externalRef0.NewPet) error
 
 	// Make sure the generated code is valid:
 	checkLint(t, "test.gen.go", []byte(code))
-
 }
 
 //go:embed test_spec.yaml

--- a/pkg/codegen/merge_schemas.go
+++ b/pkg/codegen/merge_schemas.go
@@ -156,43 +156,36 @@ func mergeOpenapiSchemas(s1, s2 openapi3.Schema, allOf bool) (openapi3.Schema, e
 	// If two schemas disagree on any of these flags, we error out.
 	if s1.UniqueItems != s2.UniqueItems {
 		return openapi3.Schema{}, errors.New("merging two schemas with different UniqueItems")
-
 	}
 	result.UniqueItems = s1.UniqueItems
 
 	if s1.ExclusiveMin != s2.ExclusiveMin {
 		return openapi3.Schema{}, errors.New("merging two schemas with different ExclusiveMin")
-
 	}
 	result.ExclusiveMin = s1.ExclusiveMin
 
 	if s1.ExclusiveMax != s2.ExclusiveMax {
 		return openapi3.Schema{}, errors.New("merging two schemas with different ExclusiveMax")
-
 	}
 	result.ExclusiveMax = s1.ExclusiveMax
 
 	if s1.Nullable != s2.Nullable {
 		return openapi3.Schema{}, errors.New("merging two schemas with different Nullable")
-
 	}
 	result.Nullable = s1.Nullable
 
 	if s1.ReadOnly != s2.ReadOnly {
 		return openapi3.Schema{}, errors.New("merging two schemas with different ReadOnly")
-
 	}
 	result.ReadOnly = s1.ReadOnly
 
 	if s1.WriteOnly != s2.WriteOnly {
 		return openapi3.Schema{}, errors.New("merging two schemas with different WriteOnly")
-
 	}
 	result.WriteOnly = s1.WriteOnly
 
 	if s1.AllowEmptyValue != s2.AllowEmptyValue {
 		return openapi3.Schema{}, errors.New("merging two schemas with different AllowEmptyValue")
-
 	}
 	result.AllowEmptyValue = s1.AllowEmptyValue
 

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -23,8 +23,9 @@ import (
 	"text/template"
 	"unicode"
 
-	"github.com/deepmap/oapi-codegen/pkg/util"
 	"github.com/getkin/kin-openapi/openapi3"
+
+	"github.com/deepmap/oapi-codegen/pkg/util"
 )
 
 type ParameterDefinition struct {
@@ -605,7 +606,6 @@ func OperationDefinitions(swagger *openapi3.T, initialismOverrides bool) ([]Oper
 				// They are the default securityPermissions which are injected into each
 				// path, except for the case where a path explicitly overrides them.
 				opDef.SecurityDefinitions = DescribeSecurityDefinition(swagger.Security)
-
 			}
 
 			if op.RequestBody != nil {
@@ -622,7 +622,7 @@ func OperationDefinitions(swagger *openapi3.T, initialismOverrides bool) ([]Oper
 }
 
 func generateDefaultOperationID(opName string, requestPath string, toCamelCaseFunc func(string) string) (string, error) {
-	var operationId = strings.ToLower(opName)
+	operationId := strings.ToLower(opName)
 
 	if opName == "" {
 		return "", fmt.Errorf("operation name cannot be an empty string")
@@ -904,7 +904,6 @@ func GenerateTypesForOperations(t *template.Template, ops []OperationDefinition)
 	}
 	if _, err := w.WriteString(addTypes); err != nil {
 		return "", fmt.Errorf("error writing boilerplate to buffer: %w", err)
-
 	}
 
 	// Generate boiler plate for all additional types.
@@ -964,7 +963,6 @@ func GenerateGorillaServer(t *template.Template, operations []OperationDefinitio
 }
 
 func GenerateStrictServer(t *template.Template, operations []OperationDefinition, opts Configuration) (string, error) {
-
 	var templates []string
 
 	if opts.Generate.ChiServer || opts.Generate.GorillaServer {

--- a/pkg/codegen/operations_test.go
+++ b/pkg/codegen/operations_test.go
@@ -80,7 +80,6 @@ func TestIsJson(t *testing.T) {
 			if got != test.want {
 				t.Fatalf("IsJson validation failed. Want [%v] Got [%v]", test.want, got)
 			}
-
 		})
 	}
 }

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -20,10 +20,11 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/deepmap/oapi-codegen/pkg/util"
 	"github.com/labstack/echo/v4"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+
+	"github.com/deepmap/oapi-codegen/pkg/util"
 )
 
 const (
@@ -91,7 +92,7 @@ func genParamNames(params []ParameterDefinition) string {
 
 // genResponsePayload generates the payload returned at the end of each client request function
 func genResponsePayload(operationID string) string {
-	var buffer = bytes.NewBufferString("")
+	buffer := bytes.NewBufferString("")
 
 	// Here is where we build up a response:
 	fmt.Fprintf(buffer, "&%s{\n", genResponseTypeName(operationID))
@@ -104,8 +105,8 @@ func genResponsePayload(operationID string) string {
 
 // genResponseUnmarshal generates unmarshaling steps for structured response payloads
 func genResponseUnmarshal(op *OperationDefinition) string {
-	var handledCaseClauses = make(map[string]string)
-	var unhandledCaseClauses = make(map[string]string)
+	handledCaseClauses := make(map[string]string)
+	unhandledCaseClauses := make(map[string]string)
 
 	// Get the type definitions from the operation:
 	typeDefinitions, err := op.GetResponseTypeDefinitions()
@@ -217,11 +218,9 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 	// groups.
 	fmt.Fprintf(buffer, "switch {\n")
 	for _, caseClauseKey := range SortedStringKeys(handledCaseClauses) {
-
 		fmt.Fprintf(buffer, "%s\n", handledCaseClauses[caseClauseKey])
 	}
 	for _, caseClauseKey := range SortedStringKeys(unhandledCaseClauses) {
-
 		fmt.Fprintf(buffer, "%s\n", unhandledCaseClauses[caseClauseKey])
 	}
 	fmt.Fprintf(buffer, "}\n")

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -725,7 +725,7 @@ func StringWithTypeNameToGoComment(in, typeName string) string {
 }
 
 func DeprecationComment(reason string) string {
-	var content = "Deprecated:" // The colon is required at the end even without reason
+	content := "Deprecated:" // The colon is required at the end even without reason
 	if reason != "" {
 		content += fmt.Sprintf(" %s", reason)
 	}

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -450,7 +450,6 @@ func TestSchemaNameToTypeName(t *testing.T) {
 	}
 }
 
-
 func TestTypeDefinitionsEquivalent(t *testing.T) {
 	def1 := TypeDefinition{TypeName: "name", Schema: Schema{
 		OAPISchema: &openapi3.Schema{},
@@ -460,7 +459,6 @@ func TestTypeDefinitionsEquivalent(t *testing.T) {
 	}}
 	assert.True(t, TypeDefinitionsEquivalent(def1, def2))
 }
-
 
 func TestRefPathToObjName(t *testing.T) {
 	t.Parallel()

--- a/pkg/fiber-middleware/oapi_validate.go
+++ b/pkg/fiber-middleware/oapi_validate.go
@@ -20,11 +20,11 @@ import (
 )
 
 type ctxKeyFiberContext struct{}
+
 type ctxKeyUserData struct{}
 
 // OapiValidatorFromYamlFile creates a validator middleware from a YAML file path
 func OapiValidatorFromYamlFile(path string) (fiber.Handler, error) {
-
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %s", path, err)
@@ -64,14 +64,12 @@ type Options struct {
 
 // OapiRequestValidatorWithOptions creates a validator from a swagger object, with validation options
 func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) fiber.Handler {
-
 	router, err := gorillamux.NewRouter(swagger)
 	if err != nil {
 		panic(err)
 	}
 
 	return func(c *fiber.Ctx) error {
-
 		err := ValidateRequestFromContext(c, router, options)
 		if err != nil {
 			if options != nil && options.ErrorHandler != nil {
@@ -90,14 +88,12 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) fibe
 // ValidateRequestFromContext is called from the middleware above and actually does the work
 // of validating a request.
 func ValidateRequestFromContext(c *fiber.Ctx, router routers.Router, options *Options) error {
-
 	r, err := adaptor.ConvertRequest(c, false)
 	if err != nil {
 		return err
 	}
 
 	route, pathParams, err := router.FindRoute(r)
-
 	// We failed to find a matching route for the request.
 	if err != nil {
 		switch e := err.(type) {
@@ -121,12 +117,12 @@ func ValidateRequestFromContext(c *fiber.Ctx, router routers.Router, options *Op
 
 	// Pass the fiber context into the request validator, so that any callbacks
 	// which it invokes make it available.
-	requestContext := context.WithValue(context.Background(), ctxKeyFiberContext{}, c) //nolint:staticcheck
+	requestContext := context.WithValue(context.Background(), ctxKeyFiberContext{}, c)
 
 	if options != nil {
 		requestValidationInput.Options = &options.Options
 		requestValidationInput.ParamDecoder = options.ParamDecoder
-		requestContext = context.WithValue(requestContext, ctxKeyUserData{}, options.UserData) //nolint:staticcheck
+		requestContext = context.WithValue(requestContext, ctxKeyUserData{}, options.UserData)
 	}
 
 	err = openapi3filter.ValidateRequest(requestContext, requestValidationInput)

--- a/pkg/fiber-middleware/oapi_validate_test.go
+++ b/pkg/fiber-middleware/oapi_validate_test.go
@@ -70,7 +70,6 @@ func doPost(t *testing.T, app *fiber.App, rawURL string, jsonBody interface{}) *
 }
 
 func TestOapiRequestValidator(t *testing.T) {
-
 	swagger, err := openapi3.NewLoader().LoadFromData(testSchema)
 	require.NoError(t, err, "Error initializing swagger")
 

--- a/pkg/gin-middleware/oapi_validate.go
+++ b/pkg/gin-middleware/oapi_validate.go
@@ -94,9 +94,9 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) gin.
 				// in case the handler didn't internally call Abort, stop the chain
 				c.Abort()
 			} else if options != nil && options.ErrorHandler != nil {
-					options.ErrorHandler(c, err.Error(), http.StatusBadRequest)
-					// in case the handler didn't internally call Abort, stop the chain
-					c.Abort()
+				options.ErrorHandler(c, err.Error(), http.StatusBadRequest)
+				// in case the handler didn't internally call Abort, stop the chain
+				c.Abort()
 			} else if err.Error() == routers.ErrPathNotFound.Error() {
 				// note: i am not sure if this is the best way to handle this
 				c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": err.Error()})
@@ -114,7 +114,6 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) gin.
 func ValidateRequestFromContext(c *gin.Context, router routers.Router, options *Options) error {
 	req := c.Request
 	route, pathParams, err := router.FindRoute(req)
-
 	// We failed to find a matching route for the request.
 	if err != nil {
 		switch e := err.(type) {

--- a/pkg/gin-middleware/oapi_validate_test.go
+++ b/pkg/gin-middleware/oapi_validate_test.go
@@ -25,12 +25,13 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/deepmap/oapi-codegen/pkg/testutil"
 )
 
 //go:embed test_spec.yaml

--- a/pkg/middleware/oapi_validate.go
+++ b/pkg/middleware/oapi_validate.go
@@ -112,7 +112,6 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) echo
 func ValidateRequestFromContext(ctx echo.Context, router routers.Router, options *Options) *echo.HTTPError {
 	req := ctx.Request()
 	route, pathParams, err := router.FindRoute(req)
-
 	// We failed to find a matching route for the request.
 	if err != nil {
 		switch e := err.(type) {

--- a/pkg/middleware/oapi_validate_test.go
+++ b/pkg/middleware/oapi_validate_test.go
@@ -24,13 +24,14 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/labstack/echo/v4"
 	echomiddleware "github.com/labstack/echo/v4/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/deepmap/oapi-codegen/pkg/testutil"
 )
 
 //go:embed test_spec.yaml
@@ -169,7 +170,6 @@ func TestOapiRequestValidator(t *testing.T) {
 	e.GET("/protected_resource", func(c echo.Context) error {
 		called = true
 		return c.NoContent(http.StatusNoContent)
-
 	})
 
 	// Call a protected function to which we have access
@@ -416,7 +416,6 @@ func TestOapiRequestValidatorWithOptionsMultiErrorAndCustomHandler(t *testing.T)
 }
 
 func TestGetSkipperFromOptions(t *testing.T) {
-
 	options := new(Options)
 	assert.NotNil(t, getSkipperFromOptions(options))
 

--- a/pkg/runtime/bindform.go
+++ b/pkg/runtime/bindform.go
@@ -13,8 +13,10 @@ import (
 	"github.com/deepmap/oapi-codegen/pkg/types"
 )
 
-const tagName = "json"
-const jsonContentType = "application/json"
+const (
+	tagName         = "json"
+	jsonContentType = "application/json"
+)
 
 type RequestBodyEncoding struct {
 	ContentType string

--- a/pkg/runtime/bindform_test.go
+++ b/pkg/runtime/bindform_test.go
@@ -6,8 +6,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/deepmap/oapi-codegen/pkg/types"
 )
 
 func TestBindURLForm(t *testing.T) {

--- a/pkg/runtime/bindparam.go
+++ b/pkg/runtime/bindparam.go
@@ -31,17 +31,14 @@ import (
 // https://swagger.io/docs/specification/serialization/
 // It is a backward compatible function to clients generated with codegen
 // up to version v1.5.5. v1.5.6+ calls the function below.
-func BindStyledParameter(style string, explode bool, paramName string,
-	value string, dest interface{}) error {
+func BindStyledParameter(style string, explode bool, paramName string, value string, dest interface{}) error {
 	return BindStyledParameterWithLocation(style, explode, paramName, ParamLocationUndefined, value, dest)
 }
 
 // BindStyledParameterWithLocation binds a parameter as described in the Path Parameters
 // section here to a Go object:
 // https://swagger.io/docs/specification/serialization/
-func BindStyledParameterWithLocation(style string, explode bool, paramName string,
-	paramLocation ParamLocation, value string, dest interface{}) error {
-
+func BindStyledParameterWithLocation(style string, explode bool, paramName string, paramLocation ParamLocation, value string, dest interface{}) error {
 	if value == "" {
 		return fmt.Errorf("parameter '%s' is empty, can't bind its value", paramName)
 	}
@@ -277,9 +274,7 @@ func bindSplitPartsToDestinationStruct(paramName string, parts []string, explode
 // tell them apart. This code tries to fail, but the moral of the story is that
 // you shouldn't pass objects via form styled query arguments, just use
 // the Content parameter form.
-func BindQueryParameter(style string, explode bool, required bool, paramName string,
-	queryParams url.Values, dest interface{}) error {
-
+func BindQueryParameter(style string, explode bool, required bool, paramName string, queryParams url.Values, dest interface{}) error {
 	// dv = destination value.
 	dv := reflect.Indirect(reflect.ValueOf(dest))
 

--- a/pkg/runtime/bindparam_test.go
+++ b/pkg/runtime/bindparam_test.go
@@ -21,9 +21,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/deepmap/oapi-codegen/pkg/types"
 )
 
 // MockBinder is just an independent version of Binder that has the Bind implemented
@@ -356,7 +357,6 @@ func TestBindQueryParameter(t *testing.T) {
 		assert.Error(t, err)
 		err = BindQueryParameter("form", true, true, "notfound", queryParams, &optionalNumber)
 		assert.Error(t, err)
-
 	})
 }
 

--- a/pkg/runtime/bindstring_test.go
+++ b/pkg/runtime/bindstring_test.go
@@ -19,8 +19,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/deepmap/oapi-codegen/pkg/types"
 )
 
 func TestBindStringToObject(t *testing.T) {
@@ -207,5 +208,4 @@ func TestBindStringToObject(t *testing.T) {
 	var dstUUID types.UUID
 	assert.NoError(t, BindStringToObject(uuidString, &dstUUID))
 	assert.Equal(t, dstUUID.String(), uuidString)
-
 }

--- a/pkg/runtime/deepobject.go
+++ b/pkg/runtime/deepobject.go
@@ -111,7 +111,6 @@ func (f *fieldOrValue) appendPathValue(path []string, value string) {
 }
 
 func makeFieldOrValue(paths [][]string, values []string) fieldOrValue {
-
 	f := fieldOrValue{
 		fields: make(map[string]fieldOrValue),
 	}
@@ -193,7 +192,6 @@ func fieldIndicesByJsonTag(i interface{}) (map[string]int, error) {
 }
 
 func assignPathValues(dst interface{}, pathValues fieldOrValue) error {
-	//t := reflect.TypeOf(dst)
 	v := reflect.ValueOf(dst)
 
 	iv := reflect.Indirect(v)

--- a/pkg/runtime/styleparam.go
+++ b/pkg/runtime/styleparam.go
@@ -26,8 +26,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/google/uuid"
+
+	"github.com/deepmap/oapi-codegen/pkg/types"
 )
 
 // Parameter escaping works differently based on where a header is found

--- a/pkg/runtime/styleparam_test.go
+++ b/pkg/runtime/styleparam_test.go
@@ -17,9 +17,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/deepmap/oapi-codegen/pkg/types"
 )
 
 func TestStyleParam(t *testing.T) {
@@ -688,5 +689,4 @@ func TestStyleParam(t *testing.T) {
 	result, err = StyleParamWithLocation("simple", false, "id", ParamLocationQuery, uuidD)
 	assert.NoError(t, err)
 	assert.EqualValues(t, "972beb41-e5ea-4b31-a79a-96f4999d8769", result)
-
 }

--- a/pkg/securityprovider/securityprovider_test.go
+++ b/pkg/securityprovider/securityprovider_test.go
@@ -3,13 +3,12 @@ package securityprovider
 import (
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/internal/test/client"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/deepmap/oapi-codegen/internal/test/client"
 )
 
-var (
-	withTrailingSlash = "https://my-api.com/some-base-url/v1/"
-)
+var withTrailingSlash = "https://my-api.com/some-base-url/v1/"
 
 func TestSecurityProviders(t *testing.T) {
 	bearer, err := NewSecurityProviderBearerToken("mytoken")

--- a/pkg/types/email_test.go
+++ b/pkg/types/email_test.go
@@ -105,11 +105,9 @@ func TestEmail_UnmarshalJSON_RequiredEmail_Validation(t *testing.T) {
 			assert.ErrorIs(t, err, tc.expectedError)
 		})
 	}
-
 }
 
 func TestEmail_UnmarshalJSON_NullableEmail_Validation(t *testing.T) {
-
 	type nullableEmail struct {
 		EmailField *Email `json:"email,omitempty"`
 	}

--- a/pkg/types/file_test.go
+++ b/pkg/types/file_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var _ json.Marshaler = (*File)(nil)
-var _ json.Unmarshaler = (*File)(nil)
+var (
+	_ json.Marshaler   = (*File)(nil)
+	_ json.Unmarshaler = (*File)(nil)
+)
 
 func TestFileJSON(t *testing.T) {
 	type Object struct {
@@ -50,5 +52,4 @@ func TestFileJSON(t *testing.T) {
 	o4Bytes, err := o4.BinaryFieldPtr.Bytes()
 	require.NoError(t, err)
 	assert.Equal(t, []byte("hello"), o4Bytes)
-
 }

--- a/pkg/types/regexes.go
+++ b/pkg/types/regexes.go
@@ -6,6 +6,4 @@ const (
 	emailRegexString = "^(?:(?:(?:(?:[a-zA-Z]|\\d|[!#\\$%&'\\*\\+\\-\\/=\\?\\^_`{\\|}~]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])+(?:\\.([a-zA-Z]|\\d|[!#\\$%&'\\*\\+\\-\\/=\\?\\^_`{\\|}~]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])+)*)|(?:(?:\\x22)(?:(?:(?:(?:\\x20|\\x09)*(?:\\x0d\\x0a))?(?:\\x20|\\x09)+)?(?:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]|\\x21|[\\x23-\\x5b]|[\\x5d-\\x7e]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(?:(?:[\\x01-\\x09\\x0b\\x0c\\x0d-\\x7f]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}]))))*(?:(?:(?:\\x20|\\x09)*(?:\\x0d\\x0a))?(\\x20|\\x09)+)?(?:\\x22))))@(?:(?:(?:[a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(?:(?:[a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])(?:[a-zA-Z]|\\d|-|\\.|~|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])*(?:[a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])))\\.)+(?:(?:[a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(?:(?:[a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])(?:[a-zA-Z]|\\d|-|\\.|~|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])*(?:[a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])))\\.?$"
 )
 
-var (
-	emailRegex = regexp.MustCompile(emailRegexString)
-)
+var emailRegex = regexp.MustCompile(emailRegexString)

--- a/pkg/util/loader.go
+++ b/pkg/util/loader.go
@@ -7,7 +7,6 @@ import (
 )
 
 func LoadSwagger(filePath string) (swagger *openapi3.T, err error) {
-
 	loader := openapi3.NewLoader()
 	loader.IsExternalRefsAllowed = true
 


### PR DESCRIPTION
This PR adds the config for golangci-lint and fixes lint issues.

Details:
- Add `.golangci.yaml` with default linters, additionally enable `gofumpt, gci, nolintlint`.
- Fix `gofumpt, gci, nolintlint` lint issues. Mostly, it's unsorted imports and unnecessary newlines.
- Use golangci-lint v1.53.3 in `.github/workflows/lint.yml`.
- Modify `Makefile` to get golangci-lint's version from the `.github/workflows/lint.yml`.