### PR TITLE
Allow setting globalState.spec without Generate

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -1104,3 +1104,7 @@ func GetParametersImports(params map[string]*openapi3.ParameterRef) (map[string]
 	}
 	return res, nil
 }
+
+func SetGlobalStateSpec(spec *openapi3.T) {
+	globalState.spec = spec
+}


### PR DESCRIPTION
We use oapi-codegen as a library.
E.g. we use public functions (e.g. codegen.OperationDefinitions()) inside our tool to make our specific additional code generation logic.
Currently the globalState.spec variable is used in refPathToGoType() and is set only in the Generate() function, so we have a panic when we use public functions without the Generate() invocation.

I suppose it is nice to have an ability to set the globalState.spec variable without the Generate() function invocation.