### PR TITLE
Fix: Use of AnyOf inline generates struct type names starting with a number

### DIFF
--- a/internal/test/any_of/codegen/anyof-inline.yaml
+++ b/internal/test/any_of/codegen/anyof-inline.yaml
@@ -1,0 +1,81 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Cats, Dogs and Rats API
+  description: This API allows the client to receive information about cats, dogs and rats.
+servers:
+  - url: https://example.com/api
+security:
+  - ApiKeyAuth: []
+paths:
+  /pets:
+    get:
+      summary: Get a list of pets
+      description: This endpoint returns a list of pets. Each pet can be either a cat, dog or a rat.
+      operationId: getPets
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      anyOf:
+                        - $ref: '#/components/schemas/Cat'
+                        - $ref: '#/components/schemas/Dog'
+                        - $ref: '#/components/schemas/Rat'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal Server Error
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  schemas:
+    Cat:
+      type: object
+      description: This is a cat
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        breed:
+          type: string
+        color:
+          type: string
+        purrs:
+          type: boolean
+    Dog:
+      type: object
+      description: This is a dog
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        breed:
+          type: string
+        color:
+          type: string
+        barks:
+          type: boolean
+    Rat:
+      type: object
+      description: This is a rat
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        color:
+          type: string
+        squeaks:
+          type: boolean

--- a/internal/test/any_of/codegen/anyof-ref-schema.yaml
+++ b/internal/test/any_of/codegen/anyof-ref-schema.yaml
@@ -1,0 +1,81 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Cats, Dogs and Rats API
+  description: This API allows the client to receive information about cats, dogs and rats.
+servers:
+  - url: https://example.com/api
+security:
+  - ApiKeyAuth: []
+paths:
+  /pets:
+    get:
+      summary: Get a list of pets
+      description: This endpoint returns a list of pets. Each pet can be either a cat, dog or a rat.
+      operationId: getPets
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPetsDto'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal Server Error
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  schemas:
+    GetPetsDto:
+      type: object
+      properties:
+        data:
+          anyOf:
+            - $ref: '#/components/schemas/Cat'
+            - $ref: '#/components/schemas/Dog'
+            - $ref: '#/components/schemas/Rat'
+    Cat:
+      type: object
+      description: This is a cat
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        breed:
+          type: string
+        color:
+          type: string
+        purrs:
+          type: boolean
+    Dog:
+      type: object
+      description: This is a dog
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        breed:
+          type: string
+        color:
+          type: string
+        barks:
+          type: boolean
+    Rat:
+      type: object
+      description: This is a rat
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        color:
+          type: string
+        squeaks:
+          type: boolean

--- a/internal/test/any_of/codegen/codegen_test.go
+++ b/internal/test/any_of/codegen/codegen_test.go
@@ -1,0 +1,70 @@
+package codegen
+
+import (
+	"github.com/deepmap/oapi-codegen/pkg/codegen"
+	"github.com/deepmap/oapi-codegen/pkg/util"
+	"github.com/golangci/lint-1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go/format"
+	"testing"
+)
+
+func TestAnyOfInlineSchema(t *testing.T) {
+	opts := codegen.Configuration{
+		PackageName: "api",
+		Generate: codegen.GenerateOptions{
+			Models:     true,
+			EchoServer: true,
+			Client:     true,
+		},
+	}
+	swagger, err := util.LoadSwagger("anyof-inline.yaml")
+	assert.NoError(t, err)
+
+	// Generate code
+	code, err := codegen.Generate(swagger, opts)
+	assert.NoError(t, err)
+
+	validateGeneratedCode(t, err, code)
+}
+
+func TestAnyOfRefSchema(t *testing.T) {
+	opts := codegen.Configuration{
+		PackageName: "api",
+		Generate: codegen.GenerateOptions{
+			Models:     true,
+			EchoServer: true,
+			Client:     true,
+		},
+	}
+	swagger, err := util.LoadSwagger("anyof-ref-schema.yaml")
+	require.NoError(t, err)
+
+	// Generate code
+	code, err := codegen.Generate(swagger, opts)
+	assert.NoError(t, err)
+
+	validateGeneratedCode(t, err, code)
+}
+
+func validateGeneratedCode(t *testing.T, err error, code string) {
+	assert.NotEmpty(t, code)
+
+	// Check that we have valid (formattable) code:
+	_, err = format.Source([]byte(code))
+	assert.NoError(t, err)
+
+	// Check that we have a package:
+	assert.Contains(t, code, "package api")
+
+	// Make sure the generated code is valid:
+	checkLint(t, "test.gen.go", []byte(code))
+}
+
+func checkLint(t *testing.T, filename string, code []byte) {
+	linter := new(lint.Linter)
+	problems, err := linter.Lint(filename, code)
+	assert.NoError(t, err)
+	assert.Len(t, problems, 0)
+}

--- a/pkg/codegen/codegen_test.go
+++ b/pkg/codegen/codegen_test.go
@@ -435,5 +435,36 @@ func (t *ExampleSchema_Item) FromExternalRef0NewPet(v externalRef0.NewPet) error
 
 }
 
+func TestAnyOfInline(t *testing.T) {
+	packageName := "api"
+	opts := Configuration{
+		PackageName: packageName,
+		Generate: GenerateOptions{
+			Models:     true,
+			EchoServer: true,
+			Client:     true,
+		},
+	}
+	spec := "test_specs/anyof-inline.yaml"
+	swagger, err := util.LoadSwagger(spec)
+	require.NoError(t, err)
+
+	// Run our code generation:
+	code, err := Generate(swagger, opts)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, code)
+
+	// Check that we have valid (formattable) code:
+	_, err = format.Source([]byte(code))
+	assert.NoError(t, err)
+
+	// Check that we have a package:
+	assert.Contains(t, code, "package api")
+	println(code)
+
+	// Make sure the generated code is valid:
+	checkLint(t, "test.gen.go", []byte(code))
+}
+
 //go:embed test_spec.yaml
 var testOpenAPIDefinition string

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -286,7 +286,7 @@ func (o *OperationDefinition) GetResponseTypeDefinitions() ([]ResponseTypeDefini
 				contentType := responseRef.Value.Content[contentTypeName]
 				// We can only generate a type if we have a schema:
 				if contentType.Schema != nil {
-					responseSchema, err := GenerateGoSchema(contentType.Schema, []string{responseName})
+					responseSchema, err := GenerateGoSchema(contentType.Schema, []string{o.OperationId, responseName})
 					if err != nil {
 						return nil, fmt.Errorf("Unable to determine Go type for %s.%s: %w", o.OperationId, contentTypeName, err)
 					}
@@ -320,8 +320,9 @@ func (o *OperationDefinition) GetResponseTypeDefinitions() ([]ResponseTypeDefini
 							TypeName: typeName,
 							Schema:   responseSchema,
 						},
-						ResponseName:    responseName,
-						ContentTypeName: contentTypeName,
+						ResponseName:              responseName,
+						ContentTypeName:           contentTypeName,
+						AdditionalTypeDefinitions: responseSchema.GetAdditionalTypeDefs(),
 					}
 					if IsGoTypeReference(responseRef.Ref) {
 						refType, err := RefPathToGoType(responseRef.Ref)

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -175,6 +175,8 @@ type ResponseTypeDefinition struct {
 
 	// The type name of a response model.
 	ResponseName string
+
+	AdditionalTypeDefinitions []TypeDefinition
 }
 
 func (t *TypeDefinition) IsAlias() bool {

--- a/pkg/codegen/templates/client-with-responses.tmpl
+++ b/pkg/codegen/templates/client-with-responses.tmpl
@@ -44,13 +44,20 @@ type ClientWithResponsesInterface interface {
 }
 
 {{range .}}{{$opid := .OperationId}}{{$op := .}}
+{{$responseTypeDefinitions := getResponseTypeDefinitions .}}
 type {{genResponseTypeName $opid | ucFirst}} struct {
     Body         []byte
 	HTTPResponse *http.Response
-    {{- range getResponseTypeDefinitions .}}
+    {{- range $responseTypeDefinitions}}
     {{.TypeName}} *{{.Schema.TypeDecl}}
     {{- end}}
 }
+
+{{- range $responseTypeDefinitions}}
+  {{- range .AdditionalTypeDefinitions}}
+    type {{.TypeName}} {{if .IsAlias }}={{end}} {{.Schema.TypeDecl}}
+  {{- end}}
+{{- end}}
 
 // Status returns HTTPResponse.Status
 func (r {{genResponseTypeName $opid | ucFirst}}) Status() string {


### PR DESCRIPTION
https://github.com/deepmap/oapi-codegen/issues/1121 reports that use of AnyOf inline generates invalid go code for client (struct type names starting with a number).
This PR fixes 2 issues:

When status code is the first element of path, PathToTypeName function will generate type name starting with a number
When a property have UnionElements and we use PathToTypeName to generate a reference type, we are not creating the corresponding struct for it
Closes https://github.com/deepmap/oapi-codegen/issues/1121