### PR TITLE
Update to minimum of Go 1.20

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Make sure this matches the version we've got in our `Makefile`
-          version: v1.50.1
+          version: v1.54.0

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 	@echo "    tidy         tidy go mod"
 
 $(GOBIN)/golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v1.50.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v1.54.0
 
 .PHONY: tools
 tools: $(GOBIN)/golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/deepmap/oapi-codegen
 
-go 1.18
+go 1.20
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/deepmap/oapi-codegen
 
+go 1.18
+
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0
 	github.com/getkin/kin-openapi v0.118.0
@@ -76,5 +78,3 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-go 1.18


### PR DESCRIPTION
- Move `go` version in `go.mod`
- Bump targeted Go version to 1.20

Closes #1158.
