### PR TITLE
Intialisms for schemas properties parameters

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -1090,3 +1090,7 @@ func GetParametersImports(params map[string]*openapi3.ParameterRef) (map[string]
 	}
 	return res, nil
 }
+
+func SetGlobalStateSpecs(spec *openapi3.T) {
+	globalState.spec = spec
+}

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -1091,6 +1091,6 @@ func GetParametersImports(params map[string]*openapi3.ParameterRef) (map[string]
 	return res, nil
 }
 
-func SetGlobalStateSpecs(spec *openapi3.T) {
+func SetGlobalStateSpec(spec *openapi3.T) {
 	globalState.spec = spec
 }

--- a/pkg/codegen/operations_test.go
+++ b/pkg/codegen/operations_test.go
@@ -131,7 +131,7 @@ func TestGenerateDefaultOperationID(t *testing.T) {
 	}
 
 	for _, test := range suite {
-		got, err := generateDefaultOperationID(test.op, test.path, ToCamelCase)
+		got, err := generateDefaultOperationID(test.op, test.path)
 		if err != nil {
 			if !test.wantErr {
 				t.Fatalf("did not expected error but got %v", err)

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -682,7 +682,7 @@ func typeNamePrefix(name string) (prefix string) {
 // SchemaNameToTypeName converts a Schema name to a valid Go type name. It converts to camel case, and makes sure the name is
 // valid in Go
 func SchemaNameToTypeName(name string) string {
-	return typeNamePrefix(name) + ToCamelCase(name)
+	return typeNamePrefix(name) + ConfiguredToCamelCase(name)
 }
 
 // According to the spec, additionalProperties may be true, false, or a
@@ -706,7 +706,7 @@ func SchemaHasAdditionalProperties(schema *openapi3.Schema) bool {
 // type name.
 func PathToTypeName(path []string) string {
 	for i, p := range path {
-		path[i] = ToCamelCase(p)
+		path[i] = ConfiguredToCamelCase(p)
 	}
 	return strings.Join(path, "_")
 }


### PR DESCRIPTION
Extends #1174
Added usage of Initialism overrides for SchemaTypes and Paths to use it in types' fields names and in types' names, not only in operations.
