### PR TITLE
Remove capitalised error strings

### DIFF
--- a/examples/petstore-expanded/strict/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/strict/api/petstore-server.gen.go
@@ -487,7 +487,7 @@ func (sh *strictHandler) FindPets(w http.ResponseWriter, r *http.Request, params
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -518,7 +518,7 @@ func (sh *strictHandler) AddPet(w http.ResponseWriter, r *http.Request) {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -544,7 +544,7 @@ func (sh *strictHandler) DeletePet(w http.ResponseWriter, r *http.Request, id in
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -570,7 +570,7 @@ func (sh *strictHandler) FindPetByID(w http.ResponseWriter, r *http.Request, id 
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 

--- a/internal/test/issues/issue-1093/api/child/child.gen.go
+++ b/internal/test/issues/issue-1093/api/child/child.gen.go
@@ -136,7 +136,7 @@ func (sh *strictHandler) GetPets(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 

--- a/internal/test/issues/issue-1093/api/parent/parent.gen.go
+++ b/internal/test/issues/issue-1093/api/parent/parent.gen.go
@@ -141,7 +141,7 @@ func (sh *strictHandler) GetPets(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 

--- a/internal/test/issues/issue-removed-external-ref/gen/spec_base/issue.gen.go
+++ b/internal/test/issues/issue-removed-external-ref/gen/spec_base/issue.gen.go
@@ -308,7 +308,7 @@ func (sh *strictHandler) PostInvalidExtRefTrouble(w http.ResponseWriter, r *http
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -332,6 +332,6 @@ func (sh *strictHandler) PostNoTrouble(w http.ResponseWriter, r *http.Request) {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }

--- a/internal/test/strict-server/chi/server.gen.go
+++ b/internal/test/strict-server/chi/server.gen.go
@@ -1090,7 +1090,7 @@ func (sh *strictHandler) JSONExample(w http.ResponseWriter, r *http.Request) {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1121,7 +1121,7 @@ func (sh *strictHandler) MultipartExample(w http.ResponseWriter, r *http.Request
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1187,7 +1187,7 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(w http.ResponseWriter, 
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1213,7 +1213,7 @@ func (sh *strictHandler) ReservedGoKeywordParameters(w http.ResponseWriter, r *h
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1244,7 +1244,7 @@ func (sh *strictHandler) ReusableResponses(w http.ResponseWriter, r *http.Reques
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1276,7 +1276,7 @@ func (sh *strictHandler) TextExample(w http.ResponseWriter, r *http.Request) {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1302,7 +1302,7 @@ func (sh *strictHandler) UnknownExample(w http.ResponseWriter, r *http.Request) 
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1330,7 +1330,7 @@ func (sh *strictHandler) UnspecifiedContentType(w http.ResponseWriter, r *http.R
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1365,7 +1365,7 @@ func (sh *strictHandler) URLEncodedExample(w http.ResponseWriter, r *http.Reques
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1398,7 +1398,7 @@ func (sh *strictHandler) HeadersExample(w http.ResponseWriter, r *http.Request, 
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1429,7 +1429,7 @@ func (sh *strictHandler) UnionExample(w http.ResponseWriter, r *http.Request) {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 

--- a/internal/test/strict-server/echo/server.gen.go
+++ b/internal/test/strict-server/echo/server.gen.go
@@ -817,7 +817,7 @@ func (sh *strictHandler) JSONExample(ctx echo.Context) error {
 	} else if validResponse, ok := response.(JSONExampleResponseObject); ok {
 		return validResponse.VisitJSONExampleResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -846,7 +846,7 @@ func (sh *strictHandler) MultipartExample(ctx echo.Context) error {
 	} else if validResponse, ok := response.(MultipartExampleResponseObject); ok {
 		return validResponse.VisitMultipartExampleResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -906,7 +906,7 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx echo.Context) error
 	} else if validResponse, ok := response.(MultipleRequestAndResponseTypesResponseObject); ok {
 		return validResponse.VisitMultipleRequestAndResponseTypesResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -931,7 +931,7 @@ func (sh *strictHandler) ReservedGoKeywordParameters(ctx echo.Context, pType str
 	} else if validResponse, ok := response.(ReservedGoKeywordParametersResponseObject); ok {
 		return validResponse.VisitReservedGoKeywordParametersResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -960,7 +960,7 @@ func (sh *strictHandler) ReusableResponses(ctx echo.Context) error {
 	} else if validResponse, ok := response.(ReusableResponsesResponseObject); ok {
 		return validResponse.VisitReusableResponsesResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -990,7 +990,7 @@ func (sh *strictHandler) TextExample(ctx echo.Context) error {
 	} else if validResponse, ok := response.(TextExampleResponseObject); ok {
 		return validResponse.VisitTextExampleResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1015,7 +1015,7 @@ func (sh *strictHandler) UnknownExample(ctx echo.Context) error {
 	} else if validResponse, ok := response.(UnknownExampleResponseObject); ok {
 		return validResponse.VisitUnknownExampleResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1042,7 +1042,7 @@ func (sh *strictHandler) UnspecifiedContentType(ctx echo.Context) error {
 	} else if validResponse, ok := response.(UnspecifiedContentTypeResponseObject); ok {
 		return validResponse.VisitUnspecifiedContentTypeResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1075,7 +1075,7 @@ func (sh *strictHandler) URLEncodedExample(ctx echo.Context) error {
 	} else if validResponse, ok := response.(URLEncodedExampleResponseObject); ok {
 		return validResponse.VisitURLEncodedExampleResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1106,7 +1106,7 @@ func (sh *strictHandler) HeadersExample(ctx echo.Context, params HeadersExampleP
 	} else if validResponse, ok := response.(HeadersExampleResponseObject); ok {
 		return validResponse.VisitHeadersExampleResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1135,7 +1135,7 @@ func (sh *strictHandler) UnionExample(ctx echo.Context) error {
 	} else if validResponse, ok := response.(UnionExampleResponseObject); ok {
 		return validResponse.VisitUnionExampleResponse(ctx.Response())
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }

--- a/internal/test/strict-server/fiber/server.gen.go
+++ b/internal/test/strict-server/fiber/server.gen.go
@@ -794,7 +794,7 @@ func (sh *strictHandler) JSONExample(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -821,7 +821,7 @@ func (sh *strictHandler) MultipartExample(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -873,7 +873,7 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -900,7 +900,7 @@ func (sh *strictHandler) ReservedGoKeywordParameters(ctx *fiber.Ctx, pType strin
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -931,7 +931,7 @@ func (sh *strictHandler) ReusableResponses(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -960,7 +960,7 @@ func (sh *strictHandler) TextExample(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -987,7 +987,7 @@ func (sh *strictHandler) UnknownExample(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1016,7 +1016,7 @@ func (sh *strictHandler) UnspecifiedContentType(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1047,7 +1047,7 @@ func (sh *strictHandler) URLEncodedExample(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1080,7 +1080,7 @@ func (sh *strictHandler) HeadersExample(ctx *fiber.Ctx, params HeadersExamplePar
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }
@@ -1111,7 +1111,7 @@ func (sh *strictHandler) UnionExample(ctx *fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	} else if response != nil {
-		return fmt.Errorf("Unexpected response type: %T", response)
+		return fmt.Errorf("unexpected response type: %T", response)
 	}
 	return nil
 }

--- a/internal/test/strict-server/gin/server.gen.go
+++ b/internal/test/strict-server/gin/server.gen.go
@@ -883,7 +883,7 @@ func (sh *strictHandler) JSONExample(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -915,7 +915,7 @@ func (sh *strictHandler) MultipartExample(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -983,7 +983,7 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1010,7 +1010,7 @@ func (sh *strictHandler) ReservedGoKeywordParameters(ctx *gin.Context, pType str
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1043,7 +1043,7 @@ func (sh *strictHandler) ReusableResponses(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1076,7 +1076,7 @@ func (sh *strictHandler) TextExample(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1103,7 +1103,7 @@ func (sh *strictHandler) UnknownExample(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1132,7 +1132,7 @@ func (sh *strictHandler) UnspecifiedContentType(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1168,7 +1168,7 @@ func (sh *strictHandler) URLEncodedExample(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1203,7 +1203,7 @@ func (sh *strictHandler) HeadersExample(ctx *gin.Context, params HeadersExampleP
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 
@@ -1236,7 +1236,7 @@ func (sh *strictHandler) UnionExample(ctx *gin.Context) {
 			ctx.Error(err)
 		}
 	} else if response != nil {
-		ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
 	}
 }
 

--- a/pkg/codegen/templates/strict/strict-echo.tmpl
+++ b/pkg/codegen/templates/strict/strict-echo.tmpl
@@ -80,7 +80,7 @@ type strictHandler struct {
         } else if validResponse, ok := response.({{$opid | ucFirst}}ResponseObject); ok {
             return validResponse.Visit{{$opid}}Response(ctx.Response())
         } else if response != nil {
-            return fmt.Errorf("Unexpected response type: %T", response)
+            return fmt.Errorf("unexpected response type: %T", response)
         }
         return nil
     }

--- a/pkg/codegen/templates/strict/strict-fiber.tmpl
+++ b/pkg/codegen/templates/strict/strict-fiber.tmpl
@@ -73,7 +73,7 @@ type strictHandler struct {
                 return fiber.NewError(fiber.StatusBadRequest, err.Error())
             }
         } else if response != nil {
-            return fmt.Errorf("Unexpected response type: %T", response)
+            return fmt.Errorf("unexpected response type: %T", response)
         }
         return nil
     }

--- a/pkg/codegen/templates/strict/strict-gin.tmpl
+++ b/pkg/codegen/templates/strict/strict-gin.tmpl
@@ -88,7 +88,7 @@ type strictHandler struct {
                 ctx.Error(err)
             }
         } else if response != nil {
-            ctx.Error(fmt.Errorf("Unexpected response type: %T", response))
+            ctx.Error(fmt.Errorf("unexpected response type: %T", response))
         }
     }
 {{end}}

--- a/pkg/codegen/templates/strict/strict-http.tmpl
+++ b/pkg/codegen/templates/strict/strict-http.tmpl
@@ -103,7 +103,7 @@ type strictHandler struct {
                 sh.options.ResponseErrorHandlerFunc(w, r, err)
             }
         } else if response != nil {
-            sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("Unexpected response type: %T", response))
+            sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
         }
     }
 {{end}}


### PR DESCRIPTION
As flagged by staticcheck ST1005, we are generating error strings that
are capitalised, which isn't recommended in Go.
