### PR TITLE
Build project with Go 1.20 and Go 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,17 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # perform matrix testing to give us an earlier insight into issues with different versions of supported major versions of Go
+      matrix:
+        # strategy is used to allow us to pin to a specific Go version, or use the version available in our `go.mod`
+        strategy: ['go-version']
+        version: [1.21]
+        include:
+          # pick up the Go version from the `go.mod`
+          - strategy: 'go-version-file'
+            version: 'go.mod'
     steps:
       - name: Check out source code
         uses: actions/checkout@v3
@@ -11,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.mod'
+          ${{ matrix.strategy }}: ${{ matrix.version }}
 
       - name: Test
         run: make test

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -4,6 +4,17 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # perform matrix testing to give us an earlier insight into issues with different versions of supported major versions of Go
+      matrix:
+        # strategy is used to allow us to pin to a specific Go version, or use the version available in our `go.mod`
+        strategy: ['go-version']
+        version: [1.21]
+        include:
+          # pick up the Go version from the `go.mod`
+          - strategy: 'go-version-file'
+            version: 'go.mod'
     steps:
       - name: Check out source code
         uses: actions/checkout@v3
@@ -11,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.mod'
+          ${{ matrix.strategy }}: ${{ matrix.version }}
 
       - name: Run `make generate`
         run: make generate

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,17 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # perform matrix testing to give us an earlier insight into issues with different versions of supported major versions of Go
+      matrix:
+        # strategy is used to allow us to pin to a specific Go version, or use the version available in our `go.mod`
+        strategy: ['go-version']
+        version: [1.21]
+        include:
+          # pick up the Go version from the `go.mod`
+          - strategy: 'go-version-file'
+            version: 'go.mod'
     steps:
       - name: Check out source code
         uses: actions/checkout@v3
@@ -11,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.mod'
+          ${{ matrix.strategy }}: ${{ matrix.version }}
 
       - name: Run `make lint-ci`
         run: make lint-ci

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -4,6 +4,17 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # perform matrix testing to give us an earlier insight into issues with different versions of supported major versions of Go
+      matrix:
+        # strategy is used to allow us to pin to a specific Go version, or use the version available in our `go.mod`
+        strategy: ['go-version']
+        version: [1.21]
+        include:
+          # pick up the Go version from the `go.mod`
+          - strategy: 'go-version-file'
+            version: 'go.mod'
     steps:
       - name: Check out source code
         uses: actions/checkout@v3
@@ -11,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.mod'
+          ${{ matrix.strategy }}: ${{ matrix.version }}
 
       - name: Install `tidied`
         run: go install gitlab.com/jamietanna/tidied@latest


### PR DESCRIPTION
As part of the upgrade to Go 1.21, the Go toolchain now requires the
`go` directive to match the maximum Go version in use in dependencies.

This leads to any transitive dependency on this library to result in a
requirement of the consuming project moving to Go 1.21.

Although in a lot of cases this may not be as problematic, it forces
consumers to migrate, which we don't need to do in this case.

As noted in #1221, dependencies on Fiber and Iris have caused Go
toolchain changes due to be required, which then requires consumers to
do the same.

By making sure we build across both the current venison and the next
version of Go - taking care to only support the two major Go versions in
use by the Go team - we can hopefully pick up on issues like this
sooner, albeit #1221 was raised super speedily!

This is a slightly more complex setup than just specifying the version
manually, but to avoid the risk of not updating it in all the places, we
can at a minimum use the `go.mod` version for the current targeted
version.

---

Will merge this as-is before #1249, to make sure we have a known "bad" build on `master`, then we can have #1249 fix it.