### PR TITLE
Add http.Request parameter to the error handler

### DIFF
--- a/pkg/chi-middleware/oapi_validate.go
+++ b/pkg/chi-middleware/oapi_validate.go
@@ -17,7 +17,7 @@ import (
 )
 
 // ErrorHandler is called when there is an error in validation
-type ErrorHandler func(w http.ResponseWriter, message string, statusCode int)
+type ErrorHandler func(w http.ResponseWriter, r *http.Request, message string, statusCode int)
 
 // MultiErrorHandler is called when oapi returns a MultiError type
 type MultiErrorHandler func(openapi3.MultiError) (int, error)
@@ -55,7 +55,7 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func
 			// validate request
 			if statusCode, err := validateRequest(r, router, options); err != nil {
 				if options != nil && options.ErrorHandler != nil {
-					options.ErrorHandler(w, err.Error(), statusCode)
+					options.ErrorHandler(w, r, err.Error(), statusCode)
 				} else {
 					http.Error(w, err.Error(), statusCode)
 				}

--- a/pkg/chi-middleware/oapi_validate_test.go
+++ b/pkg/chi-middleware/oapi_validate_test.go
@@ -264,7 +264,7 @@ func TestOapiRequestValidatorWithOptions(t *testing.T) {
 	// Set up an authenticator to check authenticated function. It will allow
 	// access to "someScope", but disallow others.
 	options := Options{
-		ErrorHandler: func(w http.ResponseWriter, message string, statusCode int) {
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, message string, statusCode int) {
 			http.Error(w, "test: "+message, statusCode)
 		},
 		Options: openapi3filter.Options{


### PR DESCRIPTION
The reason for this change is the HTTP request has information that the error handler can use.
In our project we use the path of the HTTP request in the error handler.