### PR TITLE
fix: type collisions on context.WithValue

### DIFF
--- a/examples/authenticated-api/echo/api/api.gen.go
+++ b/examples/authenticated-api/echo/api/api.gen.go
@@ -20,8 +20,11 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// contextKey provides a type for use with context.WithValue.
+type contextKey string
+
 const (
-	BearerAuthScopes = "BearerAuth.Scopes"
+	BearerAuthScopes contextKey = "BearerAuth.Scopes"
 )
 
 // Error defines model for Error.

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -14,8 +14,11 @@ import (
 	"strings"
 )
 
+// contextKey provides a type for use with context.WithValue.
+type contextKey string
+
 const (
-	OpenIdScopes = "OpenId.Scopes"
+	OpenIdScopes contextKey = "OpenId.Scopes"
 )
 
 // SchemaObject defines model for SchemaObject.

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -24,8 +24,11 @@ import (
 	"github.com/oapi-codegen/runtime"
 )
 
+// contextKey provides a type for use with context.WithValue.
+type contextKey string
+
 const (
-	Access_tokenScopes = "access_token.Scopes"
+	Access_tokenScopes contextKey = "access_token.Scopes"
 )
 
 // Defines values for EnumInObjInArrayVal.

--- a/pkg/codegen/templates/constants.tmpl
+++ b/pkg/codegen/templates/constants.tmpl
@@ -1,7 +1,11 @@
 {{- if gt (len .SecuritySchemeProviderNames) 0 }}
+
+// contextKey provides a type for use with context.WithValue.
+type contextKey string
+
 const (
 {{range $ProviderName := .SecuritySchemeProviderNames}}
-    {{- $ProviderName | sanitizeGoIdentity | ucFirst}}Scopes = "{{$ProviderName}}.Scopes"
+    {{- $ProviderName | sanitizeGoIdentity | ucFirst}}Scopes contextKey = "{{$ProviderName}}.Scopes"
 {{end}}
 )
 {{end}}


### PR DESCRIPTION
To avoid type collisions when using `context.WithValue` I've added a contextKey type to mitigate this issue.

fixes: #1200