### PR TITLE
Replace + deprecate `testutil`

### DIFF
--- a/examples/authenticated-api/echo/server/server_test.go
+++ b/examples/authenticated-api/echo/server/server_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/deepmap/oapi-codegen/examples/authenticated-api/echo/api"
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
+	"github.com/oapi-codegen/testutil"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/examples/authenticated-api/echo/server/server_test.go
+++ b/examples/authenticated-api/echo/server/server_test.go
@@ -34,21 +34,21 @@ func TestAPI(t *testing.T) {
 	t.Logf("writer jwt: %s", string(writerJWT))
 
 	// ListPets should return 403 forbidden without credentials
-	response := testutil.NewRequest().Get("/things").Go(t, e)
+	response := testutil.NewRequest().Get("/things").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusForbidden, response.Code())
 
 	// Using the writer JWT should allow us to insert a thing.
 	response = testutil.NewRequest().Post("/things").
 		WithJWSAuth(string(writerJWT)).
 		WithAcceptJson().
-		WithJsonBody(api.Thing{Name: "Thing 1"}).Go(t, e)
+		WithJsonBody(api.Thing{Name: "Thing 1"}).GoWithHTTPHandler(t, e)
 	require.Equal(t, http.StatusCreated, response.Code())
 
 	// Using the reader JWT should forbid inserting a thing.
 	response = testutil.NewRequest().Post("/things").
 		WithJWSAuth(string(readerJWT)).
 		WithAcceptJson().
-		WithJsonBody(api.Thing{Name: "Thing 2"}).Go(t, e)
+		WithJsonBody(api.Thing{Name: "Thing 2"}).GoWithHTTPHandler(t, e)
 	require.Equal(t, http.StatusForbidden, response.Code())
 
 	// Both JWT's should allow reading the list of things.
@@ -56,7 +56,7 @@ func TestAPI(t *testing.T) {
 	for _, jwt := range jwts {
 		response := testutil.NewRequest().Get("/things").
 			WithJWSAuth(jwt).
-			WithAcceptJson().Go(t, e)
+			WithAcceptJson().GoWithHTTPHandler(t, e)
 		assert.Equal(t, http.StatusOK, response.Code())
 	}
 }

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/oapi-codegen/iris-middleware v1.0.4
 	github.com/oapi-codegen/nethttp-middleware v1.0.1
 	github.com/oapi-codegen/runtime v1.0.0
+	github.com/oapi-codegen/testutil v1.0.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -180,6 +180,8 @@ github.com/oapi-codegen/nethttp-middleware v1.0.1 h1:ZWvwfnMU0eloHX1VEJmQscQm374
 github.com/oapi-codegen/nethttp-middleware v1.0.1/go.mod h1:P7xtAvpoqNB+5obR9qRCeefH7YlXWSK3KgPs/9WB8tE=
 github.com/oapi-codegen/runtime v1.0.0 h1:P4rqFX5fMFWqRzY9M/3YF9+aPSPPB06IzP2P7oOxrWo=
 github.com/oapi-codegen/runtime v1.0.0/go.mod h1:LmCUMQuPB4M/nLXilQXhHw+BLZdDb18B34OO356yJ/A=
+github.com/oapi-codegen/testutil v1.0.0 h1:1GI2IiMMLh2vDHr1OkNacaYU/VaApKdcmfgl4aeXAa8=
+github.com/oapi-codegen/testutil v1.0.0/go.mod h1:ttCaYbHvJtHuiyeBF0tPIX+4uhEPTeizXKx28okijLw=
 github.com/pelletier/go-toml/v2 v2.0.9 h1:uH2qQXheeefCCkuBBSLi7jCiSmj3VRh2+Goq2N7Xxu0=
 github.com/pelletier/go-toml/v2 v2.0.9/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/perimeterx/marshmallow v1.1.4/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=

--- a/examples/petstore-expanded/chi/petstore_test.go
+++ b/examples/petstore-expanded/chi/petstore_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/deepmap/oapi-codegen/examples/petstore-expanded/chi/api"
 	middleware "github.com/oapi-codegen/nethttp-middleware"
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
+	"github.com/oapi-codegen/testutil"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/examples/petstore-expanded/echo/petstore_test.go
+++ b/examples/petstore-expanded/echo/petstore_test.go
@@ -64,7 +64,7 @@ func TestPetStore(t *testing.T) {
 		Name: "Spot",
 		Tag:  &tag,
 	}
-	result := testutil.NewRequest().Post("/pets").WithJsonBody(newPet).Go(t, e)
+	result := testutil.NewRequest().Post("/pets").WithJsonBody(newPet).GoWithHTTPHandler(t, e)
 	// We expect 201 code on successful pet insertion
 	assert.Equal(t, http.StatusCreated, result.Code())
 
@@ -80,14 +80,14 @@ func TestPetStore(t *testing.T) {
 	petId := resultPet.Id
 
 	// Test the getter function.
-	result = testutil.NewRequest().Get(fmt.Sprintf("/pets/%d", petId)).WithAcceptJson().Go(t, e)
+	result = testutil.NewRequest().Get(fmt.Sprintf("/pets/%d", petId)).WithAcceptJson().GoWithHTTPHandler(t, e)
 	var resultPet2 models.Pet
 	err = result.UnmarshalBodyToObject(&resultPet2)
 	assert.NoError(t, err, "error getting pet")
 	assert.Equal(t, resultPet, resultPet2)
 
 	// We should get a 404 on invalid ID
-	result = testutil.NewRequest().Get("/pets/27179095781").WithAcceptJson().Go(t, e)
+	result = testutil.NewRequest().Get("/pets/27179095781").WithAcceptJson().GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusNotFound, result.Code())
 	var petError models.Error
 	err = result.UnmarshalBodyToObject(&petError)
@@ -100,7 +100,7 @@ func TestPetStore(t *testing.T) {
 		Name: "Fido",
 		Tag:  &tag,
 	}
-	result = testutil.NewRequest().Post("/pets").WithJsonBody(newPet).Go(t, e)
+	result = testutil.NewRequest().Post("/pets").WithJsonBody(newPet).GoWithHTTPHandler(t, e)
 	// We expect 201 code on successful pet insertion
 	assert.Equal(t, http.StatusCreated, result.Code())
 	// We should have gotten a response from the server with the new pet. Make
@@ -110,7 +110,7 @@ func TestPetStore(t *testing.T) {
 	petId2 := resultPet.Id
 
 	// Now, list all pets, we should have two
-	result = testutil.NewRequest().Get("/pets").WithAcceptJson().Go(t, e)
+	result = testutil.NewRequest().Get("/pets").WithAcceptJson().GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	var petList []models.Pet
 	err = result.UnmarshalBodyToObject(&petList)
@@ -119,7 +119,7 @@ func TestPetStore(t *testing.T) {
 
 	// Filter pets by tag, we should have 1
 	petList = nil
-	result = testutil.NewRequest().Get("/pets?tags=TagOfFido").WithAcceptJson().Go(t, e)
+	result = testutil.NewRequest().Get("/pets?tags=TagOfFido").WithAcceptJson().GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	err = result.UnmarshalBodyToObject(&petList)
 	assert.NoError(t, err, "error getting response", err)
@@ -127,28 +127,28 @@ func TestPetStore(t *testing.T) {
 
 	// Filter pets by non existent tag, we should have 0
 	petList = nil
-	result = testutil.NewRequest().Get("/pets?tags=NotExists").WithAcceptJson().Go(t, e)
+	result = testutil.NewRequest().Get("/pets?tags=NotExists").WithAcceptJson().GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	err = result.UnmarshalBodyToObject(&petList)
 	assert.NoError(t, err, "error getting response", err)
 	assert.Equal(t, 0, len(petList))
 
 	// Let's delete non-existent pet
-	result = testutil.NewRequest().Delete("/pets/7").Go(t, e)
+	result = testutil.NewRequest().Delete("/pets/7").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusNotFound, result.Code())
 	err = result.UnmarshalBodyToObject(&petError)
 	assert.NoError(t, err, "error unmarshaling PetError")
 	assert.Equal(t, int32(http.StatusNotFound), petError.Code)
 
 	// Now, delete both real pets
-	result = testutil.NewRequest().Delete(fmt.Sprintf("/pets/%d", petId)).Go(t, e)
+	result = testutil.NewRequest().Delete(fmt.Sprintf("/pets/%d", petId)).GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusNoContent, result.Code())
-	result = testutil.NewRequest().Delete(fmt.Sprintf("/pets/%d", petId2)).Go(t, e)
+	result = testutil.NewRequest().Delete(fmt.Sprintf("/pets/%d", petId2)).GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusNoContent, result.Code())
 
 	// Should have no pets left.
 	petList = nil
-	result = testutil.NewRequest().Get("/pets").WithAcceptJson().Go(t, e)
+	result = testutil.NewRequest().Get("/pets").WithAcceptJson().GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	err = result.UnmarshalBodyToObject(&petList)
 	assert.NoError(t, err, "error getting response", err)

--- a/examples/petstore-expanded/echo/petstore_test.go
+++ b/examples/petstore-expanded/echo/petstore_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/deepmap/oapi-codegen/examples/petstore-expanded/echo/api"
 	"github.com/deepmap/oapi-codegen/examples/petstore-expanded/echo/api/models"
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
+	"github.com/oapi-codegen/testutil"
 	"github.com/labstack/echo/v4"
 	echoMiddleware "github.com/labstack/echo/v4/middleware"
 	middleware "github.com/oapi-codegen/echo-middleware"

--- a/examples/petstore-expanded/gin/petstore_test.go
+++ b/examples/petstore-expanded/gin/petstore_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/deepmap/oapi-codegen/examples/petstore-expanded/gin/api"
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
+	"github.com/oapi-codegen/testutil"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/examples/petstore-expanded/gorilla/petstore_test.go
+++ b/examples/petstore-expanded/gorilla/petstore_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/deepmap/oapi-codegen/examples/petstore-expanded/gorilla/api"
 	middleware "github.com/oapi-codegen/nethttp-middleware"
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
+	"github.com/oapi-codegen/testutil"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/examples/petstore-expanded/iris/petstore_test.go
+++ b/examples/petstore-expanded/iris/petstore_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/deepmap/oapi-codegen/examples/petstore-expanded/iris/api"
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
+	"github.com/oapi-codegen/testutil"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/examples/petstore-expanded/strict/petstore_test.go
+++ b/examples/petstore-expanded/strict/petstore_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/deepmap/oapi-codegen/examples/petstore-expanded/strict/api"
 	middleware "github.com/oapi-codegen/nethttp-middleware"
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
+	"github.com/oapi-codegen/testutil"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/uuid v1.3.1
 	github.com/kataras/iris/v12 v12.2.6-0.20230908161203-24ba4e8933b9
 	github.com/labstack/echo/v4 v4.11.1
+	github.com/oapi-codegen/testutil v1.0.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/text v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/oapi-codegen/testutil v1.0.0 h1:1GI2IiMMLh2vDHr1OkNacaYU/VaApKdcmfgl4aeXAa8=
+github.com/oapi-codegen/testutil v1.0.0/go.mod h1:ttCaYbHvJtHuiyeBF0tPIX+4uhEPTeizXKx28okijLw=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
 github.com/perimeterx/marshmallow v1.1.4 h1:pZLDH9RjlLGGorbXhcaQLhfuV0pFMNfPO55FuFkxqLw=

--- a/internal/test/go.mod
+++ b/internal/test/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/kataras/iris/v12 v12.2.6-0.20230908161203-24ba4e8933b9
 	github.com/labstack/echo/v4 v4.11.1
 	github.com/oapi-codegen/runtime v1.0.0
+	github.com/oapi-codegen/testutil v1.0.0
 	github.com/stretchr/testify v1.8.4
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/internal/test/go.sum
+++ b/internal/test/go.sum
@@ -154,6 +154,8 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwd
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oapi-codegen/runtime v1.0.0 h1:P4rqFX5fMFWqRzY9M/3YF9+aPSPPB06IzP2P7oOxrWo=
 github.com/oapi-codegen/runtime v1.0.0/go.mod h1:LmCUMQuPB4M/nLXilQXhHw+BLZdDb18B34OO356yJ/A=
+github.com/oapi-codegen/testutil v1.0.0 h1:1GI2IiMMLh2vDHr1OkNacaYU/VaApKdcmfgl4aeXAa8=
+github.com/oapi-codegen/testutil v1.0.0/go.mod h1:ttCaYbHvJtHuiyeBF0tPIX+4uhEPTeizXKx28okijLw=
 github.com/pelletier/go-toml/v2 v2.0.9 h1:uH2qQXheeefCCkuBBSLi7jCiSmj3VRh2+Goq2N7Xxu0=
 github.com/pelletier/go-toml/v2 v2.0.9/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/perimeterx/marshmallow v1.1.4/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=

--- a/internal/test/parameters/parameters_test.go
+++ b/internal/test/parameters/parameters_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
+	"github.com/oapi-codegen/testutil"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/stretchr/testify/assert"

--- a/internal/test/parameters/parameters_test.go
+++ b/internal/test/parameters/parameters_test.go
@@ -267,7 +267,7 @@ func TestParameterBinding(t *testing.T) {
 
 	// Check the passthrough case
 	//  (GET /passThrough/{param})
-	result := testutil.NewRequest().Get("/passThrough/some%20string").Go(t, e)
+	result := testutil.NewRequest().Get("/passThrough/some%20string").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	require.NotNil(t, ts.passThrough)
 	assert.EqualValues(t, "some string", *ts.passThrough)
@@ -278,93 +278,93 @@ func TestParameterBinding(t *testing.T) {
 	marshaledComplexObject, err := json.Marshal(expectedComplexObject)
 	assert.NoError(t, err)
 	q := fmt.Sprintf("/contentObject/%s", string(marshaledComplexObject))
-	result = testutil.NewRequest().Get(q).Go(t, e)
+	result = testutil.NewRequest().Get(q).GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedComplexObject, ts.complexObject)
 	ts.reset()
 
 	//  (GET /labelExplodeArray/{.param*})
-	result = testutil.NewRequest().Get("/labelExplodeArray/.3.4.5").Go(t, e)
+	result = testutil.NewRequest().Get("/labelExplodeArray/.3.4.5").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	//  (GET /labelExplodeObject/{.param*})
-	result = testutil.NewRequest().Get("/labelExplodeObject/.role=admin.firstName=Alex").Go(t, e)
+	result = testutil.NewRequest().Get("/labelExplodeObject/.role=admin.firstName=Alex").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	//  (GET /labelNoExplodeArray/{.param})
-	result = testutil.NewRequest().Get("/labelNoExplodeArray/.3,4,5").Go(t, e)
+	result = testutil.NewRequest().Get("/labelNoExplodeArray/.3,4,5").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	//  (GET /labelNoExplodeObject/{.param})
-	result = testutil.NewRequest().Get("/labelNoExplodeObject/.role,admin,firstName,Alex").Go(t, e)
+	result = testutil.NewRequest().Get("/labelNoExplodeObject/.role,admin,firstName,Alex").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	//  (GET /matrixExplodeArray/{.param*})
 	uri := "/matrixExplodeArray/;id=3;id=4;id=5"
-	result = testutil.NewRequest().Get(uri).Go(t, e)
+	result = testutil.NewRequest().Get(uri).GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	//  (GET /matrixExplodeObject/{.param*})
 	uri = "/matrixExplodeObject/;role=admin;firstName=Alex"
-	result = testutil.NewRequest().Get(uri).Go(t, e)
+	result = testutil.NewRequest().Get(uri).GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	//  (GET /matrixNoExplodeArray/{.param})
-	result = testutil.NewRequest().Get("/matrixNoExplodeArray/;id=3,4,5").Go(t, e)
+	result = testutil.NewRequest().Get("/matrixNoExplodeArray/;id=3,4,5").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	//  (GET /matrixNoExplodeObject/{.param})
-	result = testutil.NewRequest().Get("/matrixNoExplodeObject/;id=role,admin,firstName,Alex").Go(t, e)
+	result = testutil.NewRequest().Get("/matrixNoExplodeObject/;id=role,admin,firstName,Alex").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	//  (GET /simpleExplodeArray/{param*})
-	result = testutil.NewRequest().Get("/simpleExplodeArray/3,4,5").Go(t, e)
+	result = testutil.NewRequest().Get("/simpleExplodeArray/3,4,5").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	//  (GET /simpleExplodeObject/{param*})
-	result = testutil.NewRequest().Get("/simpleExplodeObject/role=admin,firstName=Alex").Go(t, e)
+	result = testutil.NewRequest().Get("/simpleExplodeObject/role=admin,firstName=Alex").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	//  (GET /simpleNoExplodeArray/{param})
-	result = testutil.NewRequest().Get("/simpleNoExplodeArray/3,4,5").Go(t, e)
+	result = testutil.NewRequest().Get("/simpleNoExplodeArray/3,4,5").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	//  (GET /simpleNoExplodeObject/{param})
-	result = testutil.NewRequest().Get("/simpleNoExplodeObject/role,admin,firstName,Alex").Go(t, e)
+	result = testutil.NewRequest().Get("/simpleNoExplodeObject/role,admin,firstName,Alex").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	//  (GET /simplePrimitive/{param})
-	result = testutil.NewRequest().Get("/simplePrimitive/5").Go(t, e)
+	result = testutil.NewRequest().Get("/simplePrimitive/5").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedPrimitive, ts.primitive)
 	ts.reset()
 
 	//  (GET /startingWithNumber/{1param})
-	result = testutil.NewRequest().Get("/startingWithNumber/foo").Go(t, e)
+	result = testutil.NewRequest().Get("/startingWithNumber/foo").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedN1Param, ts.n1param)
 	ts.reset()
@@ -373,56 +373,56 @@ func TestParameterBinding(t *testing.T) {
 	//  (GET /queryForm)
 
 	// unexploded array
-	result = testutil.NewRequest().Get("/queryForm?a=3,4,5").Go(t, e)
+	result = testutil.NewRequest().Get("/queryForm?a=3,4,5").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	// exploded array
-	result = testutil.NewRequest().Get("/queryForm?ea=3&ea=4&ea=5").Go(t, e)
+	result = testutil.NewRequest().Get("/queryForm?ea=3&ea=4&ea=5").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	// unexploded object
-	result = testutil.NewRequest().Get("/queryForm?o=role,admin,firstName,Alex").Go(t, e)
+	result = testutil.NewRequest().Get("/queryForm?o=role,admin,firstName,Alex").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	// exploded object
-	result = testutil.NewRequest().Get("/queryForm?role=admin&firstName=Alex").Go(t, e)
+	result = testutil.NewRequest().Get("/queryForm?role=admin&firstName=Alex").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	// exploded primitive
-	result = testutil.NewRequest().Get("/queryForm?ep=5").Go(t, e)
+	result = testutil.NewRequest().Get("/queryForm?ep=5").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedPrimitive, ts.primitive)
 	ts.reset()
 
 	// unexploded primitive
-	result = testutil.NewRequest().Get("/queryForm?p=5").Go(t, e)
+	result = testutil.NewRequest().Get("/queryForm?p=5").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedPrimitive, ts.primitive)
 	ts.reset()
 
 	// primitive string within reserved char, i.e., ';' escaped to '%3B'
-	result = testutil.NewRequest().Get("/queryForm?ps=123%3B456").Go(t, e)
+	result = testutil.NewRequest().Get("/queryForm?ps=123%3B456").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedPrimitiveString, ts.primitiveString)
 	ts.reset()
 
 	// complex object
 	q = fmt.Sprintf("/queryForm?co=%s", string(marshaledComplexObject))
-	result = testutil.NewRequest().Get(q).Go(t, e)
+	result = testutil.NewRequest().Get(q).GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedComplexObject, ts.complexObject)
 	ts.reset()
 
 	// starting with number
-	result = testutil.NewRequest().Get("/queryForm?1s=foo").Go(t, e)
+	result = testutil.NewRequest().Get("/queryForm?1s=foo").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedN1Param, ts.n1param)
 	ts.reset()
@@ -430,7 +430,7 @@ func TestParameterBinding(t *testing.T) {
 	// complex object via deepObject
 	do := `deepObj[Id]=12345&deepObj[IsAdmin]=true&deepObj[Object][firstName]=Alex&deepObj[Object][role]=admin`
 	q = "/queryDeepObject?" + do
-	result = testutil.NewRequest().Get(q).Go(t, e)
+	result = testutil.NewRequest().Get(q).GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedComplexObject, ts.complexObject)
 	ts.reset()
@@ -438,80 +438,80 @@ func TestParameterBinding(t *testing.T) {
 	// ---------------------- Test Header Query Parameters --------------------
 
 	// unexploded header primitive.
-	result = testutil.NewRequest().WithHeader("X-Primitive", "5").Get("/header").Go(t, e)
+	result = testutil.NewRequest().WithHeader("X-Primitive", "5").Get("/header").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedPrimitive, ts.primitive)
 	ts.reset()
 
 	// exploded header primitive.
-	result = testutil.NewRequest().WithHeader("X-Primitive-Exploded", "5").Get("/header").Go(t, e)
+	result = testutil.NewRequest().WithHeader("X-Primitive-Exploded", "5").Get("/header").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedPrimitive, ts.primitive)
 	ts.reset()
 
 	// unexploded header array
-	result = testutil.NewRequest().WithHeader("X-Array", "3,4,5").Get("/header").Go(t, e)
+	result = testutil.NewRequest().WithHeader("X-Array", "3,4,5").Get("/header").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	// exploded header array
-	result = testutil.NewRequest().WithHeader("X-Array-Exploded", "3,4,5").Get("/header").Go(t, e)
+	result = testutil.NewRequest().WithHeader("X-Array-Exploded", "3,4,5").Get("/header").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	// unexploded header object
 	result = testutil.NewRequest().WithHeader("X-Object",
-		"role,admin,firstName,Alex").Get("/header").Go(t, e)
+		"role,admin,firstName,Alex").Get("/header").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	// exploded header object
 	result = testutil.NewRequest().WithHeader("X-Object-Exploded",
-		"role=admin,firstName=Alex").Get("/header").Go(t, e)
+		"role=admin,firstName=Alex").Get("/header").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	// complex object
 	result = testutil.NewRequest().WithHeader("X-Complex-Object",
-		string(marshaledComplexObject)).Get("/header").Go(t, e)
+		string(marshaledComplexObject)).Get("/header").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedComplexObject, ts.complexObject)
 	ts.reset()
 
 	// starting with number
 	result = testutil.NewRequest().WithHeader("1-Starting-With-Number",
-		"foo").Get("/header").Go(t, e)
+		"foo").Get("/header").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedN1Param, ts.n1param)
 	ts.reset()
 
 	// ------------------------- Test Cookie Parameters ------------------------
-	result = testutil.NewRequest().WithCookieNameValue("p", "5").Get("/cookie").Go(t, e)
+	result = testutil.NewRequest().WithCookieNameValue("p", "5").Get("/cookie").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedPrimitive, ts.primitive)
 	ts.reset()
 
-	result = testutil.NewRequest().WithCookieNameValue("ep", "5").Get("/cookie").Go(t, e)
+	result = testutil.NewRequest().WithCookieNameValue("ep", "5").Get("/cookie").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedPrimitive, ts.primitive)
 	ts.reset()
 
-	result = testutil.NewRequest().WithCookieNameValue("a", "3,4,5").Get("/cookie").Go(t, e)
+	result = testutil.NewRequest().WithCookieNameValue("a", "3,4,5").Get("/cookie").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	result = testutil.NewRequest().WithCookieNameValue(
-		"o", "role,admin,firstName,Alex").Get("/cookie").Go(t, e)
+		"o", "role,admin,firstName,Alex").Get("/cookie").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
-	result = testutil.NewRequest().WithCookieNameValue("1s", "foo").Get("/cookie").Go(t, e)
+	result = testutil.NewRequest().WithCookieNameValue("1s", "foo").Get("/cookie").GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
 	assert.EqualValues(t, &expectedN1Param, ts.n1param)
 	ts.reset()

--- a/internal/test/strict-server/strict_test.go
+++ b/internal/test/strict-server/strict_test.go
@@ -28,7 +28,7 @@ import (
 
 	// "github.com/deepmap/oapi-codegen/pkg/runtime"
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
+	"github.com/oapi-codegen/testutil"
 )
 
 func TestIrisServer(t *testing.T) {

--- a/pkg/chi-middleware/oapi_validate_test.go
+++ b/pkg/chi-middleware/oapi_validate_test.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
+	"github.com/oapi-codegen/testutil"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/go-chi/chi/v5"

--- a/pkg/gin-middleware/oapi_validate_test.go
+++ b/pkg/gin-middleware/oapi_validate_test.go
@@ -25,7 +25,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
+	"github.com/oapi-codegen/testutil"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/gin-gonic/gin"

--- a/pkg/iris-middleware/oapi_validate_test.go
+++ b/pkg/iris-middleware/oapi_validate_test.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
+	"github.com/oapi-codegen/testutil"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/kataras/iris/v12"

--- a/pkg/middleware/oapi_validate_test.go
+++ b/pkg/middleware/oapi_validate_test.go
@@ -24,7 +24,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/pkg/testutil"
+	"github.com/oapi-codegen/testutil"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/labstack/echo/v4"

--- a/pkg/testutil/request_helpers.go
+++ b/pkg/testutil/request_helpers.go
@@ -21,7 +21,7 @@ package testutil
 //   var response ResponseBody
 //   t is *testing.T, from a unit test
 //   e is *echo.Echo
-//   response := NewRequest().Post("/path").WithJsonBody(body).Go(t, e)
+//   response := NewRequest().Post("/path").WithJsonBody(body).GoWithHTTPHandler(t, e)
 //   err := response.UnmarshalBodyToObject(&response)
 import (
 	"bytes"

--- a/pkg/testutil/request_helpers.go
+++ b/pkg/testutil/request_helpers.go
@@ -36,6 +36,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#NewRequest
 func NewRequest() *RequestBuilder {
 	return &RequestBuilder{
 		Headers: make(map[string]string),
@@ -43,6 +44,7 @@ func NewRequest() *RequestBuilder {
 }
 
 // RequestBuilder caches request settings as we build up the request.
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder
 type RequestBuilder struct {
 	Method  string
 	Path    string
@@ -53,65 +55,79 @@ type RequestBuilder struct {
 }
 
 // WithMethod sets the method and path
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.WithMethod
 func (r *RequestBuilder) WithMethod(method string, path string) *RequestBuilder {
 	r.Method = method
 	r.Path = path
 	return r
 }
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.Get
 func (r *RequestBuilder) Get(path string) *RequestBuilder {
 	return r.WithMethod("GET", path)
 }
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.Post
 func (r *RequestBuilder) Post(path string) *RequestBuilder {
 	return r.WithMethod("POST", path)
 }
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.Put
 func (r *RequestBuilder) Put(path string) *RequestBuilder {
 	return r.WithMethod("PUT", path)
 }
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.Patch
 func (r *RequestBuilder) Patch(path string) *RequestBuilder {
 	return r.WithMethod("PATCH", path)
 }
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.Delete
 func (r *RequestBuilder) Delete(path string) *RequestBuilder {
 	return r.WithMethod("DELETE", path)
 }
 
 // WithHeader sets a header
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.WithHeader
 func (r *RequestBuilder) WithHeader(header, value string) *RequestBuilder {
 	r.Headers[header] = value
 	return r
 }
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.WithJWSAuth
 func (r *RequestBuilder) WithJWSAuth(jws string) *RequestBuilder {
 	r.Headers["Authorization"] = "Bearer " + jws
 	return r
 }
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.WithHost
 func (r *RequestBuilder) WithHost(value string) *RequestBuilder {
 	return r.WithHeader("Host", value)
 }
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.WithContentType
 func (r *RequestBuilder) WithContentType(value string) *RequestBuilder {
 	return r.WithHeader("Content-Type", value)
 }
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.WithJsonContentType
 func (r *RequestBuilder) WithJsonContentType() *RequestBuilder {
 	return r.WithContentType("application/json")
 }
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.WithAccept
 func (r *RequestBuilder) WithAccept(value string) *RequestBuilder {
 	return r.WithHeader("Accept", value)
 }
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.WithAcceptJson
 func (r *RequestBuilder) WithAcceptJson() *RequestBuilder {
 	return r.WithAccept("application/json")
 }
 
 // Request body operations
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.WithBody
 func (r *RequestBuilder) WithBody(body []byte) *RequestBuilder {
 	r.Body = body
 	return r
@@ -119,6 +135,7 @@ func (r *RequestBuilder) WithBody(body []byte) *RequestBuilder {
 
 // WithJsonBody takes an object as input, marshals it to JSON, and sends it
 // as the body with Content-Type: application/json
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.WithJsonBody
 func (r *RequestBuilder) WithJsonBody(obj interface{}) *RequestBuilder {
 	var err error
 	r.Body, err = json.Marshal(obj)
@@ -129,17 +146,20 @@ func (r *RequestBuilder) WithJsonBody(obj interface{}) *RequestBuilder {
 }
 
 // WithCookie sets a cookie
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.WithCookie
 func (r *RequestBuilder) WithCookie(c *http.Cookie) *RequestBuilder {
 	r.Cookies = append(r.Cookies, c)
 	return r
 }
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.WithCookieNameValue
 func (r *RequestBuilder) WithCookieNameValue(name, value string) *RequestBuilder {
 	return r.WithCookie(&http.Cookie{Name: name, Value: value})
 }
 
 // GoWithHTTPHandler performs the request, it takes a pointer to a testing context
 // to print messages, and a http handler for request handling.
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#GoWithHTTPHandler
 func (r *RequestBuilder) GoWithHTTPHandler(t *testing.T, handler http.Handler) *CompletedRequest {
 	if r.Error != nil {
 		// Fail the test if we had an error
@@ -172,12 +192,14 @@ func (r *RequestBuilder) GoWithHTTPHandler(t *testing.T, handler http.Handler) *
 
 // Go performs the request, it takes a pointer to a testing context
 // to print messages, and a pointer to an echo context for request handling.
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RequestBuilder.GoWithHTTPHandler
 func (r *RequestBuilder) Go(t *testing.T, e *echo.Echo) *CompletedRequest {
 	return r.GoWithHTTPHandler(t, e)
 }
 
 // CompletedRequest is the result of calling Go() on the request builder. We're wrapping the
 // ResponseRecorder with some nice helper functions.
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#CompletedRequest
 type CompletedRequest struct {
 	Recorder *httptest.ResponseRecorder
 
@@ -186,12 +208,14 @@ type CompletedRequest struct {
 	Strict bool
 }
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#CompletedRequest.DisallowUnknownFields
 func (c *CompletedRequest) DisallowUnknownFields() {
 	c.Strict = true
 }
 
 // UnmarshalBodyToObject takes a destination object as input, and unmarshals the object
 // in the response based on the Content-Type header.
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#CompletedRequest.UnmarshalBodyToObject
 func (c *CompletedRequest) UnmarshalBodyToObject(obj interface{}) error {
 	ctype := c.Recorder.Header().Get("Content-Type")
 
@@ -208,11 +232,13 @@ func (c *CompletedRequest) UnmarshalBodyToObject(obj interface{}) error {
 
 // UnmarshalJsonToObject assumes that the response contains JSON and unmarshals it
 // into the specified object.
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#CompletedRequest.UnmarshalJsonToObject
 func (c *CompletedRequest) UnmarshalJsonToObject(obj interface{}) error {
 	return json.Unmarshal(c.Recorder.Body.Bytes(), obj)
 }
 
 // Code is a shortcut for response code
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#CompletedRequest.Code
 func (c *CompletedRequest) Code() int {
 	return c.Recorder.Code
 }

--- a/pkg/testutil/response_handlers.go
+++ b/pkg/testutil/response_handlers.go
@@ -17,8 +17,10 @@ var (
 	knownHandlers   map[string]ResponseHandler
 )
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#ResponseHandler
 type ResponseHandler func(contentType string, raw io.Reader, obj interface{}, strict bool) error
 
+// Deprecated: This has been replaced by github.com/oapi-codegen/testutil#RegisterResponseHandler
 func RegisterResponseHandler(mime string, handler ResponseHandler) {
 	knownHandlersMu.Lock()
 	defer knownHandlersMu.Unlock()


### PR DESCRIPTION
- Replace Echo-specific handler call
- Migrate to separate `testutil` package
- Add deprecation notice for `testutil`

As part of a review towards #1309, we noticed in #1310 that `testutil` would also be best to deprecate + replace with an external module.
