### PR TITLE
Fix /pets endpoint in examples returning null when there's no pet

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Short example:
 ```go
 type PetStoreImpl struct {}
 func (*PetStoreImpl) GetPets(ctx context.Context, request GetPetsRequestObject) (GetPetsResponseObject, error) {
-    var result []Pet
+    var result []Pet = make([]Pet, 0)
 	// Implement me
     return GetPets200JSONResponse(result), nil
 }

--- a/examples/petstore-expanded/chi/api/petstore.go
+++ b/examples/petstore-expanded/chi/api/petstore.go
@@ -42,7 +42,8 @@ func (p *PetStore) FindPets(w http.ResponseWriter, r *http.Request, params FindP
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
-	var result []Pet
+	// Initialize result using make so it doesn't default to nil
+	var result []Pet = make([]Pet, 0)
 
 	for _, pet := range p.Pets {
 		if params.Tags != nil {

--- a/examples/petstore-expanded/chi/petstore_test.go
+++ b/examples/petstore-expanded/chi/petstore_test.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/deepmap/oapi-codegen/v2/examples/petstore-expanded/chi/api"
+	"github.com/go-chi/chi/v5"
 	middleware "github.com/oapi-codegen/nethttp-middleware"
 	"github.com/oapi-codegen/testutil"
-	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -96,6 +97,26 @@ func TestPetStore(t *testing.T) {
 		err = json.NewDecoder(rr.Body).Decode(&petList)
 		assert.NoError(t, err, "error getting response", err)
 		assert.Equal(t, 2, len(petList))
+	})
+
+	t.Run("List all pets returns empty array when no pet exists", func(t *testing.T) {
+		store.Pets = map[int64]api.Pet{}
+
+		// Now, list all pets, we should have two
+		rr := doGet(t, r, "/pets")
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		// Check that the response is an empty json array
+		bodyBytes := rr.Body.Bytes()
+		bodyText := string(bodyBytes)
+		bodyIsEmptyArray := strings.HasPrefix(bodyText, "[]")
+		assert.True(t, bodyIsEmptyArray, fmt.Sprintf("Body is not empty array. body=%v", bodyText))
+
+		var petList []api.Pet
+		err = json.NewDecoder(rr.Body).Decode(&petList)
+		assert.NoError(t, err, "error getting response", err)
+		assert.Equal(t, 0, len(petList))
+
 	})
 
 	t.Run("Filter pets by tag", func(t *testing.T) {

--- a/examples/petstore-expanded/echo/api/petstore.go
+++ b/examples/petstore-expanded/echo/api/petstore.go
@@ -55,7 +55,8 @@ func (p *PetStore) FindPets(ctx echo.Context, params models.FindPetsParams) erro
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
-	var result []models.Pet
+	// Initialize result using make so it doesn't default to nil
+	var result []models.Pet = make([]models.Pet, 0)
 
 	for _, pet := range p.Pets {
 		if params.Tags != nil {

--- a/examples/petstore-expanded/echo/petstore_test.go
+++ b/examples/petstore-expanded/echo/petstore_test.go
@@ -17,14 +17,15 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/deepmap/oapi-codegen/v2/examples/petstore-expanded/echo/api"
 	"github.com/deepmap/oapi-codegen/v2/examples/petstore-expanded/echo/api/models"
-	"github.com/oapi-codegen/testutil"
 	"github.com/labstack/echo/v4"
 	echoMiddleware "github.com/labstack/echo/v4/middleware"
 	middleware "github.com/oapi-codegen/echo-middleware"
+	"github.com/oapi-codegen/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -150,6 +151,13 @@ func TestPetStore(t *testing.T) {
 	petList = nil
 	result = testutil.NewRequest().Get("/pets").WithAcceptJson().GoWithHTTPHandler(t, e)
 	assert.Equal(t, http.StatusOK, result.Code())
+
+	// Assert that the body is an empty json array
+	bodyBytes := result.Recorder.Body.Bytes()
+	bodyText := string(bodyBytes)
+	bodyIsEmptyArray := strings.HasPrefix(bodyText, "[]")
+	assert.True(t, bodyIsEmptyArray, fmt.Sprintf("Body is not empty array. body=%v", bodyText))
+
 	err = result.UnmarshalBodyToObject(&petList)
 	assert.NoError(t, err, "error getting response", err)
 	assert.Equal(t, 0, len(petList))

--- a/examples/petstore-expanded/fiber/api/petstore.go
+++ b/examples/petstore-expanded/fiber/api/petstore.go
@@ -47,7 +47,8 @@ func (p *PetStore) FindPets(c *fiber.Ctx, params FindPetsParams) error {
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
-	var result []Pet
+	// Initialize result using make so it doesn't default to nil
+	var result []Pet = make([]Pet, 0)
 
 	for _, pet := range p.Pets {
 		if params.Tags != nil {

--- a/examples/petstore-expanded/gin/api/petstore.go
+++ b/examples/petstore-expanded/gin/api/petstore.go
@@ -53,7 +53,8 @@ func (p *PetStore) FindPets(c *gin.Context, params FindPetsParams) {
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
-	var result []Pet
+	// Initialize result using make so it doesn't default to nil
+	var result []Pet = make([]Pet, 0)
 
 	for _, pet := range p.Pets {
 		if params.Tags != nil {

--- a/examples/petstore-expanded/gin/petstore_test.go
+++ b/examples/petstore-expanded/gin/petstore_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/deepmap/oapi-codegen/v2/examples/petstore-expanded/gin/api"
@@ -75,6 +76,26 @@ func TestPetStore(t *testing.T) {
 		err = json.NewDecoder(rr.Body).Decode(&petList)
 		assert.NoError(t, err, "error getting response", err)
 		assert.Equal(t, 2, len(petList))
+	})
+
+	t.Run("List all pets returns empty array when no pet exists", func(t *testing.T) {
+		store.Pets = map[int64]api.Pet{}
+
+		// Now, list all pets, we should have two
+		rr := doGet(t, r, "/pets")
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		// Check that the response is an empty json array
+		bodyBytes := rr.Body.Bytes()
+		bodyText := string(bodyBytes)
+		bodyIsEmptyArray := strings.HasPrefix(bodyText, "[]")
+		assert.True(t, bodyIsEmptyArray, fmt.Sprintf("Body is not empty array. body=%v", bodyText))
+
+		var petList []api.Pet
+		err = json.NewDecoder(rr.Body).Decode(&petList)
+		assert.NoError(t, err, "error getting response", err)
+		assert.Equal(t, 0, len(petList))
+
 	})
 
 	t.Run("Filter pets by tag", func(t *testing.T) {

--- a/examples/petstore-expanded/gorilla/api/petstore.go
+++ b/examples/petstore-expanded/gorilla/api/petstore.go
@@ -42,7 +42,8 @@ func (p *PetStore) FindPets(w http.ResponseWriter, r *http.Request, params FindP
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
-	var result []Pet
+	// Initialize result using make so it doesn't default to nil
+	var result []Pet = make([]Pet, 0)
 
 	for _, pet := range p.Pets {
 		if params.Tags != nil {

--- a/examples/petstore-expanded/gorilla/petstore_test.go
+++ b/examples/petstore-expanded/gorilla/petstore_test.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/deepmap/oapi-codegen/v2/examples/petstore-expanded/gorilla/api"
+	"github.com/gorilla/mux"
 	middleware "github.com/oapi-codegen/nethttp-middleware"
 	"github.com/oapi-codegen/testutil"
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -96,6 +97,26 @@ func TestPetStore(t *testing.T) {
 		err = json.NewDecoder(rr.Body).Decode(&petList)
 		assert.NoError(t, err, "error getting response", err)
 		assert.Equal(t, 2, len(petList))
+	})
+
+	t.Run("List all pets returns empty array when no pet exists", func(t *testing.T) {
+		store.Pets = map[int64]api.Pet{}
+
+		// Now, list all pets, we should have two
+		rr := doGet(t, r, "/pets")
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		// Check that the response is an empty json array
+		bodyBytes := rr.Body.Bytes()
+		bodyText := string(bodyBytes)
+		bodyIsEmptyArray := strings.HasPrefix(bodyText, "[]")
+		assert.True(t, bodyIsEmptyArray, fmt.Sprintf("Body is not empty array. body=%v", bodyText))
+
+		var petList []api.Pet
+		err = json.NewDecoder(rr.Body).Decode(&petList)
+		assert.NoError(t, err, "error getting response", err)
+		assert.Equal(t, 0, len(petList))
+
 	})
 
 	t.Run("Filter pets by tag", func(t *testing.T) {

--- a/examples/petstore-expanded/iris/api/petstore.go
+++ b/examples/petstore-expanded/iris/api/petstore.go
@@ -53,7 +53,8 @@ func (p *PetStore) FindPets(c iris.Context, params FindPetsParams) {
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
-	var result []Pet
+	// Initialize result using make so it doesn't default to nil
+	var result []Pet = make([]Pet, 0)
 
 	for _, pet := range p.Pets {
 		if params.Tags != nil {

--- a/examples/petstore-expanded/iris/petstore_test.go
+++ b/examples/petstore-expanded/iris/petstore_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/deepmap/oapi-codegen/v2/examples/petstore-expanded/iris/api"
@@ -86,6 +87,26 @@ func TestPetStore(t *testing.T) {
 		err := json.NewDecoder(rr.Body).Decode(&petList)
 		assert.NoError(t, err, "error getting response", err)
 		assert.Equal(t, 2, len(petList))
+	})
+
+	t.Run("List all pets returns empty array when no pet exists", func(t *testing.T) {
+		store.Pets = map[int64]api.Pet{}
+
+		// Now, list all pets, we should have two
+		rr := doGet(t, irisPetServer, "/pets")
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		// Check that the response is an empty json array
+		bodyBytes := rr.Body.Bytes()
+		bodyText := string(bodyBytes)
+		bodyIsEmptyArray := strings.HasPrefix(bodyText, "[]")
+		assert.True(t, bodyIsEmptyArray, fmt.Sprintf("Body is not empty array. body=%v", bodyText))
+
+		var petList []api.Pet
+		err := json.NewDecoder(rr.Body).Decode(&petList)
+		assert.NoError(t, err, "error getting response", err)
+		assert.Equal(t, 0, len(petList))
+
 	})
 
 	t.Run("Filter pets by tag", func(t *testing.T) {

--- a/examples/petstore-expanded/strict/api/petstore.go
+++ b/examples/petstore-expanded/strict/api/petstore.go
@@ -32,7 +32,8 @@ func (p *PetStore) FindPets(ctx context.Context, request FindPetsRequestObject) 
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
-	var result []Pet
+	// Initialize result using make so it doesn't default to nil
+	var result []Pet = make([]Pet, 0)
 
 	for _, pet := range p.Pets {
 		if request.Params.Tags != nil {


### PR DESCRIPTION
When no pet is found the examples pet store implementations are returning `null` as the http response body as opposed to empty array (`[]`).

Since the zero value of a slice is nil the pets slice should be created using make so that if no pet matches the query we can return an initialized slice. Otherwise the json package will encode the slice as nil which breaks the api contract.

```diff
func (p *PetStore) FindPets(...){

-    var result []Pet
+   var result []Pet = make([]Pet, 0)
 
    // Code for populating the result
 
    // Return or write the result to the response
}
```

The go json encoder and decoder doesn't complain about the nil value, so when consuming the api using the go standard library (as the tests do) everything is fine but if we would use clients written with languages/tools (javascript for example) they would fail to parse the response body. That's why I  added additional checks to the examples api's tests.