### PR TITLE
Add support for json mediatype with version

### DIFF
--- a/pkg/util/isjson.go
+++ b/pkg/util/isjson.go
@@ -3,5 +3,5 @@ package util
 import "strings"
 
 func IsMediaTypeJson(mediaType string) bool {
-	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+	return strings.HasPrefix(mediaType, "application/json") || strings.HasSuffix(mediaType, "+json")
 }

--- a/pkg/util/isjson_test.go
+++ b/pkg/util/isjson_test.go
@@ -32,6 +32,11 @@ func TestIsMediaTypeJson(t *testing.T) {
 			want:      true,
 		},
 		{
+			name:      "When MediaType is application/json;version=v1, returns true",
+			mediaType: "application/json;version=v1",
+			want:      true,
+		},
+		{
 			name:      "When MediaType is application/json-patch+json, returns true",
 			mediaType: "application/json-patch+json",
 			want:      true,


### PR DESCRIPTION
## Description

When json media type has a version provided (like `appication/json;version=v1`), the generator ignores it and doesn't produce helper structs in response object (very useful for the parsing of the http response into a struct).

This PR adds the support for this type of json mediatype definition.