### PR TITLE
Update echo params to be idiomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ Echo server.
 ```go
 type ServerInterface interface {
     //  (GET /pets)
-    FindPets(ctx echo.Context, params FindPetsParams) error
+    FindPets(c echo.Context, params FindPetsParams) error
     //  (POST /pets)
-    AddPet(ctx echo.Context) error
+    AddPet(c echo.Context) error
     //  (DELETE /pets/{id})
-    DeletePet(ctx echo.Context, id int64) error
+    DeletePet(c echo.Context, id int64) error
     //  (GET /pets/{id})
-    FindPetById(ctx echo.Context, id int64) error
+    FindPetById(c echo.Context, id int64) error
 }
 ```
 

--- a/examples/authenticated-api/echo/api/api.gen.go
+++ b/examples/authenticated-api/echo/api/api.gen.go
@@ -410,10 +410,10 @@ func ParseAddThingResponse(rsp *http.Response) (*AddThingResponse, error) {
 type ServerInterface interface {
 
 	// (GET /things)
-	ListThings(ctx echo.Context) error
+	ListThings(c echo.Context) error
 
 	// (POST /things)
-	AddThing(ctx echo.Context) error
+	AddThing(c echo.Context) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -422,24 +422,24 @@ type ServerInterfaceWrapper struct {
 }
 
 // ListThings converts echo context to params.
-func (w *ServerInterfaceWrapper) ListThings(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) ListThings(c echo.Context) error {
 	var err error
 
-	ctx.Set(BearerAuthScopes, []string{})
+	c.Set(BearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.ListThings(ctx)
+	err = w.Handler.ListThings(c)
 	return err
 }
 
 // AddThing converts echo context to params.
-func (w *ServerInterfaceWrapper) AddThing(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) AddThing(c echo.Context) error {
 	var err error
 
-	ctx.Set(BearerAuthScopes, []string{"things:w"})
+	c.Set(BearerAuthScopes, []string{"things:w"})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.AddThing(ctx)
+	err = w.Handler.AddThing(c)
 	return err
 }
 

--- a/examples/authenticated-api/echo/server/server.go
+++ b/examples/authenticated-api/echo/server/server.go
@@ -44,7 +44,7 @@ func CreateMiddleware(v JWSValidator) ([]echo.MiddlewareFunc, error) {
 // Ensure that we implement the server interface
 var _ api.ServerInterface = (*server)(nil)
 
-func (s *server) ListThings(ctx echo.Context) error {
+func (s *server) ListThings(c echo.Context) error {
 	// This handler will only be called when a valid JWT is presented for
 	// access.
 	s.RLock()
@@ -67,7 +67,7 @@ func (s *server) ListThings(ctx echo.Context) error {
 
 	s.RUnlock()
 
-	return ctx.JSON(http.StatusOK, things)
+	return c.JSON(http.StatusOK, things)
 }
 
 type int64s []int64
@@ -86,13 +86,13 @@ func (in int64s) Swap(i, j int) {
 
 var _ sort.Interface = (int64s)(nil)
 
-func (s *server) AddThing(ctx echo.Context) error {
+func (s *server) AddThing(c echo.Context) error {
 	// This handler will only be called when the JWT is valid and the JWT contains
 	// the scopes required.
 	var thing api.Thing
-	err := ctx.Bind(&thing)
+	err := c.Bind(&thing)
 	if err != nil {
-		return returnError(ctx, http.StatusBadRequest, "could not bind request body")
+		return returnError(c, http.StatusBadRequest, "could not bind request body")
 	}
 
 	s.Lock()
@@ -105,13 +105,13 @@ func (s *server) AddThing(ctx echo.Context) error {
 	}
 	s.lastID++
 
-	return ctx.JSON(http.StatusCreated, thingWithId)
+	return c.JSON(http.StatusCreated, thingWithId)
 }
 
-func returnError(ctx echo.Context, code int, message string) error {
+func returnError(c echo.Context, code int, message string) error {
 	errResponse := api.Error{
 		Code:    int32(code),
 		Message: message,
 	}
-	return ctx.JSON(code, errResponse)
+	return c.JSON(code, errResponse)
 }

--- a/examples/no-vcs-version-override/echo/api/api.gen.go
+++ b/examples/no-vcs-version-override/echo/api/api.gen.go
@@ -11,7 +11,7 @@ import (
 type ServerInterface interface {
 
 	// (GET /nothing)
-	GetNothing(ctx echo.Context) error
+	GetNothing(c echo.Context) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -20,11 +20,11 @@ type ServerInterfaceWrapper struct {
 }
 
 // GetNothing converts echo context to params.
-func (w *ServerInterfaceWrapper) GetNothing(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetNothing(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetNothing(ctx)
+	err = w.Handler.GetNothing(c)
 	return err
 }
 

--- a/examples/petstore-expanded/echo/api/petstore-server.gen.go
+++ b/examples/petstore-expanded/echo/api/petstore-server.gen.go
@@ -23,16 +23,16 @@ import (
 type ServerInterface interface {
 	// Returns all pets
 	// (GET /pets)
-	FindPets(ctx echo.Context, params FindPetsParams) error
+	FindPets(c echo.Context, params FindPetsParams) error
 	// Creates a new pet
 	// (POST /pets)
-	AddPet(ctx echo.Context) error
+	AddPet(c echo.Context) error
 	// Deletes a pet by ID
 	// (DELETE /pets/{id})
-	DeletePet(ctx echo.Context, id int64) error
+	DeletePet(c echo.Context, id int64) error
 	// Returns a pet by ID
 	// (GET /pets/{id})
-	FindPetByID(ctx echo.Context, id int64) error
+	FindPetByID(c echo.Context, id int64) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -41,68 +41,68 @@ type ServerInterfaceWrapper struct {
 }
 
 // FindPets converts echo context to params.
-func (w *ServerInterfaceWrapper) FindPets(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) FindPets(c echo.Context) error {
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params FindPetsParams
 	// ------------- Optional query parameter "tags" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "tags", ctx.QueryParams(), &params.Tags)
+	err = runtime.BindQueryParameter("form", true, false, "tags", c.QueryParams(), &params.Tags)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter tags: %s", err))
 	}
 
 	// ------------- Optional query parameter "limit" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "limit", ctx.QueryParams(), &params.Limit)
+	err = runtime.BindQueryParameter("form", true, false, "limit", c.QueryParams(), &params.Limit)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter limit: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.FindPets(ctx, params)
+	err = w.Handler.FindPets(c, params)
 	return err
 }
 
 // AddPet converts echo context to params.
-func (w *ServerInterfaceWrapper) AddPet(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) AddPet(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.AddPet(ctx)
+	err = w.Handler.AddPet(c)
 	return err
 }
 
 // DeletePet converts echo context to params.
-func (w *ServerInterfaceWrapper) DeletePet(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) DeletePet(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
 	var id int64
 
-	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.DeletePet(ctx, id)
+	err = w.Handler.DeletePet(c, id)
 	return err
 }
 
 // FindPetByID converts echo context to params.
-func (w *ServerInterfaceWrapper) FindPetByID(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) FindPetByID(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
 	var id int64
 
-	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.FindPetByID(ctx, id)
+	err = w.Handler.FindPetByID(c, id)
 	return err
 }
 

--- a/examples/petstore-expanded/echo/api/petstore.go
+++ b/examples/petstore-expanded/echo/api/petstore.go
@@ -41,17 +41,17 @@ func NewPetStore() *PetStore {
 
 // sendPetStoreError wraps sending of an error in the Error format, and
 // handling the failure to marshal that.
-func sendPetStoreError(ctx echo.Context, code int, message string) error {
+func sendPetStoreError(c echo.Context, code int, message string) error {
 	petErr := models.Error{
 		Code:    int32(code),
 		Message: message,
 	}
-	err := ctx.JSON(code, petErr)
+	err := c.JSON(code, petErr)
 	return err
 }
 
 // FindPets implements all the handlers in the ServerInterface
-func (p *PetStore) FindPets(ctx echo.Context, params models.FindPetsParams) error {
+func (p *PetStore) FindPets(c echo.Context, params models.FindPetsParams) error {
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
@@ -78,15 +78,15 @@ func (p *PetStore) FindPets(ctx echo.Context, params models.FindPetsParams) erro
 			}
 		}
 	}
-	return ctx.JSON(http.StatusOK, result)
+	return c.JSON(http.StatusOK, result)
 }
 
-func (p *PetStore) AddPet(ctx echo.Context) error {
+func (p *PetStore) AddPet(c echo.Context) error {
 	// We expect a NewPet object in the request body.
 	var newPet models.NewPet
-	err := ctx.Bind(&newPet)
+	err := c.Bind(&newPet)
 	if err != nil {
-		return sendPetStoreError(ctx, http.StatusBadRequest, "Invalid format for NewPet")
+		return sendPetStoreError(c, http.StatusBadRequest, "Invalid format for NewPet")
 	}
 	// We now have a pet, let's add it to our "database".
 
@@ -105,7 +105,7 @@ func (p *PetStore) AddPet(ctx echo.Context) error {
 	p.Pets[pet.Id] = pet
 
 	// Now, we have to return the NewPet
-	err = ctx.JSON(http.StatusCreated, pet)
+	err = c.JSON(http.StatusCreated, pet)
 	if err != nil {
 		// Something really bad happened, tell Echo that our handler failed
 		return err
@@ -120,27 +120,27 @@ func (p *PetStore) AddPet(ctx echo.Context) error {
 	return nil
 }
 
-func (p *PetStore) FindPetByID(ctx echo.Context, petId int64) error {
+func (p *PetStore) FindPetByID(c echo.Context, petId int64) error {
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
 	pet, found := p.Pets[petId]
 	if !found {
-		return sendPetStoreError(ctx, http.StatusNotFound,
+		return sendPetStoreError(c, http.StatusNotFound,
 			fmt.Sprintf("Could not find pet with ID %d", petId))
 	}
-	return ctx.JSON(http.StatusOK, pet)
+	return c.JSON(http.StatusOK, pet)
 }
 
-func (p *PetStore) DeletePet(ctx echo.Context, id int64) error {
+func (p *PetStore) DeletePet(c echo.Context, id int64) error {
 	p.Lock.Lock()
 	defer p.Lock.Unlock()
 
 	_, found := p.Pets[id]
 	if !found {
-		return sendPetStoreError(ctx, http.StatusNotFound,
+		return sendPetStoreError(c, http.StatusNotFound,
 			fmt.Sprintf("Could not find pet with ID %d", id))
 	}
 	delete(p.Pets, id)
-	return ctx.NoContent(http.StatusNoContent)
+	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/test/issues/issue-1180/issue.gen.go
+++ b/internal/test/issues/issue-1180/issue.gen.go
@@ -240,7 +240,7 @@ func ParseGetSimplePrimitiveResponse(rsp *http.Response) (*GetSimplePrimitiveRes
 type ServerInterface interface {
 
 	// (GET /simplePrimitive/{param})
-	GetSimplePrimitive(ctx echo.Context, param string) error
+	GetSimplePrimitive(c echo.Context, param string) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -249,18 +249,18 @@ type ServerInterfaceWrapper struct {
 }
 
 // GetSimplePrimitive converts echo context to params.
-func (w *ServerInterfaceWrapper) GetSimplePrimitive(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetSimplePrimitive(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "param" -------------
 	var param string
 
-	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "param", c.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetSimplePrimitive(ctx, param)
+	err = w.Handler.GetSimplePrimitive(c, param)
 	return err
 }
 

--- a/internal/test/issues/issue-1182/pkg1/pkg1.gen.go
+++ b/internal/test/issues/issue-1182/pkg1/pkg1.gen.go
@@ -234,7 +234,7 @@ func ParseTestGetResponse(rsp *http.Response) (*TestGetResponse, error) {
 type ServerInterface interface {
 	// get test response
 	// (GET /test)
-	TestGet(ctx echo.Context) error
+	TestGet(c echo.Context) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -243,11 +243,11 @@ type ServerInterfaceWrapper struct {
 }
 
 // TestGet converts echo context to params.
-func (w *ServerInterfaceWrapper) TestGet(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) TestGet(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.TestGet(ctx)
+	err = w.Handler.TestGet(c)
 	return err
 }
 
@@ -317,22 +317,22 @@ type strictHandler struct {
 }
 
 // TestGet operation middleware
-func (sh *strictHandler) TestGet(ctx echo.Context) error {
+func (sh *strictHandler) TestGet(c echo.Context) error {
 	var request TestGetRequestObject
 
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.TestGet(ctx.Request().Context(), request.(TestGetRequestObject))
+	handler := func(c echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.TestGet(c.Request().Context(), request.(TestGetRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "TestGet")
 	}
 
-	response, err := handler(ctx, request)
+	response, err := handler(c, request)
 
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(TestGetResponseObject); ok {
-		return validResponse.VisitTestGetResponse(ctx.Response())
+		return validResponse.VisitTestGetResponse(c.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}

--- a/internal/test/issues/issue-1189/issue1189.gen.go
+++ b/internal/test/issues/issue-1189/issue1189.gen.go
@@ -419,7 +419,7 @@ func ParseTestResponse(rsp *http.Response) (*TestResponse, error) {
 type ServerInterface interface {
 
 	// (GET /test)
-	Test(ctx echo.Context) error
+	Test(c echo.Context) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -428,11 +428,11 @@ type ServerInterfaceWrapper struct {
 }
 
 // Test converts echo context to params.
-func (w *ServerInterfaceWrapper) Test(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) Test(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.Test(ctx)
+	err = w.Handler.Test(c)
 	return err
 }
 

--- a/internal/test/issues/issue-312/issue.gen.go
+++ b/internal/test/issues/issue-312/issue.gen.go
@@ -423,10 +423,10 @@ func ParseValidatePetsResponse(rsp *http.Response) (*ValidatePetsResponse, error
 type ServerInterface interface {
 	// Get pet given identifier.
 	// (GET /pets/{petId})
-	GetPet(ctx echo.Context, petId string) error
+	GetPet(c echo.Context, petId string) error
 	// Validate pets
 	// (POST /pets:validate)
-	ValidatePets(ctx echo.Context) error
+	ValidatePets(c echo.Context) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -435,27 +435,27 @@ type ServerInterfaceWrapper struct {
 }
 
 // GetPet converts echo context to params.
-func (w *ServerInterfaceWrapper) GetPet(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetPet(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "petId" -------------
 	var petId string
 
-	err = runtime.BindStyledParameterWithOptions("simple", "petId", ctx.Param("petId"), &petId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "petId", c.Param("petId"), &petId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter petId: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetPet(ctx, petId)
+	err = w.Handler.GetPet(c, petId)
 	return err
 }
 
 // ValidatePets converts echo context to params.
-func (w *ServerInterfaceWrapper) ValidatePets(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) ValidatePets(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.ValidatePets(ctx)
+	err = w.Handler.ValidatePets(c)
 	return err
 }
 

--- a/internal/test/issues/issue-312/issue_test.go
+++ b/internal/test/issues/issue-312/issue_test.go
@@ -77,9 +77,9 @@ func TestClient_ServerUnescapesEscapedArg(t *testing.T) {
 	// We'll make a function in the mock client which records the value of
 	// the petId variable
 	receivedPetID := ""
-	m.getPet = func(ctx echo.Context, petId string) error {
+	m.getPet = func(c echo.Context, petId string) error {
 		receivedPetID = petId
-		return ctx.NoContent(http.StatusOK)
+		return c.NoContent(http.StatusOK)
 	}
 
 	client, err := NewClientWithResponses(svr.URL)
@@ -108,20 +108,20 @@ func (m *HTTPRequestDoerMock) Do(req *http.Request) (*http.Response, error) {
 // An implementation of the server interface which helps us check server
 // expectations for funky paths and parameters.
 type MockClient struct {
-	getPet       func(ctx echo.Context, petId string) error
-	validatePets func(ctx echo.Context) error
+	getPet       func(c echo.Context, petId string) error
+	validatePets func(c echo.Context) error
 }
 
-func (m *MockClient) GetPet(ctx echo.Context, petId string) error {
+func (m *MockClient) GetPet(c echo.Context, petId string) error {
 	if m.getPet != nil {
-		return m.getPet(ctx, petId)
+		return m.getPet(c, petId)
 	}
-	return ctx.NoContent(http.StatusNotImplemented)
+	return c.NoContent(http.StatusNotImplemented)
 }
 
-func (m *MockClient) ValidatePets(ctx echo.Context) error {
+func (m *MockClient) ValidatePets(c echo.Context) error {
 	if m.validatePets != nil {
-		return m.validatePets(ctx)
+		return m.validatePets(c)
 	}
-	return ctx.NoContent(http.StatusNotImplemented)
+	return c.NoContent(http.StatusNotImplemented)
 }

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -258,7 +258,7 @@ func ParseExampleGetResponse(rsp *http.Response) (*ExampleGetResponse, error) {
 type ServerInterface interface {
 
 	// (GET /example)
-	ExampleGet(ctx echo.Context) error
+	ExampleGet(c echo.Context) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -267,11 +267,11 @@ type ServerInterfaceWrapper struct {
 }
 
 // ExampleGet converts echo context to params.
-func (w *ServerInterfaceWrapper) ExampleGet(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) ExampleGet(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.ExampleGet(ctx)
+	err = w.Handler.ExampleGet(c)
 	return err
 }
 

--- a/internal/test/issues/issue-grab_import_names/issue.gen.go
+++ b/internal/test/issues/issue-grab_import_names/issue.gen.go
@@ -280,7 +280,7 @@ func ParseGetFooResponse(rsp *http.Response) (*GetFooResponse, error) {
 type ServerInterface interface {
 
 	// (GET /foo)
-	GetFoo(ctx echo.Context, params GetFooParams) error
+	GetFoo(c echo.Context, params GetFooParams) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -289,13 +289,13 @@ type ServerInterfaceWrapper struct {
 }
 
 // GetFoo converts echo context to params.
-func (w *ServerInterfaceWrapper) GetFoo(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetFoo(c echo.Context) error {
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetFooParams
 
-	headers := ctx.Request().Header
+	headers := c.Request().Header
 	// ------------- Optional header parameter "Foo" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("Foo")]; found {
 		var Foo string
@@ -328,7 +328,7 @@ func (w *ServerInterfaceWrapper) GetFoo(ctx echo.Context) error {
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetFoo(ctx, params)
+	err = w.Handler.GetFoo(c, params)
 	return err
 }
 

--- a/internal/test/issues/issue-illegal_enum_names/issue.gen.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue.gen.go
@@ -261,7 +261,7 @@ func ParseGetFooResponse(rsp *http.Response) (*GetFooResponse, error) {
 type ServerInterface interface {
 
 	// (GET /foo)
-	GetFoo(ctx echo.Context) error
+	GetFoo(c echo.Context) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -270,11 +270,11 @@ type ServerInterfaceWrapper struct {
 }
 
 // GetFoo converts echo context to params.
-func (w *ServerInterfaceWrapper) GetFoo(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetFoo(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetFoo(ctx)
+	err = w.Handler.GetFoo(c)
 	return err
 }
 

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -2682,67 +2682,67 @@ func ParseGetStartingWithNumberResponse(rsp *http.Response) (*GetStartingWithNum
 type ServerInterface interface {
 
 	// (GET /contentObject/{param})
-	GetContentObject(ctx echo.Context, param ComplexObject) error
+	GetContentObject(c echo.Context, param ComplexObject) error
 
 	// (GET /cookie)
-	GetCookie(ctx echo.Context, params GetCookieParams) error
+	GetCookie(c echo.Context, params GetCookieParams) error
 
 	// (GET /enums)
-	EnumParams(ctx echo.Context, params EnumParamsParams) error
+	EnumParams(c echo.Context, params EnumParamsParams) error
 
 	// (GET /header)
-	GetHeader(ctx echo.Context, params GetHeaderParams) error
+	GetHeader(c echo.Context, params GetHeaderParams) error
 
 	// (GET /labelExplodeArray/{.param*})
-	GetLabelExplodeArray(ctx echo.Context, param []int32) error
+	GetLabelExplodeArray(c echo.Context, param []int32) error
 
 	// (GET /labelExplodeObject/{.param*})
-	GetLabelExplodeObject(ctx echo.Context, param Object) error
+	GetLabelExplodeObject(c echo.Context, param Object) error
 
 	// (GET /labelNoExplodeArray/{.param})
-	GetLabelNoExplodeArray(ctx echo.Context, param []int32) error
+	GetLabelNoExplodeArray(c echo.Context, param []int32) error
 
 	// (GET /labelNoExplodeObject/{.param})
-	GetLabelNoExplodeObject(ctx echo.Context, param Object) error
+	GetLabelNoExplodeObject(c echo.Context, param Object) error
 
 	// (GET /matrixExplodeArray/{.id*})
-	GetMatrixExplodeArray(ctx echo.Context, id []int32) error
+	GetMatrixExplodeArray(c echo.Context, id []int32) error
 
 	// (GET /matrixExplodeObject/{.id*})
-	GetMatrixExplodeObject(ctx echo.Context, id Object) error
+	GetMatrixExplodeObject(c echo.Context, id Object) error
 
 	// (GET /matrixNoExplodeArray/{.id})
-	GetMatrixNoExplodeArray(ctx echo.Context, id []int32) error
+	GetMatrixNoExplodeArray(c echo.Context, id []int32) error
 
 	// (GET /matrixNoExplodeObject/{.id})
-	GetMatrixNoExplodeObject(ctx echo.Context, id Object) error
+	GetMatrixNoExplodeObject(c echo.Context, id Object) error
 
 	// (GET /passThrough/{param})
-	GetPassThrough(ctx echo.Context, param string) error
+	GetPassThrough(c echo.Context, param string) error
 
 	// (GET /queryDeepObject)
-	GetDeepObject(ctx echo.Context, params GetDeepObjectParams) error
+	GetDeepObject(c echo.Context, params GetDeepObjectParams) error
 
 	// (GET /queryForm)
-	GetQueryForm(ctx echo.Context, params GetQueryFormParams) error
+	GetQueryForm(c echo.Context, params GetQueryFormParams) error
 
 	// (GET /simpleExplodeArray/{param*})
-	GetSimpleExplodeArray(ctx echo.Context, param []int32) error
+	GetSimpleExplodeArray(c echo.Context, param []int32) error
 
 	// (GET /simpleExplodeObject/{param*})
-	GetSimpleExplodeObject(ctx echo.Context, param Object) error
+	GetSimpleExplodeObject(c echo.Context, param Object) error
 
 	// (GET /simpleNoExplodeArray/{param})
-	GetSimpleNoExplodeArray(ctx echo.Context, param []int32) error
+	GetSimpleNoExplodeArray(c echo.Context, param []int32) error
 
 	// (GET /simpleNoExplodeObject/{param})
-	GetSimpleNoExplodeObject(ctx echo.Context, param Object) error
+	GetSimpleNoExplodeObject(c echo.Context, param Object) error
 
 	// (GET /simplePrimitive/{param})
-	GetSimplePrimitive(ctx echo.Context, param int32) error
+	GetSimplePrimitive(c echo.Context, param int32) error
 
 	// (GET /startingWithNumber/{1param})
-	GetStartingWithNumber(ctx echo.Context, n1param string) error
+	GetStartingWithNumber(c echo.Context, n1param string) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -2751,29 +2751,29 @@ type ServerInterfaceWrapper struct {
 }
 
 // GetContentObject converts echo context to params.
-func (w *ServerInterfaceWrapper) GetContentObject(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetContentObject(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "param" -------------
 	var param ComplexObject
 
-	err = json.Unmarshal([]byte(ctx.Param("param")), &param)
+	err = json.Unmarshal([]byte(c.Param("param")), &param)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Error unmarshaling parameter 'param' as JSON")
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetContentObject(ctx, param)
+	err = w.Handler.GetContentObject(c, param)
 	return err
 }
 
 // GetCookie converts echo context to params.
-func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetCookie(c echo.Context) error {
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetCookieParams
 
-	if cookie, err := ctx.Cookie("p"); err == nil {
+	if cookie, err := c.Cookie("p"); err == nil {
 
 		var value int32
 		err = runtime.BindStyledParameterWithOptions("simple", "p", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: false, Required: false})
@@ -2784,7 +2784,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 
 	}
 
-	if cookie, err := ctx.Cookie("ep"); err == nil {
+	if cookie, err := c.Cookie("ep"); err == nil {
 
 		var value int32
 		err = runtime.BindStyledParameterWithOptions("simple", "ep", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: true, Required: false})
@@ -2795,7 +2795,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 
 	}
 
-	if cookie, err := ctx.Cookie("ea"); err == nil {
+	if cookie, err := c.Cookie("ea"); err == nil {
 
 		var value []int32
 		err = runtime.BindStyledParameterWithOptions("simple", "ea", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: true, Required: false})
@@ -2806,7 +2806,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 
 	}
 
-	if cookie, err := ctx.Cookie("a"); err == nil {
+	if cookie, err := c.Cookie("a"); err == nil {
 
 		var value []int32
 		err = runtime.BindStyledParameterWithOptions("simple", "a", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: false, Required: false})
@@ -2817,7 +2817,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 
 	}
 
-	if cookie, err := ctx.Cookie("eo"); err == nil {
+	if cookie, err := c.Cookie("eo"); err == nil {
 
 		var value Object
 		err = runtime.BindStyledParameterWithOptions("simple", "eo", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: true, Required: false})
@@ -2828,7 +2828,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 
 	}
 
-	if cookie, err := ctx.Cookie("o"); err == nil {
+	if cookie, err := c.Cookie("o"); err == nil {
 
 		var value Object
 		err = runtime.BindStyledParameterWithOptions("simple", "o", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: false, Required: false})
@@ -2839,7 +2839,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 
 	}
 
-	if cookie, err := ctx.Cookie("co"); err == nil {
+	if cookie, err := c.Cookie("co"); err == nil {
 
 		var value ComplexObject
 		var decoded string
@@ -2855,7 +2855,7 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 
 	}
 
-	if cookie, err := ctx.Cookie("1s"); err == nil {
+	if cookie, err := c.Cookie("1s"); err == nil {
 
 		var value string
 		err = runtime.BindStyledParameterWithOptions("simple", "1s", cookie.Value, &value, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationCookie, Explode: true, Required: false})
@@ -2867,36 +2867,36 @@ func (w *ServerInterfaceWrapper) GetCookie(ctx echo.Context) error {
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetCookie(ctx, params)
+	err = w.Handler.GetCookie(c, params)
 	return err
 }
 
 // EnumParams converts echo context to params.
-func (w *ServerInterfaceWrapper) EnumParams(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) EnumParams(c echo.Context) error {
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params EnumParamsParams
 	// ------------- Optional query parameter "enumPathParam" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "enumPathParam", ctx.QueryParams(), &params.EnumPathParam)
+	err = runtime.BindQueryParameter("form", true, false, "enumPathParam", c.QueryParams(), &params.EnumPathParam)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter enumPathParam: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.EnumParams(ctx, params)
+	err = w.Handler.EnumParams(c, params)
 	return err
 }
 
 // GetHeader converts echo context to params.
-func (w *ServerInterfaceWrapper) GetHeader(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetHeader(c echo.Context) error {
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetHeaderParams
 
-	headers := ctx.Request().Header
+	headers := c.Request().Header
 	// ------------- Optional header parameter "X-Primitive" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("X-Primitive")]; found {
 		var XPrimitive int32
@@ -3019,227 +3019,227 @@ func (w *ServerInterfaceWrapper) GetHeader(ctx echo.Context) error {
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetHeader(ctx, params)
+	err = w.Handler.GetHeader(c, params)
 	return err
 }
 
 // GetLabelExplodeArray converts echo context to params.
-func (w *ServerInterfaceWrapper) GetLabelExplodeArray(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetLabelExplodeArray(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "param" -------------
 	var param []int32
 
-	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true})
+	err = runtime.BindStyledParameterWithOptions("label", "param", c.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetLabelExplodeArray(ctx, param)
+	err = w.Handler.GetLabelExplodeArray(c, param)
 	return err
 }
 
 // GetLabelExplodeObject converts echo context to params.
-func (w *ServerInterfaceWrapper) GetLabelExplodeObject(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetLabelExplodeObject(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "param" -------------
 	var param Object
 
-	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true})
+	err = runtime.BindStyledParameterWithOptions("label", "param", c.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetLabelExplodeObject(ctx, param)
+	err = w.Handler.GetLabelExplodeObject(c, param)
 	return err
 }
 
 // GetLabelNoExplodeArray converts echo context to params.
-func (w *ServerInterfaceWrapper) GetLabelNoExplodeArray(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetLabelNoExplodeArray(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "param" -------------
 	var param []int32
 
-	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("label", "param", c.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetLabelNoExplodeArray(ctx, param)
+	err = w.Handler.GetLabelNoExplodeArray(c, param)
 	return err
 }
 
 // GetLabelNoExplodeObject converts echo context to params.
-func (w *ServerInterfaceWrapper) GetLabelNoExplodeObject(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetLabelNoExplodeObject(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "param" -------------
 	var param Object
 
-	err = runtime.BindStyledParameterWithOptions("label", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("label", "param", c.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetLabelNoExplodeObject(ctx, param)
+	err = w.Handler.GetLabelNoExplodeObject(c, param)
 	return err
 }
 
 // GetMatrixExplodeArray converts echo context to params.
-func (w *ServerInterfaceWrapper) GetMatrixExplodeArray(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetMatrixExplodeArray(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
 	var id []int32
 
-	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true})
+	err = runtime.BindStyledParameterWithOptions("matrix", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetMatrixExplodeArray(ctx, id)
+	err = w.Handler.GetMatrixExplodeArray(c, id)
 	return err
 }
 
 // GetMatrixExplodeObject converts echo context to params.
-func (w *ServerInterfaceWrapper) GetMatrixExplodeObject(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetMatrixExplodeObject(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
 	var id Object
 
-	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true})
+	err = runtime.BindStyledParameterWithOptions("matrix", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetMatrixExplodeObject(ctx, id)
+	err = w.Handler.GetMatrixExplodeObject(c, id)
 	return err
 }
 
 // GetMatrixNoExplodeArray converts echo context to params.
-func (w *ServerInterfaceWrapper) GetMatrixNoExplodeArray(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetMatrixNoExplodeArray(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
 	var id []int32
 
-	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("matrix", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetMatrixNoExplodeArray(ctx, id)
+	err = w.Handler.GetMatrixNoExplodeArray(c, id)
 	return err
 }
 
 // GetMatrixNoExplodeObject converts echo context to params.
-func (w *ServerInterfaceWrapper) GetMatrixNoExplodeObject(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetMatrixNoExplodeObject(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "id" -------------
 	var id Object
 
-	err = runtime.BindStyledParameterWithOptions("matrix", "id", ctx.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("matrix", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetMatrixNoExplodeObject(ctx, id)
+	err = w.Handler.GetMatrixNoExplodeObject(c, id)
 	return err
 }
 
 // GetPassThrough converts echo context to params.
-func (w *ServerInterfaceWrapper) GetPassThrough(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetPassThrough(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "param" -------------
 	var param string
 
-	param = ctx.Param("param")
+	param = c.Param("param")
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetPassThrough(ctx, param)
+	err = w.Handler.GetPassThrough(c, param)
 	return err
 }
 
 // GetDeepObject converts echo context to params.
-func (w *ServerInterfaceWrapper) GetDeepObject(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetDeepObject(c echo.Context) error {
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetDeepObjectParams
 	// ------------- Required query parameter "deepObj" -------------
 
-	err = runtime.BindQueryParameter("deepObject", true, true, "deepObj", ctx.QueryParams(), &params.DeepObj)
+	err = runtime.BindQueryParameter("deepObject", true, true, "deepObj", c.QueryParams(), &params.DeepObj)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter deepObj: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetDeepObject(ctx, params)
+	err = w.Handler.GetDeepObject(c, params)
 	return err
 }
 
 // GetQueryForm converts echo context to params.
-func (w *ServerInterfaceWrapper) GetQueryForm(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetQueryForm(c echo.Context) error {
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetQueryFormParams
 	// ------------- Optional query parameter "ea" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "ea", ctx.QueryParams(), &params.Ea)
+	err = runtime.BindQueryParameter("form", true, false, "ea", c.QueryParams(), &params.Ea)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ea: %s", err))
 	}
 
 	// ------------- Optional query parameter "a" -------------
 
-	err = runtime.BindQueryParameter("form", false, false, "a", ctx.QueryParams(), &params.A)
+	err = runtime.BindQueryParameter("form", false, false, "a", c.QueryParams(), &params.A)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter a: %s", err))
 	}
 
 	// ------------- Optional query parameter "eo" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "eo", ctx.QueryParams(), &params.Eo)
+	err = runtime.BindQueryParameter("form", true, false, "eo", c.QueryParams(), &params.Eo)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter eo: %s", err))
 	}
 
 	// ------------- Optional query parameter "o" -------------
 
-	err = runtime.BindQueryParameter("form", false, false, "o", ctx.QueryParams(), &params.O)
+	err = runtime.BindQueryParameter("form", false, false, "o", c.QueryParams(), &params.O)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter o: %s", err))
 	}
 
 	// ------------- Optional query parameter "ep" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "ep", ctx.QueryParams(), &params.Ep)
+	err = runtime.BindQueryParameter("form", true, false, "ep", c.QueryParams(), &params.Ep)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ep: %s", err))
 	}
 
 	// ------------- Optional query parameter "p" -------------
 
-	err = runtime.BindQueryParameter("form", false, false, "p", ctx.QueryParams(), &params.P)
+	err = runtime.BindQueryParameter("form", false, false, "p", c.QueryParams(), &params.P)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter p: %s", err))
 	}
 
 	// ------------- Optional query parameter "ps" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "ps", ctx.QueryParams(), &params.Ps)
+	err = runtime.BindQueryParameter("form", true, false, "ps", c.QueryParams(), &params.Ps)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter ps: %s", err))
 	}
 
 	// ------------- Optional query parameter "co" -------------
 
-	if paramValue := ctx.QueryParam("co"); paramValue != "" {
+	if paramValue := c.QueryParam("co"); paramValue != "" {
 
 		var value ComplexObject
 		err = json.Unmarshal([]byte(paramValue), &value)
@@ -3252,106 +3252,106 @@ func (w *ServerInterfaceWrapper) GetQueryForm(ctx echo.Context) error {
 
 	// ------------- Optional query parameter "1s" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "1s", ctx.QueryParams(), &params.N1s)
+	err = runtime.BindQueryParameter("form", true, false, "1s", c.QueryParams(), &params.N1s)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1s: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetQueryForm(ctx, params)
+	err = w.Handler.GetQueryForm(c, params)
 	return err
 }
 
 // GetSimpleExplodeArray converts echo context to params.
-func (w *ServerInterfaceWrapper) GetSimpleExplodeArray(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetSimpleExplodeArray(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "param" -------------
 	var param []int32
 
-	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "param", c.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetSimpleExplodeArray(ctx, param)
+	err = w.Handler.GetSimpleExplodeArray(c, param)
 	return err
 }
 
 // GetSimpleExplodeObject converts echo context to params.
-func (w *ServerInterfaceWrapper) GetSimpleExplodeObject(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetSimpleExplodeObject(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "param" -------------
 	var param Object
 
-	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "param", c.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: true, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetSimpleExplodeObject(ctx, param)
+	err = w.Handler.GetSimpleExplodeObject(c, param)
 	return err
 }
 
 // GetSimpleNoExplodeArray converts echo context to params.
-func (w *ServerInterfaceWrapper) GetSimpleNoExplodeArray(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetSimpleNoExplodeArray(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "param" -------------
 	var param []int32
 
-	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "param", c.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetSimpleNoExplodeArray(ctx, param)
+	err = w.Handler.GetSimpleNoExplodeArray(c, param)
 	return err
 }
 
 // GetSimpleNoExplodeObject converts echo context to params.
-func (w *ServerInterfaceWrapper) GetSimpleNoExplodeObject(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetSimpleNoExplodeObject(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "param" -------------
 	var param Object
 
-	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "param", c.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetSimpleNoExplodeObject(ctx, param)
+	err = w.Handler.GetSimpleNoExplodeObject(c, param)
 	return err
 }
 
 // GetSimplePrimitive converts echo context to params.
-func (w *ServerInterfaceWrapper) GetSimplePrimitive(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetSimplePrimitive(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "param" -------------
 	var param int32
 
-	err = runtime.BindStyledParameterWithOptions("simple", "param", ctx.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "param", c.Param("param"), &param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter param: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetSimplePrimitive(ctx, param)
+	err = w.Handler.GetSimplePrimitive(c, param)
 	return err
 }
 
 // GetStartingWithNumber converts echo context to params.
-func (w *ServerInterfaceWrapper) GetStartingWithNumber(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetStartingWithNumber(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "1param" -------------
 	var n1param string
 
-	n1param = ctx.Param("1param")
+	n1param = c.Param("1param")
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetStartingWithNumber(ctx, n1param)
+	err = w.Handler.GetStartingWithNumber(c, n1param)
 	return err
 }
 

--- a/internal/test/parameters/parameters_test.go
+++ b/internal/test/parameters/parameters_test.go
@@ -7,9 +7,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/oapi-codegen/testutil"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/oapi-codegen/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,109 +41,109 @@ func (t *testServer) reset() {
 }
 
 // (GET /contentObject/{param})
-func (t *testServer) GetContentObject(ctx echo.Context, param ComplexObject) error {
+func (t *testServer) GetContentObject(c echo.Context, param ComplexObject) error {
 	t.complexObject = &param
 	return nil
 }
 
 // (GET /labelExplodeArray/{.param*})
-func (t *testServer) GetLabelExplodeArray(ctx echo.Context, param []int32) error {
+func (t *testServer) GetLabelExplodeArray(c echo.Context, param []int32) error {
 	t.array = param
 	return nil
 }
 
 // (GET /labelExplodeObject/{.param*})
-func (t *testServer) GetLabelExplodeObject(ctx echo.Context, param Object) error {
+func (t *testServer) GetLabelExplodeObject(c echo.Context, param Object) error {
 	t.object = &param
 	return nil
 }
 
 // (GET /labelNoExplodeArray/{.param})
-func (t *testServer) GetLabelNoExplodeArray(ctx echo.Context, param []int32) error {
+func (t *testServer) GetLabelNoExplodeArray(c echo.Context, param []int32) error {
 	t.array = param
 	return nil
 }
 
 // (GET /labelNoExplodeObject/{.param})
-func (t *testServer) GetLabelNoExplodeObject(ctx echo.Context, param Object) error {
+func (t *testServer) GetLabelNoExplodeObject(c echo.Context, param Object) error {
 	t.object = &param
 	return nil
 }
 
 // (GET /matrixExplodeArray/{.param*})
-func (t *testServer) GetMatrixExplodeArray(ctx echo.Context, param []int32) error {
+func (t *testServer) GetMatrixExplodeArray(c echo.Context, param []int32) error {
 	t.array = param
 	return nil
 }
 
 // (GET /matrixExplodeObject/{.param*})
-func (t *testServer) GetMatrixExplodeObject(ctx echo.Context, param Object) error {
+func (t *testServer) GetMatrixExplodeObject(c echo.Context, param Object) error {
 	t.object = &param
 	return nil
 }
 
 // (GET /matrixNoExplodeArray/{.param})
-func (t *testServer) GetMatrixNoExplodeArray(ctx echo.Context, param []int32) error {
+func (t *testServer) GetMatrixNoExplodeArray(c echo.Context, param []int32) error {
 	t.array = param
 	return nil
 }
 
 // (GET /matrixNoExplodeObject/{.param})
-func (t *testServer) GetMatrixNoExplodeObject(ctx echo.Context, param Object) error {
+func (t *testServer) GetMatrixNoExplodeObject(c echo.Context, param Object) error {
 	t.object = &param
 	return nil
 }
 
 // (GET /simpleExplodeArray/{param*})
-func (t *testServer) GetSimpleExplodeArray(ctx echo.Context, param []int32) error {
+func (t *testServer) GetSimpleExplodeArray(c echo.Context, param []int32) error {
 	t.array = param
 	return nil
 }
 
 // (GET /simpleExplodeObject/{param*})
-func (t *testServer) GetSimpleExplodeObject(ctx echo.Context, param Object) error {
+func (t *testServer) GetSimpleExplodeObject(c echo.Context, param Object) error {
 	t.object = &param
 	return nil
 }
 
 // (GET /simpleNoExplodeArray/{param})
-func (t *testServer) GetSimpleNoExplodeArray(ctx echo.Context, param []int32) error {
+func (t *testServer) GetSimpleNoExplodeArray(c echo.Context, param []int32) error {
 	t.array = param
 	return nil
 }
 
 // (GET /simpleNoExplodeObject/{param})
-func (t *testServer) GetSimpleNoExplodeObject(ctx echo.Context, param Object) error {
+func (t *testServer) GetSimpleNoExplodeObject(c echo.Context, param Object) error {
 	t.object = &param
 	return nil
 }
 
 // (GET /passThrough/{param})
-func (t *testServer) GetPassThrough(ctx echo.Context, param string) error {
+func (t *testServer) GetPassThrough(c echo.Context, param string) error {
 	t.passThrough = &param
 	return nil
 }
 
 // (GET /startingWithjNumber/{param})
-func (t *testServer) GetStartingWithNumber(ctx echo.Context, n1param string) error {
+func (t *testServer) GetStartingWithNumber(c echo.Context, n1param string) error {
 	t.n1param = &n1param
 	return nil
 }
 
 // (GET /queryDeepObject)
-func (t *testServer) GetDeepObject(ctx echo.Context, params GetDeepObjectParams) error {
+func (t *testServer) GetDeepObject(c echo.Context, params GetDeepObjectParams) error {
 	t.complexObject = &params.DeepObj
 	return nil
 }
 
 // (GET /simplePrimitive/{param})
-func (t *testServer) GetSimplePrimitive(ctx echo.Context, param int32) error {
+func (t *testServer) GetSimplePrimitive(c echo.Context, param int32) error {
 	t.primitive = &param
 	return nil
 }
 
 // (GET /queryForm)
-func (t *testServer) GetQueryForm(ctx echo.Context, params GetQueryFormParams) error {
+func (t *testServer) GetQueryForm(c echo.Context, params GetQueryFormParams) error {
 	t.queryParams = &params
 	if params.Ea != nil {
 		t.array = *params.Ea
@@ -176,7 +176,7 @@ func (t *testServer) GetQueryForm(ctx echo.Context, params GetQueryFormParams) e
 }
 
 // (GET /header)
-func (t *testServer) GetHeader(ctx echo.Context, params GetHeaderParams) error {
+func (t *testServer) GetHeader(c echo.Context, params GetHeaderParams) error {
 	t.headerParams = &params
 	if params.XPrimitive != nil {
 		t.primitive = params.XPrimitive
@@ -206,7 +206,7 @@ func (t *testServer) GetHeader(ctx echo.Context, params GetHeaderParams) error {
 }
 
 // (GET /cookie)
-func (t *testServer) GetCookie(ctx echo.Context, params GetCookieParams) error {
+func (t *testServer) GetCookie(c echo.Context, params GetCookieParams) error {
 	t.cookieParams = &params
 	if params.Ea != nil {
 		t.array = *params.Ea
@@ -236,8 +236,8 @@ func (t *testServer) GetCookie(ctx echo.Context, params GetCookieParams) error {
 }
 
 // (GET /enums)
-func (t *testServer) EnumParams(ctx echo.Context, params EnumParamsParams) error {
-	return ctx.NoContent(http.StatusNotImplemented)
+func (t *testServer) EnumParams(c echo.Context, params EnumParamsParams) error {
+	return c.NoContent(http.StatusNotImplemented)
 }
 
 func TestParameterBinding(t *testing.T) {

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -1367,34 +1367,34 @@ func ParseIssue975Response(rsp *http.Response) (*Issue975Response, error) {
 type ServerInterface interface {
 
 	// (GET /ensure-everything-is-referenced)
-	EnsureEverythingIsReferenced(ctx echo.Context) error
+	EnsureEverythingIsReferenced(c echo.Context) error
 
 	// (GET /issues/1051)
-	Issue1051(ctx echo.Context) error
+	Issue1051(c echo.Context) error
 
 	// (GET /issues/127)
-	Issue127(ctx echo.Context) error
+	Issue127(c echo.Context) error
 
 	// (GET /issues/185)
-	Issue185(ctx echo.Context) error
+	Issue185(c echo.Context) error
 
 	// (GET /issues/209/${str})
-	Issue209(ctx echo.Context, str StringInPath) error
+	Issue209(c echo.Context, str StringInPath) error
 
 	// (GET /issues/30/{fallthrough})
-	Issue30(ctx echo.Context, pFallthrough string) error
+	Issue30(c echo.Context, pFallthrough string) error
 
 	// (GET /issues/375)
-	GetIssues375(ctx echo.Context) error
+	GetIssues375(c echo.Context) error
 
 	// (GET /issues/41/{1param})
-	Issue41(ctx echo.Context, n1param N5StartsWithNumber) error
+	Issue41(c echo.Context, n1param N5StartsWithNumber) error
 
 	// (GET /issues/9)
-	Issue9(ctx echo.Context, params Issue9Params) error
+	Issue9(c echo.Context, params Issue9Params) error
 
 	// (GET /issues/975)
-	Issue975(ctx echo.Context) error
+	Issue975(c echo.Context) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -1403,142 +1403,142 @@ type ServerInterfaceWrapper struct {
 }
 
 // EnsureEverythingIsReferenced converts echo context to params.
-func (w *ServerInterfaceWrapper) EnsureEverythingIsReferenced(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) EnsureEverythingIsReferenced(c echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{})
+	c.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.EnsureEverythingIsReferenced(ctx)
+	err = w.Handler.EnsureEverythingIsReferenced(c)
 	return err
 }
 
 // Issue1051 converts echo context to params.
-func (w *ServerInterfaceWrapper) Issue1051(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) Issue1051(c echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{})
+	c.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.Issue1051(ctx)
+	err = w.Handler.Issue1051(c)
 	return err
 }
 
 // Issue127 converts echo context to params.
-func (w *ServerInterfaceWrapper) Issue127(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) Issue127(c echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{})
+	c.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.Issue127(ctx)
+	err = w.Handler.Issue127(c)
 	return err
 }
 
 // Issue185 converts echo context to params.
-func (w *ServerInterfaceWrapper) Issue185(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) Issue185(c echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{})
+	c.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.Issue185(ctx)
+	err = w.Handler.Issue185(c)
 	return err
 }
 
 // Issue209 converts echo context to params.
-func (w *ServerInterfaceWrapper) Issue209(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) Issue209(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "str" -------------
 	var str StringInPath
 
-	err = runtime.BindStyledParameterWithOptions("simple", "str", ctx.Param("str"), &str, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "str", c.Param("str"), &str, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter str: %s", err))
 	}
 
-	ctx.Set(Access_tokenScopes, []string{})
+	c.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.Issue209(ctx, str)
+	err = w.Handler.Issue209(c, str)
 	return err
 }
 
 // Issue30 converts echo context to params.
-func (w *ServerInterfaceWrapper) Issue30(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) Issue30(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "fallthrough" -------------
 	var pFallthrough string
 
-	err = runtime.BindStyledParameterWithOptions("simple", "fallthrough", ctx.Param("fallthrough"), &pFallthrough, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "fallthrough", c.Param("fallthrough"), &pFallthrough, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter fallthrough: %s", err))
 	}
 
-	ctx.Set(Access_tokenScopes, []string{})
+	c.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.Issue30(ctx, pFallthrough)
+	err = w.Handler.Issue30(c, pFallthrough)
 	return err
 }
 
 // GetIssues375 converts echo context to params.
-func (w *ServerInterfaceWrapper) GetIssues375(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) GetIssues375(c echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{})
+	c.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetIssues375(ctx)
+	err = w.Handler.GetIssues375(c)
 	return err
 }
 
 // Issue41 converts echo context to params.
-func (w *ServerInterfaceWrapper) Issue41(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) Issue41(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "1param" -------------
 	var n1param N5StartsWithNumber
 
-	err = runtime.BindStyledParameterWithOptions("simple", "1param", ctx.Param("1param"), &n1param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "1param", c.Param("1param"), &n1param, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter 1param: %s", err))
 	}
 
-	ctx.Set(Access_tokenScopes, []string{})
+	c.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.Issue41(ctx, n1param)
+	err = w.Handler.Issue41(c, n1param)
 	return err
 }
 
 // Issue9 converts echo context to params.
-func (w *ServerInterfaceWrapper) Issue9(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) Issue9(c echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{})
+	c.Set(Access_tokenScopes, []string{})
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params Issue9Params
 	// ------------- Required query parameter "foo" -------------
 
-	err = runtime.BindQueryParameter("form", true, true, "foo", ctx.QueryParams(), &params.Foo)
+	err = runtime.BindQueryParameter("form", true, true, "foo", c.QueryParams(), &params.Foo)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter foo: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.Issue9(ctx, params)
+	err = w.Handler.Issue9(c, params)
 	return err
 }
 
 // Issue975 converts echo context to params.
-func (w *ServerInterfaceWrapper) Issue975(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) Issue975(c echo.Context) error {
 	var err error
 
-	ctx.Set(Access_tokenScopes, []string{})
+	c.Set(Access_tokenScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.Issue975(ctx)
+	err = w.Handler.Issue975(c)
 	return err
 }
 

--- a/internal/test/strict-server/echo/server.gen.go
+++ b/internal/test/strict-server/echo/server.gen.go
@@ -27,37 +27,37 @@ import (
 type ServerInterface interface {
 
 	// (POST /json)
-	JSONExample(ctx echo.Context) error
+	JSONExample(c echo.Context) error
 
 	// (POST /multipart)
-	MultipartExample(ctx echo.Context) error
+	MultipartExample(c echo.Context) error
 
 	// (POST /multiple)
-	MultipleRequestAndResponseTypes(ctx echo.Context) error
+	MultipleRequestAndResponseTypes(c echo.Context) error
 
 	// (GET /reserved-go-keyword-parameters/{type})
-	ReservedGoKeywordParameters(ctx echo.Context, pType string) error
+	ReservedGoKeywordParameters(c echo.Context, pType string) error
 
 	// (POST /reusable-responses)
-	ReusableResponses(ctx echo.Context) error
+	ReusableResponses(c echo.Context) error
 
 	// (POST /text)
-	TextExample(ctx echo.Context) error
+	TextExample(c echo.Context) error
 
 	// (POST /unknown)
-	UnknownExample(ctx echo.Context) error
+	UnknownExample(c echo.Context) error
 
 	// (POST /unspecified-content-type)
-	UnspecifiedContentType(ctx echo.Context) error
+	UnspecifiedContentType(c echo.Context) error
 
 	// (POST /urlencoded)
-	URLEncodedExample(ctx echo.Context) error
+	URLEncodedExample(c echo.Context) error
 
 	// (POST /with-headers)
-	HeadersExample(ctx echo.Context, params HeadersExampleParams) error
+	HeadersExample(c echo.Context, params HeadersExampleParams) error
 
 	// (POST /with-union)
-	UnionExample(ctx echo.Context) error
+	UnionExample(c echo.Context) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -66,101 +66,101 @@ type ServerInterfaceWrapper struct {
 }
 
 // JSONExample converts echo context to params.
-func (w *ServerInterfaceWrapper) JSONExample(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) JSONExample(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.JSONExample(ctx)
+	err = w.Handler.JSONExample(c)
 	return err
 }
 
 // MultipartExample converts echo context to params.
-func (w *ServerInterfaceWrapper) MultipartExample(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) MultipartExample(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.MultipartExample(ctx)
+	err = w.Handler.MultipartExample(c)
 	return err
 }
 
 // MultipleRequestAndResponseTypes converts echo context to params.
-func (w *ServerInterfaceWrapper) MultipleRequestAndResponseTypes(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) MultipleRequestAndResponseTypes(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.MultipleRequestAndResponseTypes(ctx)
+	err = w.Handler.MultipleRequestAndResponseTypes(c)
 	return err
 }
 
 // ReservedGoKeywordParameters converts echo context to params.
-func (w *ServerInterfaceWrapper) ReservedGoKeywordParameters(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) ReservedGoKeywordParameters(c echo.Context) error {
 	var err error
 	// ------------- Path parameter "type" -------------
 	var pType string
 
-	err = runtime.BindStyledParameterWithOptions("simple", "type", ctx.Param("type"), &pType, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "type", c.Param("type"), &pType, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter type: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.ReservedGoKeywordParameters(ctx, pType)
+	err = w.Handler.ReservedGoKeywordParameters(c, pType)
 	return err
 }
 
 // ReusableResponses converts echo context to params.
-func (w *ServerInterfaceWrapper) ReusableResponses(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) ReusableResponses(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.ReusableResponses(ctx)
+	err = w.Handler.ReusableResponses(c)
 	return err
 }
 
 // TextExample converts echo context to params.
-func (w *ServerInterfaceWrapper) TextExample(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) TextExample(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.TextExample(ctx)
+	err = w.Handler.TextExample(c)
 	return err
 }
 
 // UnknownExample converts echo context to params.
-func (w *ServerInterfaceWrapper) UnknownExample(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) UnknownExample(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.UnknownExample(ctx)
+	err = w.Handler.UnknownExample(c)
 	return err
 }
 
 // UnspecifiedContentType converts echo context to params.
-func (w *ServerInterfaceWrapper) UnspecifiedContentType(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) UnspecifiedContentType(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.UnspecifiedContentType(ctx)
+	err = w.Handler.UnspecifiedContentType(c)
 	return err
 }
 
 // URLEncodedExample converts echo context to params.
-func (w *ServerInterfaceWrapper) URLEncodedExample(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) URLEncodedExample(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.URLEncodedExample(ctx)
+	err = w.Handler.URLEncodedExample(c)
 	return err
 }
 
 // HeadersExample converts echo context to params.
-func (w *ServerInterfaceWrapper) HeadersExample(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) HeadersExample(c echo.Context) error {
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params HeadersExampleParams
 
-	headers := ctx.Request().Header
+	headers := c.Request().Header
 	// ------------- Required header parameter "header1" -------------
 	if valueList, found := headers[http.CanonicalHeaderKey("header1")]; found {
 		var Header1 string
@@ -195,16 +195,16 @@ func (w *ServerInterfaceWrapper) HeadersExample(ctx echo.Context) error {
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.HeadersExample(ctx, params)
+	err = w.Handler.HeadersExample(c, params)
 	return err
 }
 
 // UnionExample converts echo context to params.
-func (w *ServerInterfaceWrapper) UnionExample(ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) UnionExample(c echo.Context) error {
 	var err error
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.UnionExample(ctx)
+	err = w.Handler.UnionExample(c)
 	return err
 }
 
@@ -795,28 +795,28 @@ type strictHandler struct {
 }
 
 // JSONExample operation middleware
-func (sh *strictHandler) JSONExample(ctx echo.Context) error {
+func (sh *strictHandler) JSONExample(c echo.Context) error {
 	var request JSONExampleRequestObject
 
 	var body JSONExampleJSONRequestBody
-	if err := ctx.Bind(&body); err != nil {
+	if err := c.Bind(&body); err != nil {
 		return err
 	}
 	request.Body = &body
 
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.JSONExample(ctx.Request().Context(), request.(JSONExampleRequestObject))
+	handler := func(c echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.JSONExample(c.Request().Context(), request.(JSONExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "JSONExample")
 	}
 
-	response, err := handler(ctx, request)
+	response, err := handler(c, request)
 
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(JSONExampleResponseObject); ok {
-		return validResponse.VisitJSONExampleResponse(ctx.Response())
+		return validResponse.VisitJSONExampleResponse(c.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}
@@ -824,28 +824,28 @@ func (sh *strictHandler) JSONExample(ctx echo.Context) error {
 }
 
 // MultipartExample operation middleware
-func (sh *strictHandler) MultipartExample(ctx echo.Context) error {
+func (sh *strictHandler) MultipartExample(c echo.Context) error {
 	var request MultipartExampleRequestObject
 
-	if reader, err := ctx.Request().MultipartReader(); err != nil {
+	if reader, err := c.Request().MultipartReader(); err != nil {
 		return err
 	} else {
 		request.Body = reader
 	}
 
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.MultipartExample(ctx.Request().Context(), request.(MultipartExampleRequestObject))
+	handler := func(c echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.MultipartExample(c.Request().Context(), request.(MultipartExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "MultipartExample")
 	}
 
-	response, err := handler(ctx, request)
+	response, err := handler(c, request)
 
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(MultipartExampleResponseObject); ok {
-		return validResponse.VisitMultipartExampleResponse(ctx.Response())
+		return validResponse.VisitMultipartExampleResponse(c.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}
@@ -853,18 +853,18 @@ func (sh *strictHandler) MultipartExample(ctx echo.Context) error {
 }
 
 // MultipleRequestAndResponseTypes operation middleware
-func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx echo.Context) error {
+func (sh *strictHandler) MultipleRequestAndResponseTypes(c echo.Context) error {
 	var request MultipleRequestAndResponseTypesRequestObject
 
-	if strings.HasPrefix(ctx.Request().Header.Get("Content-Type"), "application/json") {
+	if strings.HasPrefix(c.Request().Header.Get("Content-Type"), "application/json") {
 		var body MultipleRequestAndResponseTypesJSONRequestBody
-		if err := ctx.Bind(&body); err != nil {
+		if err := c.Bind(&body); err != nil {
 			return err
 		}
 		request.JSONBody = &body
 	}
-	if strings.HasPrefix(ctx.Request().Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
-		if form, err := ctx.FormParams(); err == nil {
+	if strings.HasPrefix(c.Request().Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
+		if form, err := c.FormParams(); err == nil {
 			var body MultipleRequestAndResponseTypesFormdataRequestBody
 			if err := runtime.BindForm(&body, form, nil, nil); err != nil {
 				return err
@@ -874,18 +874,18 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx echo.Context) error
 			return err
 		}
 	}
-	if strings.HasPrefix(ctx.Request().Header.Get("Content-Type"), "image/png") {
-		request.Body = ctx.Request().Body
+	if strings.HasPrefix(c.Request().Header.Get("Content-Type"), "image/png") {
+		request.Body = c.Request().Body
 	}
-	if strings.HasPrefix(ctx.Request().Header.Get("Content-Type"), "multipart/form-data") {
-		if reader, err := ctx.Request().MultipartReader(); err != nil {
+	if strings.HasPrefix(c.Request().Header.Get("Content-Type"), "multipart/form-data") {
+		if reader, err := c.Request().MultipartReader(); err != nil {
 			return err
 		} else {
 			request.MultipartBody = reader
 		}
 	}
-	if strings.HasPrefix(ctx.Request().Header.Get("Content-Type"), "text/plain") {
-		data, err := io.ReadAll(ctx.Request().Body)
+	if strings.HasPrefix(c.Request().Header.Get("Content-Type"), "text/plain") {
+		data, err := io.ReadAll(c.Request().Body)
 		if err != nil {
 			return err
 		}
@@ -893,19 +893,19 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx echo.Context) error
 		request.TextBody = &body
 	}
 
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.MultipleRequestAndResponseTypes(ctx.Request().Context(), request.(MultipleRequestAndResponseTypesRequestObject))
+	handler := func(c echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.MultipleRequestAndResponseTypes(c.Request().Context(), request.(MultipleRequestAndResponseTypesRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "MultipleRequestAndResponseTypes")
 	}
 
-	response, err := handler(ctx, request)
+	response, err := handler(c, request)
 
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(MultipleRequestAndResponseTypesResponseObject); ok {
-		return validResponse.VisitMultipleRequestAndResponseTypesResponse(ctx.Response())
+		return validResponse.VisitMultipleRequestAndResponseTypesResponse(c.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}
@@ -913,24 +913,24 @@ func (sh *strictHandler) MultipleRequestAndResponseTypes(ctx echo.Context) error
 }
 
 // ReservedGoKeywordParameters operation middleware
-func (sh *strictHandler) ReservedGoKeywordParameters(ctx echo.Context, pType string) error {
+func (sh *strictHandler) ReservedGoKeywordParameters(c echo.Context, pType string) error {
 	var request ReservedGoKeywordParametersRequestObject
 
 	request.Type = pType
 
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.ReservedGoKeywordParameters(ctx.Request().Context(), request.(ReservedGoKeywordParametersRequestObject))
+	handler := func(c echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.ReservedGoKeywordParameters(c.Request().Context(), request.(ReservedGoKeywordParametersRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "ReservedGoKeywordParameters")
 	}
 
-	response, err := handler(ctx, request)
+	response, err := handler(c, request)
 
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(ReservedGoKeywordParametersResponseObject); ok {
-		return validResponse.VisitReservedGoKeywordParametersResponse(ctx.Response())
+		return validResponse.VisitReservedGoKeywordParametersResponse(c.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}
@@ -938,28 +938,28 @@ func (sh *strictHandler) ReservedGoKeywordParameters(ctx echo.Context, pType str
 }
 
 // ReusableResponses operation middleware
-func (sh *strictHandler) ReusableResponses(ctx echo.Context) error {
+func (sh *strictHandler) ReusableResponses(c echo.Context) error {
 	var request ReusableResponsesRequestObject
 
 	var body ReusableResponsesJSONRequestBody
-	if err := ctx.Bind(&body); err != nil {
+	if err := c.Bind(&body); err != nil {
 		return err
 	}
 	request.Body = &body
 
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.ReusableResponses(ctx.Request().Context(), request.(ReusableResponsesRequestObject))
+	handler := func(c echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.ReusableResponses(c.Request().Context(), request.(ReusableResponsesRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "ReusableResponses")
 	}
 
-	response, err := handler(ctx, request)
+	response, err := handler(c, request)
 
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(ReusableResponsesResponseObject); ok {
-		return validResponse.VisitReusableResponsesResponse(ctx.Response())
+		return validResponse.VisitReusableResponsesResponse(c.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}
@@ -967,29 +967,29 @@ func (sh *strictHandler) ReusableResponses(ctx echo.Context) error {
 }
 
 // TextExample operation middleware
-func (sh *strictHandler) TextExample(ctx echo.Context) error {
+func (sh *strictHandler) TextExample(c echo.Context) error {
 	var request TextExampleRequestObject
 
-	data, err := io.ReadAll(ctx.Request().Body)
+	data, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		return err
 	}
 	body := TextExampleTextRequestBody(data)
 	request.Body = &body
 
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.TextExample(ctx.Request().Context(), request.(TextExampleRequestObject))
+	handler := func(c echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.TextExample(c.Request().Context(), request.(TextExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "TextExample")
 	}
 
-	response, err := handler(ctx, request)
+	response, err := handler(c, request)
 
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(TextExampleResponseObject); ok {
-		return validResponse.VisitTextExampleResponse(ctx.Response())
+		return validResponse.VisitTextExampleResponse(c.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}
@@ -997,24 +997,24 @@ func (sh *strictHandler) TextExample(ctx echo.Context) error {
 }
 
 // UnknownExample operation middleware
-func (sh *strictHandler) UnknownExample(ctx echo.Context) error {
+func (sh *strictHandler) UnknownExample(c echo.Context) error {
 	var request UnknownExampleRequestObject
 
-	request.Body = ctx.Request().Body
+	request.Body = c.Request().Body
 
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.UnknownExample(ctx.Request().Context(), request.(UnknownExampleRequestObject))
+	handler := func(c echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.UnknownExample(c.Request().Context(), request.(UnknownExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "UnknownExample")
 	}
 
-	response, err := handler(ctx, request)
+	response, err := handler(c, request)
 
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(UnknownExampleResponseObject); ok {
-		return validResponse.VisitUnknownExampleResponse(ctx.Response())
+		return validResponse.VisitUnknownExampleResponse(c.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}
@@ -1022,26 +1022,26 @@ func (sh *strictHandler) UnknownExample(ctx echo.Context) error {
 }
 
 // UnspecifiedContentType operation middleware
-func (sh *strictHandler) UnspecifiedContentType(ctx echo.Context) error {
+func (sh *strictHandler) UnspecifiedContentType(c echo.Context) error {
 	var request UnspecifiedContentTypeRequestObject
 
-	request.ContentType = ctx.Request().Header.Get("Content-Type")
+	request.ContentType = c.Request().Header.Get("Content-Type")
 
-	request.Body = ctx.Request().Body
+	request.Body = c.Request().Body
 
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.UnspecifiedContentType(ctx.Request().Context(), request.(UnspecifiedContentTypeRequestObject))
+	handler := func(c echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.UnspecifiedContentType(c.Request().Context(), request.(UnspecifiedContentTypeRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "UnspecifiedContentType")
 	}
 
-	response, err := handler(ctx, request)
+	response, err := handler(c, request)
 
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(UnspecifiedContentTypeResponseObject); ok {
-		return validResponse.VisitUnspecifiedContentTypeResponse(ctx.Response())
+		return validResponse.VisitUnspecifiedContentTypeResponse(c.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}
@@ -1049,10 +1049,10 @@ func (sh *strictHandler) UnspecifiedContentType(ctx echo.Context) error {
 }
 
 // URLEncodedExample operation middleware
-func (sh *strictHandler) URLEncodedExample(ctx echo.Context) error {
+func (sh *strictHandler) URLEncodedExample(c echo.Context) error {
 	var request URLEncodedExampleRequestObject
 
-	if form, err := ctx.FormParams(); err == nil {
+	if form, err := c.FormParams(); err == nil {
 		var body URLEncodedExampleFormdataRequestBody
 		if err := runtime.BindForm(&body, form, nil, nil); err != nil {
 			return err
@@ -1062,19 +1062,19 @@ func (sh *strictHandler) URLEncodedExample(ctx echo.Context) error {
 		return err
 	}
 
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.URLEncodedExample(ctx.Request().Context(), request.(URLEncodedExampleRequestObject))
+	handler := func(c echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.URLEncodedExample(c.Request().Context(), request.(URLEncodedExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "URLEncodedExample")
 	}
 
-	response, err := handler(ctx, request)
+	response, err := handler(c, request)
 
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(URLEncodedExampleResponseObject); ok {
-		return validResponse.VisitURLEncodedExampleResponse(ctx.Response())
+		return validResponse.VisitURLEncodedExampleResponse(c.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}
@@ -1082,30 +1082,30 @@ func (sh *strictHandler) URLEncodedExample(ctx echo.Context) error {
 }
 
 // HeadersExample operation middleware
-func (sh *strictHandler) HeadersExample(ctx echo.Context, params HeadersExampleParams) error {
+func (sh *strictHandler) HeadersExample(c echo.Context, params HeadersExampleParams) error {
 	var request HeadersExampleRequestObject
 
 	request.Params = params
 
 	var body HeadersExampleJSONRequestBody
-	if err := ctx.Bind(&body); err != nil {
+	if err := c.Bind(&body); err != nil {
 		return err
 	}
 	request.Body = &body
 
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.HeadersExample(ctx.Request().Context(), request.(HeadersExampleRequestObject))
+	handler := func(c echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.HeadersExample(c.Request().Context(), request.(HeadersExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "HeadersExample")
 	}
 
-	response, err := handler(ctx, request)
+	response, err := handler(c, request)
 
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(HeadersExampleResponseObject); ok {
-		return validResponse.VisitHeadersExampleResponse(ctx.Response())
+		return validResponse.VisitHeadersExampleResponse(c.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}
@@ -1113,28 +1113,28 @@ func (sh *strictHandler) HeadersExample(ctx echo.Context, params HeadersExampleP
 }
 
 // UnionExample operation middleware
-func (sh *strictHandler) UnionExample(ctx echo.Context) error {
+func (sh *strictHandler) UnionExample(c echo.Context) error {
 	var request UnionExampleRequestObject
 
 	var body UnionExampleJSONRequestBody
-	if err := ctx.Bind(&body); err != nil {
+	if err := c.Bind(&body); err != nil {
 		return err
 	}
 	request.Body = &body
 
-	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
-		return sh.ssi.UnionExample(ctx.Request().Context(), request.(UnionExampleRequestObject))
+	handler := func(c echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.UnionExample(c.Request().Context(), request.(UnionExampleRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
 		handler = middleware(handler, "UnionExample")
 	}
 
-	response, err := handler(ctx, request)
+	response, err := handler(c, request)
 
 	if err != nil {
 		return err
 	} else if validResponse, ok := response.(UnionExampleResponseObject); ok {
-		return validResponse.VisitUnionExampleResponse(ctx.Response())
+		return validResponse.VisitUnionExampleResponse(c.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}

--- a/pkg/codegen/templates/echo/echo-interface.tmpl
+++ b/pkg/codegen/templates/echo/echo-interface.tmpl
@@ -2,6 +2,6 @@
 type ServerInterface interface {
 {{range .}}{{.SummaryAsComment }}
 // ({{.Method}} {{.Path}})
-{{.OperationId}}(ctx echo.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{.OperationId}}Params{{end}}) error
+{{.OperationId}}(c echo.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{.OperationId}}Params{{end}}) error
 {{end}}
 }

--- a/pkg/codegen/templates/echo/echo-wrappers.tmpl
+++ b/pkg/codegen/templates/echo/echo-wrappers.tmpl
@@ -4,21 +4,21 @@ type ServerInterfaceWrapper struct {
 }
 
 {{range .}}{{$opid := .OperationId}}// {{$opid}} converts echo context to params.
-func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
+func (w *ServerInterfaceWrapper) {{.OperationId}} (c echo.Context) error {
     var err error
 {{range .PathParams}}// ------------- Path parameter "{{.ParamName}}" -------------
     var {{$varName := .GoVariableName}}{{$varName}} {{.TypeDef}}
 {{if .IsPassThrough}}
-    {{$varName}} = ctx.Param("{{.ParamName}}")
+    {{$varName}} = c.Param("{{.ParamName}}")
 {{end}}
 {{if .IsJson}}
-    err = json.Unmarshal([]byte(ctx.Param("{{.ParamName}}")), &{{$varName}})
+    err = json.Unmarshal([]byte(c.Param("{{.ParamName}}")), &{{$varName}})
     if err != nil {
         return echo.NewHTTPError(http.StatusBadRequest, "Error unmarshaling parameter '{{.ParamName}}' as JSON")
     }
 {{end}}
 {{if .IsStyled}}
-    err = runtime.BindStyledParameterWithOptions("{{.Style}}", "{{.ParamName}}", ctx.Param("{{.ParamName}}"), &{{$varName}}, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: {{.Explode}}, Required: {{.Required}}})
+    err = runtime.BindStyledParameterWithOptions("{{.Style}}", "{{.ParamName}}", c.Param("{{.ParamName}}"), &{{$varName}}, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: {{.Explode}}, Required: {{.Required}}})
     if err != nil {
         return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err))
     }
@@ -26,7 +26,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
 {{end}}
 
 {{range .SecurityDefinitions}}
-    ctx.Set({{.ProviderName | sanitizeGoIdentity | ucFirst}}Scopes, {{toStringArray .Scopes}})
+    c.Set({{.ProviderName | sanitizeGoIdentity | ucFirst}}Scopes, {{toStringArray .Scopes}})
 {{end}}
 
 {{if .RequiresParamObject}}
@@ -37,12 +37,12 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
       // ------------- {{if .Required}}Required{{else}}Optional{{end}} query parameter "{{.ParamName}}" -------------
     {{ end }}
     {{if .IsStyled}}
-    err = runtime.BindQueryParameter("{{.Style}}", {{.Explode}}, {{.Required}}, "{{.ParamName}}", ctx.QueryParams(), &params.{{.GoName}})
+    err = runtime.BindQueryParameter("{{.Style}}", {{.Explode}}, {{.Required}}, "{{.ParamName}}", c.QueryParams(), &params.{{.GoName}})
     if err != nil {
         return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter {{.ParamName}}: %s", err))
     }
     {{else}}
-    if paramValue := ctx.QueryParam("{{.ParamName}}"); paramValue != "" {
+    if paramValue := c.QueryParam("{{.ParamName}}"); paramValue != "" {
     {{if .IsPassThrough}}
     params.{{.GoName}} = {{if not .Required}}&{{end}}paramValue
     {{end}}
@@ -61,7 +61,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
 {{end}}
 
 {{if .HeaderParams}}
-    headers := ctx.Request().Header
+    headers := c.Request().Header
 {{range .HeaderParams}}// ------------- {{if .Required}}Required{{else}}Optional{{end}} header parameter "{{.ParamName}}" -------------
     if valueList, found := headers[http.CanonicalHeaderKey("{{.ParamName}}")]; found {
         var {{.GoName}} {{.TypeDef}}
@@ -92,7 +92,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
 {{end}}
 
 {{range .CookieParams}}
-    if cookie, err := ctx.Cookie("{{.ParamName}}"); err == nil {
+    if cookie, err := c.Cookie("{{.ParamName}}"); err == nil {
     {{if .IsPassThrough}}
     params.{{.GoName}} = {{if not .Required}}&{{end}}cookie.Value
     {{end}}
@@ -125,7 +125,7 @@ func (w *ServerInterfaceWrapper) {{.OperationId}} (ctx echo.Context) error {
 
 {{end}}{{/* .RequiresParamObject */}}
     // Invoke the callback with all the unmarshaled arguments
-    err = w.Handler.{{.OperationId}}(ctx{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
+    err = w.Handler.{{.OperationId}}(c{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{end}})
     return err
 }
 {{end}}

--- a/pkg/codegen/templates/strict/strict-echo.tmpl
+++ b/pkg/codegen/templates/strict/strict-echo.tmpl
@@ -13,7 +13,7 @@ type strictHandler struct {
 {{range .}}
     {{$opid := .OperationId}}
     // {{$opid}} operation middleware
-    func (sh *strictHandler) {{.OperationId}}(ctx echo.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{.OperationId}}Params{{end}}) error {
+    func (sh *strictHandler) {{.OperationId}}(c echo.Context{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{.OperationId}}Params{{end}}) error {
         var request {{$opid | ucFirst}}RequestObject
 
         {{range .PathParams -}}
@@ -25,20 +25,20 @@ type strictHandler struct {
         {{end -}}
 
         {{ if .HasMaskedRequestContentTypes -}}
-            request.ContentType = ctx.Request().Header.Get("Content-Type")
+            request.ContentType = c.Request().Header.Get("Content-Type")
         {{end -}}
 
         {{$multipleBodies := gt (len .Bodies) 1 -}}
         {{range .Bodies -}}
-            {{if $multipleBodies}}if strings.HasPrefix(ctx.Request().Header.Get("Content-Type"), "{{.ContentType}}") { {{end}}
+            {{if $multipleBodies}}if strings.HasPrefix(c.Request().Header.Get("Content-Type"), "{{.ContentType}}") { {{end}}
                 {{if .IsJSON -}}
                     var body {{$opid}}{{.NameTag}}RequestBody
-                    if err := ctx.Bind(&body); err != nil {
+                    if err := c.Bind(&body); err != nil {
                         return err
                     }
                     request.{{if $multipleBodies}}{{.NameTag}}{{end}}Body = &body
                 {{else if eq .NameTag "Formdata" -}}
-                    if form, err := ctx.FormParams(); err == nil {
+                    if form, err := c.FormParams(); err == nil {
                         var body {{$opid}}{{.NameTag}}RequestBody
                         if err := runtime.BindForm(&body, form, nil, nil); err != nil {
                             return err
@@ -48,37 +48,37 @@ type strictHandler struct {
                         return err
                     }
                 {{else if eq .NameTag "Multipart" -}}
-                    if reader, err := ctx.Request().MultipartReader(); err != nil {
+                    if reader, err := c.Request().MultipartReader(); err != nil {
                         return err
                     } else {
                         request.{{if $multipleBodies}}{{.NameTag}}{{end}}Body = reader
                     }
                 {{else if eq .NameTag "Text" -}}
-                    data, err := io.ReadAll(ctx.Request().Body)
+                    data, err := io.ReadAll(c.Request().Body)
                     if err != nil {
                         return err
                     }
                     body := {{$opid}}{{.NameTag}}RequestBody(data)
                     request.{{if $multipleBodies}}{{.NameTag}}{{end}}Body = &body
                 {{else -}}
-                    request.{{if $multipleBodies}}{{.NameTag}}{{end}}Body = ctx.Request().Body
+                    request.{{if $multipleBodies}}{{.NameTag}}{{end}}Body = c.Request().Body
                 {{end}}{{/* if eq .NameTag "JSON" */ -}}
             {{if $multipleBodies}}}{{end}}
         {{end}}{{/* range .Bodies */}}
 
-        handler := func(ctx echo.Context, request interface{}) (interface{}, error){
-            return sh.ssi.{{.OperationId}}(ctx.Request().Context(), request.({{$opid | ucFirst}}RequestObject))
+        handler := func(c echo.Context, request interface{}) (interface{}, error){
+            return sh.ssi.{{.OperationId}}(c.Request().Context(), request.({{$opid | ucFirst}}RequestObject))
         }
         for _, middleware := range sh.middlewares {
             handler = middleware(handler, "{{.OperationId}}")
         }
 
-        response, err := handler(ctx, request)
+        response, err := handler(c, request)
 
         if err != nil {
             return err
         } else if validResponse, ok := response.({{$opid | ucFirst}}ResponseObject); ok {
-            return validResponse.Visit{{$opid}}Response(ctx.Response())
+            return validResponse.Visit{{$opid}}Response(c.Response())
         } else if response != nil {
             return fmt.Errorf("unexpected response type: %T", response)
         }


### PR DESCRIPTION
Note To Reviewer: I'm aware that you [don't usually want to change variable names in generated code](https://github.com/deepmap/oapi-codegen#contributing), but this particular change should not affect existing code, as interfaces don't need to have the same parameter _names_ as their implementations.

## Change Description

Echo uses `c` as the `echo.Context` parameter name, differentiating it from the widely used `ctx` for a `context.Context`.

This commit updates the generated code to use the `c` convention to bring it in line with Echo's common practice and make generated code more readable.

This change will not break existing code.  Existing `ServerInterface` do not need to have the same parameter names, so all existing code that uses `ctx echo.Context` will be able to ignore the change (or update when it's convenient).