### PR TITLE
Support media type parameters for `IsMediaTypeJson`

### DIFF
--- a/pkg/util/isjson.go
+++ b/pkg/util/isjson.go
@@ -1,7 +1,14 @@
 package util
 
-import "strings"
+import (
+	"mime"
+	"strings"
+)
 
 func IsMediaTypeJson(mediaType string) bool {
-	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+	parsed, _, err := mime.ParseMediaType(mediaType)
+	if err != nil {
+		return false
+	}
+	return parsed == "application/json" || strings.HasSuffix(parsed, "+json")
 }

--- a/pkg/util/isjson_test.go
+++ b/pkg/util/isjson_test.go
@@ -41,6 +41,18 @@ func TestIsMediaTypeJson(t *testing.T) {
 			mediaType: "application/vnd.api+json",
 			want:      true,
 		},
+		{
+			// NOTE that this _technically_ isn't a standard extension to JSON https://www.iana.org/assignments/media-types/application/json but due to the fact that several APIs do use it, we should support it
+			name:      "When MediaType is application/json;v=1, returns true",
+			mediaType: "application/json;v=1",
+			want:      true,
+		},
+		{
+			// NOTE that this _technically_ isn't a standard extension to JSON https://www.iana.org/assignments/media-types/application/json but due to the fact that several APIs do use it, we should support it
+			name:      "When MediaType is application/json;version=1, returns true",
+			mediaType: "application/json;version=1",
+			want:      true,
+		},
 	}
 	for _, test := range suite {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Although not _technically_ a valid extension to JSON according to [the
media type definition], it's got a number of services using it for a `v`
or `version` parameter, so we should support this as a valid option.

This makes sure that we parse it as a valid media type, performing the
same checks as we did before by ignoring the parameters.

[the media type definition]: https://www.iana.org/assignments/media-types/application/json

---

As an alternative to https://github.com/deepmap/oapi-codegen/pull/1374