### PR TITLE
Add OperationID in client request header

### DIFF
--- a/examples/authenticated-api/echo/api/api.gen.go
+++ b/examples/authenticated-api/echo/api/api.gen.go
@@ -189,6 +189,8 @@ func NewListThingsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "ListThings")
+
 	return req, nil
 }
 
@@ -227,6 +229,7 @@ func NewAddThingRequestWithBody(server string, contentType string, body io.Reade
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "AddThing")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil

--- a/examples/custom-client-type/custom-client-type.gen.go
+++ b/examples/custom-client-type/custom-client-type.gen.go
@@ -131,6 +131,8 @@ func NewGetClientRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetClient")
+
 	return req, nil
 }
 

--- a/examples/petstore-expanded/petstore-client.gen.go
+++ b/examples/petstore-expanded/petstore-client.gen.go
@@ -268,6 +268,8 @@ func NewFindPetsRequest(server string, params *FindPetsParams) (*http.Request, e
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "FindPets")
+
 	return req, nil
 }
 
@@ -306,6 +308,7 @@ func NewAddPetRequestWithBody(server string, contentType string, body io.Reader)
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "AddPet")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -342,6 +345,8 @@ func NewDeletePetRequest(server string, id int64) (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "DeletePet")
+
 	return req, nil
 }
 
@@ -375,6 +380,8 @@ func NewFindPetByIDRequest(server string, id int64) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "FindPetByID")
 
 	return req, nil
 }

--- a/internal/test/any_of/param/param.gen.go
+++ b/internal/test/any_of/param/param.gen.go
@@ -324,6 +324,8 @@ func NewGetTestRequest(server string, params *GetTestParams) (*http.Request, err
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetTest")
+
 	return req, nil
 }
 

--- a/internal/test/client/client.gen.go
+++ b/internal/test/client/client.gen.go
@@ -307,6 +307,7 @@ func NewPostBothRequestWithBody(server string, contentType string, body io.Reade
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "PostBoth")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -335,6 +336,8 @@ func NewGetBothRequest(server string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "GetBoth")
 
 	return req, nil
 }
@@ -374,6 +377,7 @@ func NewPostJsonRequestWithBody(server string, contentType string, body io.Reade
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "PostJson")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -403,6 +407,8 @@ func NewGetJsonRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetJson")
+
 	return req, nil
 }
 
@@ -430,6 +436,7 @@ func NewPostOtherRequestWithBody(server string, contentType string, body io.Read
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "PostOther")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -459,6 +466,8 @@ func NewGetOtherRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetOther")
+
 	return req, nil
 }
 
@@ -485,6 +494,8 @@ func NewGetJsonWithTrailingSlashRequest(server string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "GetJsonWithTrailingSlash")
 
 	return req, nil
 }
@@ -524,6 +535,7 @@ func NewPostVendorJsonRequestWithBody(server string, contentType string, body io
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "PostVendorJson")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil

--- a/internal/test/issues/issue-1087/api.gen.go
+++ b/internal/test/issues/issue-1087/api.gen.go
@@ -146,6 +146,8 @@ func NewGetThingsRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetThings")
+
 	return req, nil
 }
 

--- a/internal/test/issues/issue-1180/issue.gen.go
+++ b/internal/test/issues/issue-1180/issue.gen.go
@@ -140,6 +140,8 @@ func NewGetSimplePrimitiveRequest(server string, param string) (*http.Request, e
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetSimplePrimitive")
+
 	return req, nil
 }
 

--- a/internal/test/issues/issue-1182/pkg1/pkg1.gen.go
+++ b/internal/test/issues/issue-1182/pkg1/pkg1.gen.go
@@ -134,6 +134,8 @@ func NewTestGetRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "TestGet")
+
 	return req, nil
 }
 

--- a/internal/test/issues/issue-1189/issue1189.gen.go
+++ b/internal/test/issues/issue-1189/issue1189.gen.go
@@ -308,6 +308,8 @@ func NewTestRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "Test")
+
 	return req, nil
 }
 

--- a/internal/test/issues/issue-1208-1209/issue-multi-json.gen.go
+++ b/internal/test/issues/issue-1208-1209/issue-multi-json.gen.go
@@ -150,6 +150,8 @@ func NewTestRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "Test")
+
 	return req, nil
 }
 

--- a/internal/test/issues/issue-1212/pkg1/pkg1.gen.go
+++ b/internal/test/issues/issue-1212/pkg1/pkg1.gen.go
@@ -136,6 +136,8 @@ func NewTestRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "Test")
+
 	return req, nil
 }
 

--- a/internal/test/issues/issue-1298/issue1298.gen.go
+++ b/internal/test/issues/issue-1298/issue1298.gen.go
@@ -164,6 +164,7 @@ func NewTestRequestWithBody(server string, contentType string, body io.Reader) (
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "Test")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil

--- a/internal/test/issues/issue-312/issue.gen.go
+++ b/internal/test/issues/issue-312/issue.gen.go
@@ -194,6 +194,8 @@ func NewGetPetRequest(server string, petId string) (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetPet")
+
 	return req, nil
 }
 
@@ -232,6 +234,7 @@ func NewValidatePetsRequestWithBody(server string, contentType string, body io.R
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "ValidatePets")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil

--- a/internal/test/issues/issue-52/issue.gen.go
+++ b/internal/test/issues/issue-52/issue.gen.go
@@ -147,6 +147,8 @@ func NewExampleGetRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "ExampleGet")
+
 	return req, nil
 }
 

--- a/internal/test/issues/issue-grab_import_names/issue.gen.go
+++ b/internal/test/issues/issue-grab_import_names/issue.gen.go
@@ -143,6 +143,8 @@ func NewGetFooRequest(server string, params *GetFooParams) (*http.Request, error
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetFoo")
+
 	if params != nil {
 
 		if params.Foo != nil {

--- a/internal/test/issues/issue-illegal_enum_names/issue.gen.go
+++ b/internal/test/issues/issue-illegal_enum_names/issue.gen.go
@@ -150,6 +150,8 @@ func NewGetFooRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetFoo")
+
 	return req, nil
 }
 

--- a/internal/test/parameters/parameters.gen.go
+++ b/internal/test/parameters/parameters.gen.go
@@ -561,6 +561,8 @@ func NewGetContentObjectRequest(server string, param ComplexObject) (*http.Reque
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetContentObject")
+
 	return req, nil
 }
 
@@ -587,6 +589,8 @@ func NewGetCookieRequest(server string, params *GetCookieParams) (*http.Request,
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "GetCookie")
 
 	if params != nil {
 
@@ -761,6 +765,8 @@ func NewEnumParamsRequest(server string, params *EnumParamsParams) (*http.Reques
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "EnumParams")
+
 	return req, nil
 }
 
@@ -787,6 +793,8 @@ func NewGetHeaderRequest(server string, params *GetHeaderParams) (*http.Request,
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "GetHeader")
 
 	if params != nil {
 
@@ -916,6 +924,8 @@ func NewGetLabelExplodeArrayRequest(server string, param []int32) (*http.Request
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetLabelExplodeArray")
+
 	return req, nil
 }
 
@@ -949,6 +959,8 @@ func NewGetLabelExplodeObjectRequest(server string, param Object) (*http.Request
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "GetLabelExplodeObject")
 
 	return req, nil
 }
@@ -984,6 +996,8 @@ func NewGetLabelNoExplodeArrayRequest(server string, param []int32) (*http.Reque
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetLabelNoExplodeArray")
+
 	return req, nil
 }
 
@@ -1017,6 +1031,8 @@ func NewGetLabelNoExplodeObjectRequest(server string, param Object) (*http.Reque
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "GetLabelNoExplodeObject")
 
 	return req, nil
 }
@@ -1052,6 +1068,8 @@ func NewGetMatrixExplodeArrayRequest(server string, id []int32) (*http.Request, 
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetMatrixExplodeArray")
+
 	return req, nil
 }
 
@@ -1085,6 +1103,8 @@ func NewGetMatrixExplodeObjectRequest(server string, id Object) (*http.Request, 
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "GetMatrixExplodeObject")
 
 	return req, nil
 }
@@ -1120,6 +1140,8 @@ func NewGetMatrixNoExplodeArrayRequest(server string, id []int32) (*http.Request
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetMatrixNoExplodeArray")
+
 	return req, nil
 }
 
@@ -1154,6 +1176,8 @@ func NewGetMatrixNoExplodeObjectRequest(server string, id Object) (*http.Request
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetMatrixNoExplodeObject")
+
 	return req, nil
 }
 
@@ -1184,6 +1208,8 @@ func NewGetPassThroughRequest(server string, param string) (*http.Request, error
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "GetPassThrough")
 
 	return req, nil
 }
@@ -1229,6 +1255,8 @@ func NewGetDeepObjectRequest(server string, params *GetDeepObjectParams) (*http.
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "GetDeepObject")
 
 	return req, nil
 }
@@ -1401,6 +1429,8 @@ func NewGetQueryFormRequest(server string, params *GetQueryFormParams) (*http.Re
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetQueryForm")
+
 	return req, nil
 }
 
@@ -1434,6 +1464,8 @@ func NewGetSimpleExplodeArrayRequest(server string, param []int32) (*http.Reques
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "GetSimpleExplodeArray")
 
 	return req, nil
 }
@@ -1469,6 +1501,8 @@ func NewGetSimpleExplodeObjectRequest(server string, param Object) (*http.Reques
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetSimpleExplodeObject")
+
 	return req, nil
 }
 
@@ -1502,6 +1536,8 @@ func NewGetSimpleNoExplodeArrayRequest(server string, param []int32) (*http.Requ
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "GetSimpleNoExplodeArray")
 
 	return req, nil
 }
@@ -1537,6 +1573,8 @@ func NewGetSimpleNoExplodeObjectRequest(server string, param Object) (*http.Requ
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetSimpleNoExplodeObject")
+
 	return req, nil
 }
 
@@ -1571,6 +1609,8 @@ func NewGetSimplePrimitiveRequest(server string, param int32) (*http.Request, er
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "GetSimplePrimitive")
+
 	return req, nil
 }
 
@@ -1601,6 +1641,8 @@ func NewGetStartingWithNumberRequest(server string, n1param string) (*http.Reque
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "GetStartingWithNumber")
 
 	return req, nil
 }

--- a/internal/test/schemas/schemas.gen.go
+++ b/internal/test/schemas/schemas.gen.go
@@ -389,6 +389,8 @@ func NewEnsureEverythingIsReferencedRequest(server string) (*http.Request, error
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "EnsureEverythingIsReferenced")
+
 	return req, nil
 }
 
@@ -416,6 +418,8 @@ func NewIssue1051Request(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "Issue1051")
+
 	return req, nil
 }
 
@@ -442,6 +446,8 @@ func NewIssue127Request(server string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "Issue127")
 
 	return req, nil
 }
@@ -481,6 +487,7 @@ func NewIssue185RequestWithBody(server string, contentType string, body io.Reade
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "Issue185")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -517,6 +524,8 @@ func NewIssue209Request(server string, str StringInPath) (*http.Request, error) 
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "Issue209")
+
 	return req, nil
 }
 
@@ -551,6 +560,8 @@ func NewIssue30Request(server string, pFallthrough string) (*http.Request, error
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "Issue30")
+
 	return req, nil
 }
 
@@ -577,6 +588,8 @@ func NewGetIssues375Request(server string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "GetIssues375")
 
 	return req, nil
 }
@@ -611,6 +624,8 @@ func NewIssue41Request(server string, n1param N5StartsWithNumber) (*http.Request
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "Issue41")
 
 	return req, nil
 }
@@ -668,6 +683,7 @@ func NewIssue9RequestWithBody(server string, params *Issue9Params, contentType s
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "Issue9")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -696,6 +712,8 @@ func NewIssue975Request(server string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "Issue975")
 
 	return req, nil
 }

--- a/internal/test/strict-server/client/client.gen.go
+++ b/internal/test/strict-server/client/client.gen.go
@@ -487,6 +487,7 @@ func NewJSONExampleRequestWithBody(server string, contentType string, body io.Re
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "JSONExample")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -516,6 +517,7 @@ func NewMultipartExampleRequestWithBody(server string, contentType string, body 
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "MultipartExample")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -545,6 +547,7 @@ func NewMultipartRelatedExampleRequestWithBody(server string, contentType string
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "MultipartRelatedExample")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -603,6 +606,7 @@ func NewMultipleRequestAndResponseTypesRequestWithBody(server string, contentTyp
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "MultipleRequestAndResponseTypes")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -638,6 +642,8 @@ func NewReservedGoKeywordParametersRequest(server string, pType string) (*http.R
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Operation-Id", "ReservedGoKeywordParameters")
 
 	return req, nil
 }
@@ -677,6 +683,7 @@ func NewReusableResponsesRequestWithBody(server string, contentType string, body
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "ReusableResponses")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -713,6 +720,7 @@ func NewTextExampleRequestWithBody(server string, contentType string, body io.Re
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "TextExample")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -742,6 +750,7 @@ func NewUnknownExampleRequestWithBody(server string, contentType string, body io
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "UnknownExample")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -771,6 +780,7 @@ func NewUnspecifiedContentTypeRequestWithBody(server string, contentType string,
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "UnspecifiedContentType")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -811,6 +821,7 @@ func NewURLEncodedExampleRequestWithBody(server string, contentType string, body
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "URLEncodedExample")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
@@ -851,6 +862,7 @@ func NewHeadersExampleRequestWithBody(server string, params *HeadersExampleParam
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "HeadersExample")
 	req.Header.Add("Content-Type", contentType)
 
 	if params != nil {
@@ -915,6 +927,7 @@ func NewUnionExampleRequestWithBody(server string, contentType string, body io.R
 		return nil, err
 	}
 
+	req.Header.Add("Operation-Id", "UnionExample")
 	req.Header.Add("Content-Type", contentType)
 
 	return req, nil

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -232,6 +232,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
         return nil, err
     }
 
+    req.Header.Add("Operation-Id", "{{$opid}}")
     {{if .HasBody}}req.Header.Add("Content-Type", contentType){{end}}
 {{ if .HeaderParams }}
     if params != nil {


### PR DESCRIPTION
I utilized this library to create a client from an OpenAPI specification, and now I aim to develop an interceptor for monitoring outgoing HTTP requests using Prometheus. 
However, the request path varies based on path parameters, making it impractical to use it as a label value for Prometheus metrics. 
As a solution, I propose adding an additional header (`Operation-Id`) to each HTTP request. This adjustment simplifies the process of writing the monitoring interceptor.

It just a naive solution. Feel free to suggest me the better solutions.