### PR TITLE
Fix Iris strict server for no content case

### DIFF
--- a/pkg/codegen/templates/strict/strict-iris-interface.tmpl
+++ b/pkg/codegen/templates/strict/strict-iris-interface.tmpl
@@ -126,7 +126,7 @@
             {{end -}}
             func (response {{$opid}}{{$statusCode}}Response) Visit{{$opid}}Response(ctx iris.Context) error {
                 {{range $headers -}}
-                    ctx.Response().Header.Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
+                    ctx.ResponseWriter().Header().Set("{{.Name}}", fmt.Sprint(response.Headers.{{.GoName}}))
                 {{end -}}
                 ctx.StatusCode({{if $fixedStatusCode}}{{$statusCode}}{{else}}response.StatusCode{{end}})
                 return nil


### PR DESCRIPTION
Fix broken code when response content is not exist, but response headers are exist in Iris strict server.