### PR TITLE
add unit tests for go type gen function

### DIFF
--- a/pkg/codegen/schema_test.go
+++ b/pkg/codegen/schema_test.go
@@ -158,7 +158,7 @@ func TestProperty_GoTypeDef(t *testing.T) {
 			want: "*int",
 		},
 		{
-			name: "When field is readOnly and optional and and read only pointer disabled",
+			name: "When field is readOnly and optional and read only pointer disabled",
 			fields: fields{
 				GlobalStateDisableRequiredReadOnlyAsPointer: true,
 				Schema: Schema{
@@ -174,9 +174,22 @@ func TestProperty_GoTypeDef(t *testing.T) {
 		// When field is write only, it will always be pointer unless pointer is
 		// skipped by setting SkipOptionalPointer flag
 		{
-			name: "When field is write only",
+			name: "When field is write only and read only pointer disabled",
 			fields: fields{
 				GlobalStateDisableRequiredReadOnlyAsPointer: true,
+				Schema: Schema{
+					SkipOptionalPointer: false,
+					GoType:              "int",
+				},
+				WriteOnly: true,
+			},
+			want: "*int",
+		},
+
+		{
+			name: "When field is write only and read only pointer enabled",
+			fields: fields{
+				GlobalStateDisableRequiredReadOnlyAsPointer: false,
 				Schema: Schema{
 					SkipOptionalPointer: false,
 					GoType:              "int",
@@ -196,7 +209,7 @@ func TestProperty_GoTypeDef(t *testing.T) {
 				ReadOnly:  tt.fields.ReadOnly,
 				WriteOnly: tt.fields.WriteOnly,
 			}
-			assert.Equalf(t, tt.want, p.GoTypeDef(), "GoTypeDef()")
+			assert.Equal(t, tt.want, p.GoTypeDef())
 		})
 	}
 }

--- a/pkg/codegen/schema_test.go
+++ b/pkg/codegen/schema_test.go
@@ -1,0 +1,202 @@
+package codegen
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestProperty_GoTypeDef(t *testing.T) {
+	type fields struct {
+		GlobalStateDisableRequiredReadOnlyAsPointer bool
+		Schema                                      Schema
+		Required                                    bool
+		Nullable                                    bool
+		ReadOnly                                    bool
+		WriteOnly                                   bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			// When pointer is skipped by setting flag SkipOptionalPointer, the
+			// flag will never be pointer irrespective of other flags.
+			name: "Set skip optional pointer type for go type",
+			fields: fields{
+				Schema: Schema{
+					SkipOptionalPointer: true,
+					RefType:             "",
+					GoType:              "int",
+				},
+			},
+			want: "int",
+		},
+
+		{
+			// if the field is optional, it will always be pointer irrespective of other
+			// flags, given that pointer type is not skipped by setting SkipOptionalPointer
+			// flag to true
+			name: "When the field is optional",
+			fields: fields{
+				Schema: Schema{
+					SkipOptionalPointer: false,
+					RefType:             "",
+					GoType:              "int",
+				},
+				Required: false,
+			},
+			want: "*int",
+		},
+
+		{
+			// if the field(custom-type) is optional, it will NOT be a pointer if
+			// SkipOptionalPointer flag is set to true
+			name: "Set skip optional pointer type for ref type",
+			fields: fields{
+				Schema: Schema{
+					SkipOptionalPointer: true,
+					RefType:             "CustomType",
+					GoType:              "int",
+				},
+				Required: false,
+			},
+			want: "CustomType",
+		},
+
+		// For the following test cases, SkipOptionalPointer flag is false.
+		{
+			name: "When field is required and not nullable",
+			fields: fields{
+				Schema: Schema{
+					SkipOptionalPointer: false,
+					GoType:              "int",
+				},
+				Required: true,
+				Nullable: false,
+			},
+			want: "int",
+		},
+
+		{
+			name: "When field is required and nullable",
+			fields: fields{
+				Schema: Schema{
+					SkipOptionalPointer: false,
+					GoType:              "int",
+				},
+				Required: true,
+				Nullable: true,
+			},
+			want: "*int",
+		},
+
+		{
+			name: "When field is optional and not nullable",
+			fields: fields{
+				Schema: Schema{
+					SkipOptionalPointer: false,
+					GoType:              "int",
+				},
+				Required: false,
+				Nullable: false,
+			},
+			want: "*int",
+		},
+
+		{
+			name: "When field is optional and nullable",
+			fields: fields{
+				Schema: Schema{
+					SkipOptionalPointer: false,
+					GoType:              "int",
+				},
+				Required: false,
+				Nullable: true,
+			},
+			want: "*int",
+		},
+
+		// Following tests cases for non-nullable and required; and skip pointer is not opted
+		{
+			name: "When field is readOnly it will always be pointer",
+			fields: fields{
+				Schema: Schema{
+					SkipOptionalPointer: false,
+					GoType:              "int",
+				},
+				ReadOnly: true,
+				Required: true,
+			},
+			want: "*int",
+		},
+
+		{
+			name: "When field is readOnly and read only pointer disabled",
+			fields: fields{
+				GlobalStateDisableRequiredReadOnlyAsPointer: true,
+				Schema: Schema{
+					SkipOptionalPointer: false,
+					GoType:              "int",
+				},
+				ReadOnly: true,
+				Required: true,
+			},
+			want: "int",
+		},
+
+		{
+			name: "When field is readOnly and optional",
+			fields: fields{
+				Schema: Schema{
+					SkipOptionalPointer: false,
+					GoType:              "int",
+				},
+				ReadOnly: true,
+				Required: false,
+			},
+			want: "*int",
+		},
+		{
+			name: "When field is readOnly and optional and and read only pointer disabled",
+			fields: fields{
+				GlobalStateDisableRequiredReadOnlyAsPointer: true,
+				Schema: Schema{
+					SkipOptionalPointer: false,
+					GoType:              "int",
+				},
+				ReadOnly: true,
+				Required: false,
+			},
+			want: "*int",
+		},
+
+		// When field is write only, it will always be pointer unless pointer is
+		// skipped by setting SkipOptionalPointer flag
+		{
+			name: "When field is write only",
+			fields: fields{
+				GlobalStateDisableRequiredReadOnlyAsPointer: true,
+				Schema: Schema{
+					SkipOptionalPointer: false,
+					GoType:              "int",
+				},
+				WriteOnly: true,
+			},
+			want: "*int",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			globalState.options.Compatibility.DisableRequiredReadOnlyAsPointer = tt.fields.GlobalStateDisableRequiredReadOnlyAsPointer
+			p := Property{
+				Schema:    tt.fields.Schema,
+				Required:  tt.fields.Required,
+				Nullable:  tt.fields.Nullable,
+				ReadOnly:  tt.fields.ReadOnly,
+				WriteOnly: tt.fields.WriteOnly,
+			}
+			assert.Equalf(t, tt.want, p.GoTypeDef(), "GoTypeDef()")
+		})
+	}
+}


### PR DESCRIPTION
This PR adds unit test for `GoTypeDef()` method. 