### PR TITLE
Simplify extensions merge in `mergeOpenapiSchemas`

### DIFF
--- a/pkg/codegen/merge_schemas.go
+++ b/pkg/codegen/merge_schemas.go
@@ -86,19 +86,14 @@ func mergeAllOf(allOf []*openapi3.SchemaRef) (openapi3.Schema, error) {
 // all of whose fields are composed.
 func mergeOpenapiSchemas(s1, s2 openapi3.Schema, allOf bool) (openapi3.Schema, error) {
 	var result openapi3.Schema
-	if s1.Extensions != nil || s2.Extensions != nil {
-		result.Extensions = make(map[string]interface{})
-		if s1.Extensions != nil {
-			for k, v := range s1.Extensions {
-				result.Extensions[k] = v
-			}
-		}
-		if s2.Extensions != nil {
-			for k, v := range s2.Extensions {
-				// TODO: Check for collisions
-				result.Extensions[k] = v
-			}
-		}
+
+	result.Extensions = make(map[string]interface{})
+	for k, v := range s1.Extensions {
+		result.Extensions[k] = v
+	}
+	for k, v := range s2.Extensions {
+		// TODO: Check for collisions
+		result.Extensions[k] = v
 	}
 
 	result.OneOf = append(s1.OneOf, s2.OneOf...)


### PR DESCRIPTION
From the Go specification [^1]:

>  "3. If the map is nil, the number of iterations is 0."

Therefore, we don't need the `nil` checks for merging the `Extensions`. Just like how we did for `Properties`:

https://github.com/deepmap/oapi-codegen/blob/66f9bb8d73111908bb20d30bae90e65eb49a6770/pkg/codegen/merge_schemas.go#L202-L210

[^1]: https://go.dev/ref/spec#For_range