### PR TITLE
Fixes type collision for enum values that start with _ (underscore)

### DIFF
--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -680,6 +680,8 @@ func typeNamePrefix(name string) (prefix string) {
 			prefix += "Caret"
 		case '%':
 			prefix += "Percent"
+		case '_':
+			prefix += "Underscore"
 		default:
 			// Prepend "N" to schemas starting with a number
 			if prefix == "" && unicode.IsDigit(r) {

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -462,6 +462,7 @@ func TestSchemaNameToTypeName(t *testing.T) {
 		"=3":           "Equal3",
 		"#Tag":         "HashTag",
 		".com":         "DotCom",
+		"_1":           "Underscore1",
 	} {
 		assert.Equal(t, want, SchemaNameToTypeName(in))
 	}


### PR DESCRIPTION
Resolves an issue with type collision when enum values start with `_` (underscore) value.