### PR TITLE
refactor: add generic function codegen.SortedKeys

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -524,7 +524,7 @@ func GenerateTypesForSchemas(t *template.Template, schemas map[string]*openapi3.
 // components/parameters section of the Swagger spec.
 func GenerateTypesForParameters(t *template.Template, params map[string]*openapi3.ParameterRef) ([]TypeDefinition, error) {
 	var types []TypeDefinition
-	for _, paramName := range SortedParameterKeys(params) {
+	for _, paramName := range SortedKeys(params) {
 		paramOrRef := params[paramName]
 
 		goType, err := paramToGoType(paramOrRef.Value, nil)
@@ -562,7 +562,7 @@ func GenerateTypesForParameters(t *template.Template, params map[string]*openapi
 func GenerateTypesForResponses(t *template.Template, responses openapi3.ResponseBodies) ([]TypeDefinition, error) {
 	var types []TypeDefinition
 
-	for _, responseName := range SortedResponsesKeys(responses) {
+	for _, responseName := range SortedKeys(responses) {
 		responseOrRef := responses[responseName]
 
 		// We have to generate the response object. We're only going to
@@ -577,7 +577,7 @@ func GenerateTypesForResponses(t *template.Template, responses openapi3.Response
 			}
 		}
 
-		sortedContentKeys := SortedContentKeys(response.Content)
+		sortedContentKeys := SortedKeys(response.Content)
 		for _, mediaType := range sortedContentKeys {
 			response := response.Content[mediaType]
 			if !util.IsMediaTypeJson(mediaType) {
@@ -624,7 +624,7 @@ func GenerateTypesForResponses(t *template.Template, responses openapi3.Response
 func GenerateTypesForRequestBodies(t *template.Template, bodies map[string]*openapi3.RequestBodyRef) ([]TypeDefinition, error) {
 	var types []TypeDefinition
 
-	for _, requestBodyName := range SortedRequestBodyKeys(bodies) {
+	for _, requestBodyName := range SortedKeys(bodies) {
 		requestBodyRef := bodies[requestBodyName]
 
 		// As for responses, we will only generate Go code for JSON bodies,

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -197,7 +197,7 @@ func DescribeSecurityDefinition(securityRequirements openapi3.SecurityRequiremen
 	outDefs := make([]SecurityDefinition, 0)
 
 	for _, sr := range securityRequirements {
-		for _, k := range SortedSecurityRequirementKeys(sr) {
+		for _, k := range SortedKeys(sr) {
 			v := sr[k]
 			outDefs = append(outDefs, SecurityDefinition{ProviderName: k, Scopes: v})
 		}
@@ -279,7 +279,7 @@ func (o *OperationDefinition) GetResponseTypeDefinitions() ([]ResponseTypeDefini
 		return tds, nil
 	}
 
-	sortedResponsesKeys := SortedResponsesKeys(o.Spec.Responses.Map())
+	sortedResponsesKeys := SortedKeys(o.Spec.Responses.Map())
 	for _, responseName := range sortedResponsesKeys {
 		responseRef := o.Spec.Responses.Value(responseName)
 
@@ -292,7 +292,7 @@ func (o *OperationDefinition) GetResponseTypeDefinitions() ([]ResponseTypeDefini
 				}
 			}
 
-			sortedContentKeys := SortedContentKeys(responseRef.Value.Content)
+			sortedContentKeys := SortedKeys(responseRef.Value.Content)
 			for _, contentTypeName := range sortedContentKeys {
 				contentType := responseRef.Value.Content[contentTypeName]
 				// We can only generate a type if we have a schema:
@@ -544,7 +544,7 @@ func OperationDefinitions(swagger *openapi3.T, initialismOverrides bool) ([]Oper
 		return operations, nil
 	}
 
-	for _, requestPath := range SortedPathsKeys(swagger.Paths.Map()) {
+	for _, requestPath := range SortedKeys(swagger.Paths.Map()) {
 		pathItem := swagger.Paths.Value(requestPath)
 		// These are parameters defined for all methods on a given path. They
 		// are shared by all methods.
@@ -556,7 +556,7 @@ func OperationDefinitions(swagger *openapi3.T, initialismOverrides bool) ([]Oper
 
 		// Each path can have a number of operations, POST, GET, OPTIONS, etc.
 		pathOps := pathItem.Operations()
-		for _, opName := range SortedOperationsKeys(pathOps) {
+		for _, opName := range SortedKeys(pathOps) {
 			op := pathOps[opName]
 			if pathItem.Servers != nil {
 				op.Servers = &pathItem.Servers
@@ -686,7 +686,7 @@ func GenerateBodyDefinitions(operationID string, bodyOrRef *openapi3.RequestBody
 	var bodyDefinitions []RequestBodyDefinition
 	var typeDefinitions []TypeDefinition
 
-	for _, contentType := range SortedContentKeys(body.Content) {
+	for _, contentType := range SortedKeys(body.Content) {
 		content := body.Content[contentType]
 		var tag string
 		var defaultBody bool
@@ -781,7 +781,7 @@ func GenerateResponseDefinitions(operationID string, responses map[string]*opena
 	// do not let multiple status codes ref to same response, it will break the type switch
 	refSet := make(map[string]struct{})
 
-	for _, statusCode := range SortedResponsesKeys(responses) {
+	for _, statusCode := range SortedKeys(responses) {
 		responseOrRef := responses[statusCode]
 		if responseOrRef == nil {
 			continue
@@ -790,7 +790,7 @@ func GenerateResponseDefinitions(operationID string, responses map[string]*opena
 
 		var responseContentDefinitions []ResponseContentDefinition
 
-		for _, contentType := range SortedContentKeys(response.Content) {
+		for _, contentType := range SortedKeys(response.Content) {
 			content := response.Content[contentType]
 			var tag string
 			switch {
@@ -828,7 +828,7 @@ func GenerateResponseDefinitions(operationID string, responses map[string]*opena
 		}
 
 		var responseHeaderDefinitions []ResponseHeaderDefinition
-		for _, headerName := range SortedHeadersKeys(response.Headers) {
+		for _, headerName := range SortedKeys(response.Headers) {
 			header := response.Headers[headerName]
 			contentSchema, err := GenerateGoSchema(header.Value.Schema, []string{})
 			if err != nil {

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -737,14 +737,14 @@ func GenFieldsFromProperties(props []Property) []string {
 		// Support x-oapi-codegen-extra-tags
 		if extension, ok := p.Extensions[extPropExtraTags]; ok {
 			if tags, err := extExtraTags(extension); err == nil {
-				keys := SortedStringKeys(tags)
+				keys := SortedKeys(tags)
 				for _, k := range keys {
 					fieldTags[k] = tags[k]
 				}
 			}
 		}
 		// Convert the fieldTags map into Go field annotations.
-		keys := SortedStringKeys(fieldTags)
+		keys := SortedKeys(fieldTags)
 		tags := make([]string, len(keys))
 		for i, k := range keys {
 			tags[i] = fmt.Sprintf(`%s:"%s"`, k, fieldTags[k])

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -143,7 +143,7 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 		}
 
 		// If we made it this far then we need to handle unmarshaling for each content-type:
-		sortedContentKeys := SortedContentKeys(responseRef.Value.Content)
+		sortedContentKeys := SortedKeys(responseRef.Value.Content)
 		jsonCount := 0
 		for _, contentTypeName := range sortedContentKeys {
 			if StringInArray(contentTypeName, contentTypesJSON) || util.IsMediaTypeJson(contentTypeName) {
@@ -228,11 +228,11 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 	// See: https://github.com/deepmap/oapi-codegen/issues/127 for why we handle this in two separate
 	// groups.
 	fmt.Fprintf(buffer, "switch {\n")
-	for _, caseClauseKey := range SortedStringKeys(handledCaseClauses) {
+	for _, caseClauseKey := range SortedKeys(handledCaseClauses) {
 
 		fmt.Fprintf(buffer, "%s\n", handledCaseClauses[caseClauseKey])
 	}
-	for _, caseClauseKey := range SortedStringKeys(unhandledCaseClauses) {
+	for _, caseClauseKey := range SortedKeys(unhandledCaseClauses) {
 
 		fmt.Fprintf(buffer, "%s\n", unhandledCaseClauses[caseClauseKey])
 	}

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -225,110 +225,79 @@ func SortedSchemaKeys(dict map[string]*openapi3.SchemaRef) []string {
 	return keys
 }
 
-// SortedPathsKeys is the same as above, except it sorts the keys for a Paths
-// dictionary.
+// SortedKeys returns the keys of the dictionary in sorted order.
+func SortedKeys[M ~map[string]V, V any](dict M) []string {
+	keys := make([]string, len(dict))
+	i := 0
+	for key := range dict {
+		keys[i] = key
+		i++
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// SortedPathsKeys returns PathItem dictionary keys in sorted order.
+//
+// Deprecated: use SortedKeys instead.
 func SortedPathsKeys(dict map[string]*openapi3.PathItem) []string {
-	keys := make([]string, len(dict))
-	i := 0
-	for key := range dict {
-		keys[i] = key
-		i++
-	}
-	sort.Strings(keys)
-	return keys
+	return SortedKeys(dict)
 }
 
-// SortedOperationsKeys returns Operation dictionary keys in sorted order
+// SortedOperationsKeys returns Operation dictionary keys in sorted order.
+//
+// Deprecated: use SortedKeys instead.
 func SortedOperationsKeys(dict map[string]*openapi3.Operation) []string {
-	keys := make([]string, len(dict))
-	i := 0
-	for key := range dict {
-		keys[i] = key
-		i++
-	}
-	sort.Strings(keys)
-	return keys
+	return SortedKeys(dict)
 }
 
-// SortedResponsesKeys returns Responses dictionary keys in sorted order
+// SortedResponsesKeys returns Responses dictionary keys in sorted order.
+//
+// Deprecated: use SortedKeys instead.
 func SortedResponsesKeys(dict map[string]*openapi3.ResponseRef) []string {
-	keys := make([]string, len(dict))
-	i := 0
-	for key := range dict {
-		keys[i] = key
-		i++
-	}
-	sort.Strings(keys)
-	return keys
+	return SortedKeys(dict)
 }
 
+// SortedResponsesKeys returns Headers dictionary keys in sorted order.
+//
+// Deprecated: use SortedKeys instead.
 func SortedHeadersKeys(dict openapi3.Headers) []string {
-	keys := make([]string, len(dict))
-	i := 0
-	for key := range dict {
-		keys[i] = key
-		i++
-	}
-	sort.Strings(keys)
-	return keys
+	return SortedKeys(dict)
 }
 
-// SortedContentKeys returns Content dictionary keys in sorted order
+// SortedContentKeys returns Content dictionary keys in sorted order.
+//
+// Deprecated: use SortedKeys instead.
 func SortedContentKeys(dict openapi3.Content) []string {
-	keys := make([]string, len(dict))
-	i := 0
-	for key := range dict {
-		keys[i] = key
-		i++
-	}
-	sort.Strings(keys)
-	return keys
+	return SortedKeys(dict)
 }
 
-// SortedStringKeys returns string map keys in sorted order
+// SortedStringKeys returns string map keys in sorted order.
+//
+// Deprecated: use SortedKeys instead.
 func SortedStringKeys(dict map[string]string) []string {
-	keys := make([]string, len(dict))
-	i := 0
-	for key := range dict {
-		keys[i] = key
-		i++
-	}
-	sort.Strings(keys)
-	return keys
+	return SortedKeys(dict)
 }
 
-// SortedParameterKeys returns sorted keys for a ParameterRef dict
+// SortedParameterKeys returns sorted keys for a ParameterRef dict.
+//
+// Deprecated: use SortedKeys instead.
 func SortedParameterKeys(dict map[string]*openapi3.ParameterRef) []string {
-	keys := make([]string, len(dict))
-	i := 0
-	for key := range dict {
-		keys[i] = key
-		i++
-	}
-	sort.Strings(keys)
-	return keys
+	return SortedKeys(dict)
 }
 
+// SortedParameterKeys returns sorted keys for a RequestBodyRef dict.
+//
+// Deprecated: use SortedKeys instead.
 func SortedRequestBodyKeys(dict map[string]*openapi3.RequestBodyRef) []string {
-	keys := make([]string, len(dict))
-	i := 0
-	for key := range dict {
-		keys[i] = key
-		i++
-	}
-	sort.Strings(keys)
-	return keys
+	return SortedKeys(dict)
 }
 
+// SortedParameterKeys returns sorted keys for a SecurityRequirement dict.
+//
+// Deprecated: use SortedKeys instead.
 func SortedSecurityRequirementKeys(sr openapi3.SecurityRequirement) []string {
-	keys := make([]string, len(sr))
-	i := 0
-	for key := range sr {
-		keys[i] = key
-		i++
-	}
-	sort.Strings(keys)
-	return keys
+	return SortedKeys(sr)
 }
 
 // StringInArray checks whether the specified string is present in an array

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -29,6 +29,21 @@ func TestStringOps(t *testing.T) {
 	assert.Equal(t, "Number1234", ToCamelCase("number-1234"), "Number Camelcasing not working.")
 }
 
+func TestSortedKeys(t *testing.T) {
+	dict := map[string]*openapi3.SchemaRef{
+		"f": nil,
+		"c": nil,
+		"b": nil,
+		"e": nil,
+		"d": nil,
+		"a": nil,
+	}
+
+	expected := []string{"a", "b", "c", "d", "e", "f"}
+
+	assert.EqualValues(t, expected, SortedKeys(dict), "Keys are not sorted properly")
+}
+
 func TestSortedSchemaKeys(t *testing.T) {
 	dict := map[string]*openapi3.SchemaRef{
 		"f": nil,


### PR DESCRIPTION
This PR adds a new generic function `codegen.SortedKeys` to be used instead of specific `SortedPathsKeys`, `SortedOperationsKeys`, `SortedResponsesKeys`, `SortedHeadersKeys`, `SortedContentKeys`, `SortedStringKeys`, `SortedParameterKeys`, `SortedRequestBodyKeys`, `SortedSecurityRequirementKeys`.