### PR TITLE
Ensure docstring comment names are set correctly

### DIFF
--- a/internal/test/components/components.gen.go
+++ b/internal/test/components/components.gen.go
@@ -329,7 +329,7 @@ type OneOfVariant6 struct {
 
 // ReferenceToRenameMe When a Schema is renamed, $ref should refer to the new name
 type ReferenceToRenameMe struct {
-	// ToNewName This schema should be renamed via x-go-name when generating
+	// NewName This schema should be renamed via x-go-name when generating
 	NewName NewName `json:"ToNewName"`
 }
 

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -98,7 +98,14 @@ type Property struct {
 }
 
 func (p Property) GoFieldName() string {
-	return SchemaNameToTypeName(p.JsonFieldName)
+	goFieldName := p.JsonFieldName
+	if _, ok := p.Extensions[extGoName]; ok {
+		if extGoFieldName, err := extParseGoFieldName(p.Extensions[extGoName]); err == nil {
+			goFieldName = extGoFieldName
+		}
+	}
+
+	return SchemaNameToTypeName(goFieldName)
 }
 
 func (p Property) GoTypeDef() string {
@@ -659,11 +666,6 @@ func GenFieldsFromProperties(props []Property) []string {
 		field := ""
 
 		goFieldName := p.GoFieldName()
-		if _, ok := p.Extensions[extGoName]; ok {
-			if extGoFieldName, err := extParseGoFieldName(p.Extensions[extGoName]); err == nil {
-				goFieldName = extGoFieldName
-			}
-		}
 
 		// Add a comment to a field in case we have one, otherwise skip.
 		if p.Description != "" {


### PR DESCRIPTION
This PR ensures that the docstring comment names are set using `x-go-name` so that they actually match the Go name.

Currently, it would generate this as shown in the test:
```
// ReferenceToRenameMe When a Schema is renamed, $ref should refer to the new name
 type ReferenceToRenameMe struct {
        // ToNewName This schema should be renamed via x-go-name when generating
        NewName NewName `json:"ToNewName"`
 }
```

Whereas, it should instead show this:
```
// ReferenceToRenameMe When a Schema is renamed, $ref should refer to the new name
 type ReferenceToRenameMe struct {
        // NewName This schema should be renamed via x-go-name when generating
        NewName NewName `json:"ToNewName"`
 }
```