### PR TITLE
Lint: enable `unparam` and fix up issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,17 @@ $(GOBIN)/golangci-lint:
 .PHONY: tools
 tools: $(GOBIN)/golangci-lint
 
+LINT_RUN_CMD=$(GOBIN)/golangci-lint run ./... --enable=unparam
+
 lint: tools
 	# run the root module explicitly, to prevent recursive calls by re-invoking `make ...` top-level
-	$(GOBIN)/golangci-lint run ./...
+	$(LINT_RUN_CMD)
 	# then, for all child modules, use a module-managed `Makefile`
 	git ls-files '**/*go.mod' -z | xargs -0 -I{} bash -xc 'cd $$(dirname {}) && env GOBIN=$(GOBIN) make lint'
 
 lint-ci: tools
 	# for the root module, explicitly run the step, to prevent recursive calls
-	$(GOBIN)/golangci-lint run ./... --out-format=github-actions --timeout=5m
+	$(LINT_RUN_CMD) --out-format=github-actions --timeout=5m
 	# then, for all child modules, use a module-managed `Makefile`
 	git ls-files '**/*go.mod' -z | xargs -0 -I{} bash -xc 'cd $$(dirname {}) && env GOBIN=$(GOBIN) make lint-ci'
 

--- a/examples/petstore-expanded/iris/petstore.go
+++ b/examples/petstore-expanded/iris/petstore.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kataras/iris/v12"
 )
 
-func NewIrisPetServer(petStore *api.PetStore, port int) *iris.Application {
+func NewIrisPetServer(petStore *api.PetStore) *iris.Application {
 	swagger, err := api.GetSwagger()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading swagger spec\n: %s", err)
@@ -43,7 +43,7 @@ func main() {
 	flag.Parse()
 	// Create an instance of our handler which satisfies the generated interface
 	petStore := api.NewPetStore()
-	s := NewIrisPetServer(petStore, *port)
+	s := NewIrisPetServer(petStore)
 
 	// And we serve HTTP until the world ends.
 	log.Fatal(s.Listen(fmt.Sprintf("localhost:%d", *port)))

--- a/examples/petstore-expanded/iris/petstore_test.go
+++ b/examples/petstore-expanded/iris/petstore_test.go
@@ -33,7 +33,7 @@ func doGet(t *testing.T, handler http.Handler, url string) *httptest.ResponseRec
 
 func TestPetStore(t *testing.T) {
 	store := api.NewPetStore()
-	irisPetServer := NewIrisPetServer(store, 8080)
+	irisPetServer := NewIrisPetServer(store)
 
 	t.Run("Add pet", func(t *testing.T) {
 		tag := "TagOfSpot"

--- a/internal/test/externalref/externalref.gen.go
+++ b/internal/test/externalref/externalref.gen.go
@@ -29,14 +29,15 @@ type Container struct {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/5xUwW7bMAz9lYDbUWgybNjBt7W7L4ftVBQDYzOOBlvSKKZrUOjfB0pN7MRbk+YSKPJ7",
-	"5HvUk56h9n3wjpxEqJ4h1hvqMS/vUKj1vNN1YB+IxVL+Yhv9pSfsQ0dQfTCw9tyjQAXWyedPYEB2gcpf",
-	"aokhGXDY0xENvvo2DtAobF0LKR12/OoX1QIGnvpOmaUC1HtdCr3zTtA64qnKQv+Jun7PtIYK3s0Ht/MX",
-	"q/NvGfdFNb5QVpdRbkeU+hzlgEsGAsk5+JIEkhrcq5vY28/zZHxXmBja3F7cRjnLYuMYX49S81r3Q7qS",
-	"meRpcWWgGt+2lqaRMhA2XvwP7kp8hfo49XSasz1nHElkxt2A/MMYAjVQCW9JYVFQtrl2Q7FmG8R6p7VI",
-	"ZuXbzLqZbGgWxbNKJbftoboHfETb4arTvUCuKYqi7xp4+IchwfbYy2uz/o6Fc4mHZIDp99aybt2XWYzn",
-	"93DueoacXAPa9D8vxxsO962Pg2BBja8lNo3Vc8BuORKjdk+rZfvWrX1ubSWnCgw8EsdykPmCBXIYLFTw",
-	"8WZxs9DxoGzUX0p/AwAA//++YR/sUAUAAA==",
+	"H4sIAAAAAAAC/+yYz24bIRDGX8Wa9ohiV6162FuT3utDe4qiarw7XlPtAoVxGivi3Ssg6117Hf9TK+XA",
+	"DcMMfPPxG1v4GUrdGq1IsYPiGVy5ohbj8A6Zam03YWysNmRZUlyR1Wtz9IStaQiKDwKW2rbIUIBU/PkT",
+	"COCNofSRarLgBShsaScNvura9aGOrVQ1eL+d0YtfVDIIeGqbkJl2gLLT6ge7vlGBlxVzpxWjVGTHFaX0",
+	"nxjG7y0toYB30/46py93Of0W476Eel5SFuel3A5SylMp2zgvwBCfCp8TJy86daPyOu/3rL6iiP6Y27OP",
+	"CTnzVMZufPlqWwxXjunaNpYXIypnV2JZ6bqWNAZTgFlp1j9sk5qAqXXjavcJ7HKGYKO1uOkj/1g0hioo",
+	"2K4phDlGXse9K3KllYalVmEv4klam0g14RVNHGsbpJJat1DcAz6ibHDRhDlDqkqKnG4qeDhQEGO9W8sx",
+	"r79jyjmnBi/A0u+1tGHqPnkx9O/hVOOayLQ4+P2Y4chwHPl1ynhkPKJjO5ZnRjIjBxjprciAZEAOANIp",
+	"zHhkPEZ4/DPKgvYL/hu4gJtLX9eM9cmX/38//myVwxc1VpUMIGIzH2gO972/WzxAqqWOCiXHtgIBj2Rd",
+	"Ijm+jQ0pNBIK+Hgzu5mFi0VeBRu8/xsAAP//L2nIWOwRAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/test/parameters/parameters_test.go
+++ b/internal/test/parameters/parameters_test.go
@@ -517,11 +517,10 @@ func TestParameterBinding(t *testing.T) {
 	ts.reset()
 }
 
-func doRequest(t *testing.T, e *echo.Echo, code int, req *http.Request) *httptest.ResponseRecorder {
+func doOKRequest(t *testing.T, e *echo.Echo, req *http.Request) {
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
-	assert.Equal(t, code, rec.Code)
-	return rec
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestClientPathParams(t *testing.T) {
@@ -548,102 +547,102 @@ func TestClientPathParams(t *testing.T) {
 
 	req, err := NewGetPassThroughRequest(server, "some string")
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	require.NotNil(t, ts.passThrough)
 	assert.Equal(t, "some string", *ts.passThrough)
 	ts.reset()
 
 	req, err = NewGetStartingWithNumberRequest(server, "some string")
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	require.NotNil(t, ts.n1param)
 	assert.Equal(t, "some string", *ts.n1param)
 	ts.reset()
 
 	req, err = NewGetContentObjectRequest(server, expectedComplexObject)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	assert.EqualValues(t, &expectedComplexObject, ts.complexObject)
 	ts.reset()
 
 	// Label style
 	req, err = NewGetLabelExplodeArrayRequest(server, expectedArray)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	req, err = NewGetLabelNoExplodeArrayRequest(server, expectedArray)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	req, err = NewGetLabelExplodeObjectRequest(server, expectedObject)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	req, err = NewGetLabelNoExplodeObjectRequest(server, expectedObject)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	// Matrix style
 	req, err = NewGetMatrixExplodeArrayRequest(server, expectedArray)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	req, err = NewGetMatrixNoExplodeArrayRequest(server, expectedArray)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	req, err = NewGetMatrixExplodeObjectRequest(server, expectedObject)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	req, err = NewGetMatrixNoExplodeObjectRequest(server, expectedObject)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	// Simple style
 	req, err = NewGetSimpleExplodeArrayRequest(server, expectedArray)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	req, err = NewGetSimpleNoExplodeArrayRequest(server, expectedArray)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	assert.EqualValues(t, expectedArray, ts.array)
 	ts.reset()
 
 	req, err = NewGetSimpleExplodeObjectRequest(server, expectedObject)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	req, err = NewGetSimpleNoExplodeObjectRequest(server, expectedObject)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	assert.EqualValues(t, &expectedObject, ts.object)
 	ts.reset()
 
 	req, err = NewGetSimplePrimitiveRequest(server, expectedPrimitive)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	assert.EqualValues(t, &expectedPrimitive, ts.primitive)
 	ts.reset()
 }
@@ -694,7 +693,7 @@ func TestClientQueryParams(t *testing.T) {
 
 	req, err := NewGetQueryFormRequest(server, &qParams)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	require.NotNil(t, ts.queryParams)
 	assert.EqualValues(t, qParams, *ts.queryParams)
 	ts.reset()
@@ -712,7 +711,7 @@ func TestClientQueryParams(t *testing.T) {
 	}
 	req, err = NewGetCookieRequest(server, &cParams)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	require.NotNil(t, ts.cookieParams)
 	assert.EqualValues(t, cParams, *ts.cookieParams)
 	ts.reset()
@@ -730,7 +729,7 @@ func TestClientQueryParams(t *testing.T) {
 	}
 	req, err = NewGetHeaderRequest(server, &hParams)
 	assert.NoError(t, err)
-	doRequest(t, e, http.StatusOK, req)
+	doOKRequest(t, e, req)
 	require.NotNil(t, ts.headerParams)
 	assert.EqualValues(t, hParams, *ts.headerParams)
 	ts.reset()

--- a/pkg/codegen/template_helpers.go
+++ b/pkg/codegen/template_helpers.go
@@ -137,7 +137,7 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 		// If there is no content-type then we have no unmarshaling to do:
 		if len(responseRef.Value.Content) == 0 {
 			caseAction := "break // No content-type"
-			caseClauseKey := "case " + getConditionOfResponseName("rsp.StatusCode", typeDefinition.ResponseName) + ":"
+			caseClauseKey := "case " + getConditionOfResponseName(typeDefinition.ResponseName) + ":"
 			unhandledCaseClauses[prefixLeastSpecific+caseClauseKey] = fmt.Sprintf("%s\n%s\n", caseClauseKey, caseAction)
 			continue
 		}
@@ -213,7 +213,7 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 			// Everything else:
 			default:
 				caseAction := fmt.Sprintf("// Content-type (%s) unsupported", contentTypeName)
-				caseClauseKey := "case " + getConditionOfResponseName("rsp.StatusCode", typeDefinition.ResponseName) + ":"
+				caseClauseKey := "case " + getConditionOfResponseName(typeDefinition.ResponseName) + ":"
 				unhandledCaseClauses[prefixLeastSpecific+caseClauseKey] = fmt.Sprintf("%s\n%s\n", caseClauseKey, caseAction)
 			}
 		}
@@ -244,14 +244,14 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 // buildUnmarshalCase builds an unmarshaling case clause for different content-types:
 func buildUnmarshalCase(typeDefinition ResponseTypeDefinition, caseAction string, contentType string) (caseKey string, caseClause string) {
 	caseKey = fmt.Sprintf("%s.%s.%s", prefixLeastSpecific, contentType, typeDefinition.ResponseName)
-	caseClauseKey := getConditionOfResponseName("rsp.StatusCode", typeDefinition.ResponseName)
+	caseClauseKey := getConditionOfResponseName(typeDefinition.ResponseName)
 	caseClause = fmt.Sprintf("case strings.Contains(rsp.Header.Get(\"%s\"), \"%s\") && %s:\n%s\n", "Content-Type", contentType, caseClauseKey, caseAction)
 	return caseKey, caseClause
 }
 
 func buildUnmarshalCaseStrict(typeDefinition ResponseTypeDefinition, caseAction string, contentType string) (caseKey string, caseClause string) {
 	caseKey = fmt.Sprintf("%s.%s.%s", prefixLeastSpecific, contentType, typeDefinition.ResponseName)
-	caseClauseKey := getConditionOfResponseName("rsp.StatusCode", typeDefinition.ResponseName)
+	caseClauseKey := getConditionOfResponseName(typeDefinition.ResponseName)
 	caseClause = fmt.Sprintf("case rsp.Header.Get(\"%s\") == \"%s\" && %s:\n%s\n", "Content-Type", contentType, caseClauseKey, caseAction)
 	return caseKey, caseClause
 }
@@ -270,14 +270,14 @@ func getResponseTypeDefinitions(op *OperationDefinition) []ResponseTypeDefinitio
 }
 
 // Return the statusCode comparison clause from the response name.
-func getConditionOfResponseName(statusCodeVar, responseName string) string {
+func getConditionOfResponseName(responseName string) string {
 	switch responseName {
 	case "default":
 		return "true"
 	case "1XX", "2XX", "3XX", "4XX", "5XX":
-		return fmt.Sprintf("%s / 100 == %s", statusCodeVar, responseName[:1])
+		return fmt.Sprintf("rsp.StatusCode / 100 == %s", responseName[:1])
 	default:
-		return fmt.Sprintf("%s == %s", statusCodeVar, responseName)
+		return fmt.Sprintf("rsp.StatusCode == %s", responseName)
 	}
 }
 

--- a/pkg/securityprovider/securityprovider.go
+++ b/pkg/securityprovider/securityprovider.go
@@ -70,16 +70,17 @@ func (s *SecurityProviderBearerToken) Intercept(ctx context.Context, req *http.R
 // NewSecurityProviderApiKey will attach a generic apiKey for a given name
 // either to a cookie, header or as a query parameter.
 func NewSecurityProviderApiKey(in, name, apiKey string) (*SecurityProviderApiKey, error) {
+	//nolint:unparam // result 0 (error) is always nil
 	interceptors := map[string]func(ctx context.Context, req *http.Request) error{
-		"cookie": func(ctx context.Context, req *http.Request) error {
+		"cookie": func(_ context.Context, req *http.Request) error {
 			req.AddCookie(&http.Cookie{Name: name, Value: apiKey})
 			return nil
 		},
-		"header": func(ctx context.Context, req *http.Request) error {
+		"header": func(_ context.Context, req *http.Request) error {
 			req.Header.Add(name, apiKey)
 			return nil
 		},
-		"query": func(ctx context.Context, req *http.Request) error {
+		"query": func(_ context.Context, req *http.Request) error {
 			query := req.URL.Query()
 			query.Add(name, apiKey)
 			req.URL.RawQuery = query.Encode()


### PR DESCRIPTION
The PR enables [`unparam`](https://golangci-lint.run/usage/linters/#unparam) linter and addresses lint issues. The linter has identified a significant amount of unused code that can be easily deleted without affecting functionality.

The whole log of running `golangci-lint`:
```
❯ make lint
git ls-files go.mod '**/*go.mod' -z | xargs -0 -I{} bash -xc 'cd $(dirname {}) && /Users/Oleksandr_Redko/src/github.com/deepmap/oapi-codegen/bin/golangci-lint run --enable=unparam ./...'
++ dirname examples/go.mod
+ cd examples
+ /Users/Oleksandr_Redko/src/github.com/deepmap/oapi-codegen/bin/golangci-lint run --enable=unparam ./...
petstore-expanded/iris/petstore.go:19:47: `NewIrisPetServer` - `port` is unused (unparam)
func NewIrisPetServer(petStore *api.PetStore, port int) *iris.Application {
                                              ^
++ dirname go.mod
+ cd .
+ /Users/Oleksandr_Redko/src/github.com/deepmap/oapi-codegen/bin/golangci-lint run --enable=unparam ./...
pkg/securityprovider/securityprovider.go:74:18: `NewSecurityProviderApiKey$1` - `ctx` is unused (unparam)
                "cookie": func(ctx context.Context, req *http.Request) error {
                               ^
pkg/securityprovider/securityprovider.go:78:18: `NewSecurityProviderApiKey$2` - `ctx` is unused (unparam)
                "header": func(ctx context.Context, req *http.Request) error {
                               ^
pkg/securityprovider/securityprovider.go:82:17: `NewSecurityProviderApiKey$3` - `ctx` is unused (unparam)
                "query": func(ctx context.Context, req *http.Request) error {
                              ^
pkg/codegen/prune.go:24:76: walkSwagger - result 0 (error) is always nil (unparam)
func walkSwagger(swagger *openapi3.T, doFn func(RefWrapper) (bool, error)) error {
                                                                           ^
pkg/codegen/prune.go:43:81: walkOperation - result 0 (error) is always nil (unparam)
func walkOperation(op *openapi3.Operation, doFn func(RefWrapper) (bool, error)) error {
                                                                                ^
pkg/codegen/prune.go:68:91: walkComponents - result 0 (error) is always nil (unparam)
func walkComponents(components *openapi3.Components, doFn func(RefWrapper) (bool, error)) error {
                                                                                          ^
pkg/codegen/template_helpers.go:273:33: `getConditionOfResponseName` - `statusCodeVar` always receives `"rsp.StatusCode"` (unparam)
func getConditionOfResponseName(statusCodeVar, responseName string) string {
                                ^
++ dirname internal/test/go.mod
+ cd internal/test
+ /Users/Oleksandr_Redko/src/github.com/deepmap/oapi-codegen/bin/golangci-lint run --enable=unparam ./...
parameters/parameters_test.go:520:44: `doRequest` - `code` always receives `http.StatusOK` (`200`) (unparam)
func doRequest(t *testing.T, e *echo.Echo, code int, req *http.Request) *httptest.ResponseRecorder {
                                           ^
make: *** [Makefile:19: lint] Error 1
```