### PR TITLE
Prefactor: Build changes for #1475

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
 
       - name: Test
         run: make test
+        env:
+          # A combination of our GitHub Actions setup, with the Go toolchain, leads to inconsistencies in calling `go env`, in particular with Go 1.21, where having (the default) `GOTOOLCHAIN=auto` results in build failures
+          GOTOOLCHAIN: local
 
       - name: Build
         run: go build ./cmd/oapi-codegen

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -23,6 +23,9 @@ jobs:
 
       - name: Run `make generate`
         run: make generate
+        env:
+          # A combination of our GitHub Actions setup, with the Go toolchain, leads to inconsistencies in calling `go env`, in particular with Go 1.21, where having (the default) `GOTOOLCHAIN=auto` results in build failures
+          GOTOOLCHAIN: local
 
       - name: Check for no untracked files
         run: git status && git diff-index --exit-code -p HEAD --

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,3 +23,6 @@ jobs:
 
       - name: Run `make lint-ci`
         run: make lint-ci
+        env:
+          # A combination of our GitHub Actions setup, with the Go toolchain, leads to inconsistencies in calling `go env`, in particular with Go 1.21, where having (the default) `GOTOOLCHAIN=auto` results in build failures
+          GOTOOLCHAIN: local

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -25,4 +25,4 @@ jobs:
         run: go install gitlab.com/jamietanna/tidied@latest
 
       - name: Check for no untracked files
-        run: git ls-files go.mod '**/*go.mod' -z | xargs -0 -I{} bash -xc 'cd $(dirname {}) && tidied -verbose'
+        run: make tidy-ci

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Check for no untracked files
         run: make tidy-ci
+        env:
+          # A combination of our GitHub Actions setup, with the Go toolchain, leads to inconsistencies in calling `go env`, in particular with Go 1.21, where having (the default) `GOTOOLCHAIN=auto` results in build failures
+          GOTOOLCHAIN: local

--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,4 @@ test:
 	git ls-files go.mod '**/*go.mod' -z | xargs -0 -I{} bash -xc 'cd $$(dirname {}) && go test -cover ./...'
 
 tidy:
-	@echo "tidy..."
 	git ls-files go.mod '**/*go.mod' -z | xargs -0 -I{} bash -xc 'cd $$(dirname {}) && go mod tidy'

--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,9 @@ tidy:
 	go mod tidy
 	# then, for all child modules, use a module-managed `Makefile`
 	git ls-files '**/*go.mod' -z | xargs -0 -I{} bash -xc 'cd $$(dirname {}) && make tidy'
+
+tidy-ci:
+	# for the root module, explicitly run the step, to prevent recursive calls
+	tidied -verbose
+	# then, for all child modules, use a module-managed `Makefile`
+	git ls-files '**/*go.mod' -z | xargs -0 -I{} bash -xc 'cd $$(dirname {}) && make tidy-ci'

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ help:
 	@echo "    generate:    regenerate all generated files"
 	@echo "    test:        run all tests"
 	@echo "    tidy         tidy go mod"
+	@echo "    lint         lint the project"
 
 $(GOBIN)/golangci-lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v1.56.1

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ help:
 	@echo "Targets:"
 	@echo "    generate:    regenerate all generated files"
 	@echo "    test:        run all tests"
-	@echo "    gin_example  generate gin example server code"
 	@echo "    tidy         tidy go mod"
 
 $(GOBIN)/golangci-lint:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,14 @@
+lint:
+	$(GOBIN)/golangci-lint run ./...
+
+lint-ci:
+	$(GOBIN)/golangci-lint run ./... --out-format=github-actions --timeout=5m
+
+generate:
+	go generate ./...
+
+test:
+	go test -cover ./...
+
+tidy:
+	go mod tidy

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -12,3 +12,6 @@ test:
 
 tidy:
 	go mod tidy
+
+tidy-ci:
+	tidied -verbose

--- a/internal/test/Makefile
+++ b/internal/test/Makefile
@@ -1,0 +1,14 @@
+lint:
+	$(GOBIN)/golangci-lint run ./...
+
+lint-ci:
+	$(GOBIN)/golangci-lint run ./... --out-format=github-actions --timeout=5m
+
+generate:
+	go generate ./...
+
+test:
+	go test -cover ./...
+
+tidy:
+	go mod tidy

--- a/internal/test/Makefile
+++ b/internal/test/Makefile
@@ -12,3 +12,6 @@ test:
 
 tidy:
 	go mod tidy
+
+tidy-ci:
+	tidied -verbose


### PR DESCRIPTION
- build: remove invalid `make` target
- build: add `make lint` to `make help`
- build: remove unnecessary output
- build: create a `Makefile` per module
- build: Add `tidy-ci` make target
- build: explicitly set `GOTOOLCHAIN`
