### PR TITLE
enh: Add optional enum prefix separator setting

### DIFF
--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -70,6 +70,9 @@ type CompatibilityOptions struct {
 	// When set to true, always prefix enum values with their type name instead of only
 	// when typenames would be conflicting.
 	AlwaysPrefixEnumValues bool `yaml:"always-prefix-enum-values,omitempty"`
+	// When prefixing enum values with typename, this specifies an optional separator string to include for improving
+	// readability. By default, the empty string is used (i.e., no separator).
+	EnumPrefixSeparator string `yaml:"enum-prefix-separator,omitempty"`
 	// Our generated code for Chi has historically inverted the order in which Chi middleware is
 	// applied such that the last invoked middleware ends up executing first in the Chi chain
 	// This resolves the behavior such that middlewares are chained in the order they are invoked.

--- a/pkg/codegen/schema.go
+++ b/pkg/codegen/schema.go
@@ -149,7 +149,7 @@ func (e *EnumDefinition) GetValues() map[string]string {
 	// If we do have conflicts, we will prefix the enum's typename to the values.
 	newValues := make(map[string]string, len(e.Schema.EnumValues))
 	for k, v := range e.Schema.EnumValues {
-		newName := e.TypeName + UppercaseFirstCharacter(k)
+		newName := e.TypeName + globalState.options.Compatibility.EnumPrefixSeparator + UppercaseFirstCharacter(k)
 		newValues[newName] = v
 	}
 	return newValues


### PR DESCRIPTION
For readability purposes, it's useful to allow an optional separator string for enum values. For example: `TypeName_EnumValue` instead of `TypeNameEnumValue`. 

This PR adds the `EnumPrefixSeparator` configuration parameter to control such a separator. Since the new parameter defaults to the empty string, no existing generated code should be affected.