### PR TITLE
feat: add support for custom query param name

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,6 +920,24 @@ which help you to use the various OpenAPI 3 Authentication mechanism.
       End   *openapi_types.Date `json:"end,omitempty"`
     }
     ```
+
+- `x-query-param-name`: allows you to specify custom name for query parameters.
+
+  ```yaml
+  components:
+    parameters:
+      Pets:
+        in: query
+        name: pets
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+              - dog
+              - cat
+        x-query-param-name: "pets[]"
+  ```
   
 ## Using `oapi-codegen`
 

--- a/pkg/codegen/extension.go
+++ b/pkg/codegen/extension.go
@@ -22,6 +22,7 @@ const (
 	extEnumVarNames      = "x-enum-varnames"
 	extEnumNames         = "x-enumNames"
 	extDeprecationReason = "x-deprecated-reason"
+	extQueryParamName    = "x-query-param-name"
 )
 
 func extString(extPropValue interface{}) (string, error) {

--- a/pkg/codegen/operations.go
+++ b/pkg/codegen/operations.go
@@ -139,6 +139,16 @@ func (pd ParameterDefinition) IndirectOptional() bool {
 	return !pd.Required && !pd.Schema.SkipOptionalPointer
 }
 
+func (pd ParameterDefinition) QueryParamName() string {
+	queryParamName := pd.ParamName
+	if _, ok := pd.Spec.Extensions[extQueryParamName]; ok {
+		if extGoFieldName, err := extParseGoFieldName(pd.Spec.Extensions[extQueryParamName]); err == nil {
+			queryParamName = extGoFieldName
+		}
+	}
+	return queryParamName
+}
+
 type ParameterDefinitions []ParameterDefinition
 
 func (p ParameterDefinitions) FindByName(name string) *ParameterDefinition {

--- a/pkg/codegen/templates/client.tmpl
+++ b/pkg/codegen/templates/client.tmpl
@@ -210,7 +210,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
 
             {{end}}
             {{if .IsStyled}}
-            if queryFrag, err := runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationQuery, {{if not .Required}}*{{end}}params.{{.GoName}}); err != nil {
+            if queryFrag, err := runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.QueryParamName}}", runtime.ParamLocationQuery, {{if not .Required}}*{{end}}params.{{.GoName}}); err != nil {
                 return nil, err
             } else if parsed, err := url.ParseQuery(queryFrag); err != nil {
                return nil, err


### PR DESCRIPTION
This PR adds support for clients to use custom query parameter names. 

This change is motivated by a [discussion](https://stackoverflow.com/questions/11490326/is-array-syntax-using-square-brackets-in-url-query-strings-valid) on stack how different languages handle array syntax with square brackets in URL.