### PR TITLE
chore: log warning when using 3.1.x

### DIFF
--- a/cmd/oapi-codegen/oapi-codegen.go
+++ b/cmd/oapi-codegen/oapi-codegen.go
@@ -283,6 +283,10 @@ func main() {
 		errExit("error loading swagger spec in %s\n: %s", flag.Arg(0), err)
 	}
 
+	if strings.HasPrefix(swagger.OpenAPI, "3.1.") {
+		fmt.Println("WARNING: You are using an OpenAPI 3.1.x specification, which is not yet supported by oapi-codegen (https://github.com/deepmap/oapi-codegen/issues/373) and so some functionality may not be available. Until oapi-codegen supports OpenAPI 3.1, it is recommended to downgrade your spec to 3.0.x")
+	}
+
 	if len(noVCSVersionOverride) > 0 {
 		opts.Configuration.NoVCSVersionOverride = &noVCSVersionOverride
 	}


### PR DESCRIPTION
As noted in #373 we don't yet have support, and this should make it
clearer to consumers of that.
