### PR TITLE
fix: don't allow `strict-server` to be used on its own

### DIFF
--- a/pkg/codegen/configuration.go
+++ b/pkg/codegen/configuration.go
@@ -185,5 +185,10 @@ func (o Configuration) Validate() error {
 	if nServers > 1 {
 		return errors.New("only one server type is supported at a time")
 	}
+
+	if o.Generate.Strict && nServers == 0 {
+		return errors.New("the `strict-server` option is added in addition to another server to be generated. Adding `strict-server` on its own will not generate anything")
+	}
+
 	return nil
 }


### PR DESCRIPTION
As it doesn't actually do anything, as it wraps an existing server i.e.
Chi.

Closes #1558.
