### PR TITLE
chore: add missing test case for replaceInitialism

### DIFF
--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -654,7 +654,7 @@ func TestLowercaseFirstCharacters(t *testing.T) {
 	}
 }
 
-func Test_replaceInitialisms(t *testing.T) {
+func Test_replaceInitialism(t *testing.T) {
 	type args struct {
 		s string
 	}
@@ -687,6 +687,16 @@ func Test_replaceInitialisms(t *testing.T) {
 			name: "already initialism",
 			args: args{s: "fooIDBarAPI"},
 			want: "fooIDBarAPI",
+		},
+		{
+			name: "one initialism at start",
+			args: args{s: "idFoo"},
+			want: "idFoo",
+		},
+		{
+			name: "one initialism at start and one in middle",
+			args: args{s: "apiIdFoo"},
+			want: "apiIDFoo",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
The PR extends tests for the `replaceInitialism` with new test case. Additionally, changes test name to `Test_replaceInitialism` by removing unneeded `s` suffix.

Coverage before:
<img width="588" alt="image" src="https://github.com/deepmap/oapi-codegen/assets/3228886/666b8e36-18dd-40af-baa8-11031eeefe02">

Coverage after:
<img width="596" alt="image" src="https://github.com/deepmap/oapi-codegen/assets/3228886/ca02dc2d-65d8-4e3c-8aac-be0fa280e6db">
